### PR TITLE
Request for comments - Adding tox testing capability

### DIFF
--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -41,11 +41,47 @@ environment variable:
 
     vunit/ > VUNIT_SIMULATOR=ghdl python -m unittest discover vunit/test/acceptance/
 
+Testing with tox
+~~~~~~~~~~~~~~~~
+
+VUnit supports the Python `tox <http://tox.readthedocs.org/>`__ tool. Tox makes
+it easier to test VUnit in various configurations in an automatic way. Tox 
+automates creation of virtual environments and installation of dependencies
+needed for testing. In fact, all of the tests can be run in a single command:
+
+.. code-block:: console
+
+    vunit/ > tox
+
+If tox is not available in your Python environment, it can be installed from
+PyPI with pip:
+
+.. code-block:: console
+
+    vunit/ > pip install tox
+
+For most developers, running the full testsuite will likely lead to failed test
+cases because not all Python interpreters or HDL simulators are installed in
+their environment. More focused testing is possible by specifying which tox
+"environments" should be tested. For example, assume a developer uses Python 2.7
+and Modelsim and would like to test changes using tools available in his
+environment:
+
+.. code-block:: console
+
+    vunit/ > tox -e py27-unit,py27-acceptance-modelsim
+
+A full list of test environments can be seen by issuing the following command:
+
+.. code-block:: console
+
+    vunit/ > tox -l
+
 Dependencies
 ------------
 
-Other that the dependencies required to use VUnit as a user the
-following are also required for developers to run the test suite:
+Other than the dependencies required to use VUnit as a user the
+following are also required for developers to run the test suite manually:
 
 `mock <https://pypi.python.org/pypi/mock>`__
    For Python 2.7 only, built into Python 3.x

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,25 @@
+[tox]
+envlist = py{27,35}-unit, py{27,35}-acceptance-{activehdl,ghdl,modelsim,rivierapro}, lint, docs 
+
+[testenv]
+recreate=True
+
+deps=
+    py27: mock
+    lint: pep8
+    lint: pylint
+    docs: sphinx
+    docs: sphinx-argparse
+    docs: ablog
+
+setenv=
+    acceptance-activehdl:  VUNIT_SIMULATOR=activehdl
+    acceptance-ghdl:       VUNIT_SIMULATOR=ghdl
+    acceptance-modelsim:   VUNIT_SIMULATOR=modelsim
+    acceptance-rivierapro: VUNIT_SIMULATOR=rivierapro
+
+commands=
+    unit:       {envpython} -m unittest discover -s {envdir} vunit/test/unit
+    acceptance: {envpython} -m unittest discover -s {envdir} vunit/test/acceptance
+    lint:       {envpython} -m unittest discover -s {envdir} vunit/test/lint
+    docs:       {envbindir}/sphinx-build docs {envtmpdir}/docsbuild

--- a/vunit/test/lint/test_license.py
+++ b/vunit/test/lint/test_license.py
@@ -37,6 +37,8 @@ class TestLicense(unittest.TestCase):
                     continue
                 if root == join(ROOT, "docs"):
                     continue
+                if join(ROOT, ".tox") in root:
+                    continue
                 osvvm_directory = abspath(join(VHDL_PATH, 'osvvm'))
                 if is_prefix_of(osvvm_directory, abspath(join(root, file_name))):
                     continue

--- a/vunit/test/lint/test_pep8.py
+++ b/vunit/test/lint/test_pep8.py
@@ -11,6 +11,7 @@ PEP8 check
 import unittest
 from subprocess import check_call
 import sys
+from os.path import join
 from vunit import ROOT
 
 
@@ -25,5 +26,4 @@ class TestPep8(unittest.TestCase):
                     "--show-pep8",
                     "--max-line-length=120",
                     "--ignore=E402",
-                    "--exclude=docs/conf.py",
-                    ROOT])
+                    join(ROOT, "vunit")])


### PR DESCRIPTION
After having a bit of a struggle (even with the documentation) trying to figure out how to fully test VUnit, I decided to "package up" all the instructions into a `tox.ini` file so that testing could be easily performed, with all the test dependencies handled automatically.

I thought of this when we had the issue in the past week where there was differences in the version of pylint being used. By using tox, you ensure that the environment you test in is clean, and the dependencies of testing are freshly installed every time you test. As a bonus, you can even generate the documentation!

I have added some documentation to `contributing.rst` about how to use tox, if you are not familiar.

A few things that I want to point out:

1. Testing the license now explicitly ignores the .tox directory which gets created in the project level vunit directory. It needs to be ignored because platform python files (like os.py) are present in the .tox directory when it gets created, which causes failures of lint testing if it is not ignored.
2. pep8 testing is now only performed against the vunit package itself. Previously it would attempt to perform testing on any python code in the vunit project directory. This caused problems related to bullet 1. If this is not acceptable, perhaps the rules can be improved to ignore files that may cause failures.
3. I see the actual configuration contained in tox.ini up for debate -- e.g. we could additionally test for python 3.3, 3.4. Maybe we don't want to independently run unit tests with all the different python interpreters.
4. It is possible to add code coverage functionality into the tox.ini, but I thought we could review this as a first cut, and if it is adopted, perhaps we can add that in later.
5. I am not a tox configuration expert, so someone else might see a more efficient way of achieving the same result. But, after some testing I think this covers most of the combinations of testing that VUnit would want.
5. I have had a problem with the lint check passing. I am suspecting that this is an issue related to testing inside of a virtual environment. The problem is obviously a false-positive -- specifically, the problem is:

```
************* Module vunit.ghdl_interface
E: 15, 0: No name 'spawn' in module 'distutils' (no-name-in-module)
E: 15, 0: Unable to import 'distutils.spawn' (import-error)
```

Please let me know if this interests you, or if there are changes I should make.