### PR TITLE
Fixes for Aldec simulators

### DIFF
--- a/vunit/activehdl_interface.py
+++ b/vunit/activehdl_interface.py
@@ -216,11 +216,12 @@ proc vunit_run {} {
         set true_value true
     } else {
         echo "No finish mechanism detected"
-        return 1;
+        return 1
     }
 
     run -all
-    set failed [expr [examine ${status_boolean}]!=${true_value}]
+    set status_boolean_value [examine ${status_boolean}]
+    set failed [expr {$status_boolean_value} ne {$true_value}]
     if {$failed} {
         catch {
             # tb command can fail when error comes from pli

--- a/vunit/rivierapro_interface.py
+++ b/vunit/rivierapro_interface.py
@@ -248,11 +248,12 @@ proc vunit_run {} {
         set true_value 1
     } else {
         echo "No finish mechanism detected"
-        return 1;
+        return 1
     }
 
     run -all
-    set failed [expr [examine ${status_boolean}]!=${true_value}]
+    set status_boolean_value [examine ${status_boolean}]
+    set failed [expr {$status_boolean_value} ne {$true_value}]
     if {$failed} {
         catch {
             # tb command can fail when error comes from pli

--- a/vunit/vhdl/run/test/tb_run.vhd
+++ b/vunit/vhdl/run/test/tb_run.vhd
@@ -209,6 +209,7 @@ begin
     variable checker_cfg : checker_cfg_t;
     variable runner_cfg : line;
     variable passed : boolean;
+    variable phase : runner_phase_t;
   begin
     logger_init(runner_trace_logger, file_name => output_path & "test_runner_trace.csv");
     checker_init(c, display_format => verbose, default_src => "Test Runner", stop_level => error, file_name => output_path & "error.csv");
@@ -361,14 +362,18 @@ begin
     ---------------------------------------------------------------------------
     banner("Should maintain correct phase when using the full run mode of operation without any early exits");
     test_case_setup;
-    check(c, get_phase = test_runner_entry_phase, "Phase should be test runner entry");
+    phase := get_phase;
+    check(c, phase = test_runner_entry_phase, "Phase should be test runner entry");
     test_runner_setup(runner, "enabled_test_cases : test a,, test b");
-    check(c, get_phase = test_suite_setup_phase, "Phase should be test suite setup");
+	phase := get_phase;
+    check(c, phase = test_suite_setup_phase, "Phase should be test suite setup");
     i := 0;
     while test_suite loop
-      check(c, get_phase = test_case_setup_phase, "Phase should be test case setup." & " Got " & phase_to_string(get_phase) & ".");
+      phase := get_phase;
+      check(c, phase = test_case_setup_phase, "Phase should be test case setup." & " Got " & phase_to_string(phase) & ".");
       while in_test_case loop
-        check(c, get_phase = test_case_phase, "Phase should be test case main."  & " Got " & phase_to_string(get_phase) & ".");
+        phase := get_phase;
+        check(c, phase = test_case_phase, "Phase should be test case main."  & " Got " & phase_to_string(phase) & ".");
         if i = 0 then
           check_false(c, run("test b"), "Test b should not be enabled at this time.");
           check(c, run("test a"), "Test a should be enabled at this time");
@@ -379,23 +384,29 @@ begin
         i := i + 1;
       end loop;
     end loop;
-    check(c, get_phase = test_suite_cleanup_phase, "Phase should be test suite cleanup" & " Got " & phase_to_string(get_phase) & ".");
+    phase := get_phase;
+    check(c, phase = test_suite_cleanup_phase, "Phase should be test suite cleanup" & " Got " & phase_to_string(phase) & ".");
     test_runner_cleanup(runner, disable_simulation_exit => true);
-    check(c, get_phase = test_runner_exit_phase, "Phase should be test runner exit" & " Got " & phase_to_string(get_phase) & ".");
+    phase := get_phase;
+    check(c, phase = test_runner_exit_phase, "Phase should be test runner exit" & " Got " & phase_to_string(phase) & ".");
 
 
 
     ---------------------------------------------------------------------------
     banner("Should maintain correct phase when using the full run mode of operation and there is a premature exit of a test case.");
     test_case_setup;
-    check(c, get_phase = test_runner_entry_phase, "Phase should be test runner entry");
+    phase := get_phase;
+    check(c, phase = test_runner_entry_phase, "Phase should be test runner entry");
     test_runner_setup(runner, "enabled_test_cases : test a,, test b");
-    check(c, get_phase = test_suite_setup_phase, "Phase should be test suite setup");
+    phase := get_phase;
+    check(c, phase = test_suite_setup_phase, "Phase should be test suite setup");
     i := 0;
     while test_suite loop
-      check(c, get_phase = test_case_setup_phase, "Phase should be test case setup." & " Got " & phase_to_string(get_phase) & ".");
+      phase := get_phase;
+      check(c, phase = test_case_setup_phase, "Phase should be test case setup." & " Got " & phase_to_string(phase) & ".");
       while in_test_case loop
-        check(c, get_phase = test_case_phase, "Phase should be test case main."  & " Got " & phase_to_string(get_phase) & ".");
+        phase := get_phase;
+        check(c, phase = test_case_phase, "Phase should be test case main."  & " Got " & phase_to_string(phase) & ".");
         if i = 0 then
           check_false(c, run("test b"), "Test b should not be enabled at this time.");
           check(c, run("test a"), "Test a should be enabled at this time");
@@ -407,36 +418,46 @@ begin
           i := i + 1;
         end if;
       end loop;
-      check(c, get_phase = test_case_cleanup_phase, "Phase should be test case cleanup."  & " Got " & phase_to_string(get_phase) & ".");
+      phase := get_phase;
+      check(c, phase = test_case_cleanup_phase, "Phase should be test case cleanup."  & " Got " & phase_to_string(phase) & ".");
     end loop;
-    check(c, get_phase = test_suite_cleanup_phase, "Phase should be test suite cleanup" & " Got " & phase_to_string(get_phase) & ".");
+    phase := get_phase;
+    check(c, phase = test_suite_cleanup_phase, "Phase should be test suite cleanup" & " Got " & phase_to_string(phase) & ".");
     test_runner_cleanup(runner, disable_simulation_exit => true);
-    check(c, get_phase = test_runner_exit_phase, "Phase should be test runner exit" & " Got " & phase_to_string(get_phase) & ".");
+    phase := get_phase;
+    check(c, phase = test_runner_exit_phase, "Phase should be test runner exit" & " Got " & phase_to_string(phase) & ".");
 
 
 
     ---------------------------------------------------------------------------
     banner("Should maintain correct phase when using the full run mode of operation and there is a premature exit of a test suite.");
     test_case_setup;
-    check(c, get_phase = test_runner_entry_phase, "Phase should be test runner entry");
+    phase := get_phase;
+    check(c, phase = test_runner_entry_phase, "Phase should be test runner entry");
     test_runner_setup(runner, "enabled_test_cases : test a,, test b");
-    check(c, get_phase = test_suite_setup_phase, "Phase should be test suite setup");
+    phase := get_phase;
+    check(c, phase = test_suite_setup_phase, "Phase should be test suite setup");
     i := 0;
     while test_suite loop
-      check(c, get_phase = test_case_setup_phase, "Phase should be test case setup." & " Got " & phase_to_string(get_phase) & ".");
+      phase := get_phase;
+      check(c, phase = test_case_setup_phase, "Phase should be test case setup." & " Got " & phase_to_string(phase) & ".");
       while in_test_case loop
-        check(c, get_phase = test_case_phase, "Phase should be test case main."  & " Got " & phase_to_string(get_phase) & ".");
+        phase := get_phase;
+        check(c, phase = test_case_phase, "Phase should be test case main."  & " Got " & phase_to_string(phase) & ".");
         check(c, i = 0, "The second test case should never be activated");
         check_false(c, run("test b"), "Test b should not be enabled at this time.");
         check(c, run("test a"), "Test a should be enabled at this time");
         i := i + 1;
         exit when test_suite_error(true);
       end loop;
-      check(c, get_phase = test_case_cleanup_phase, "Phase should be test case cleanup."  & " Got " & phase_to_string(get_phase) & ".");
+      phase := get_phase;
+      check(c, phase = test_case_cleanup_phase, "Phase should be test case cleanup."  & " Got " & phase_to_string(phase) & ".");
     end loop;
-    check(c, get_phase = test_suite_cleanup_phase, "Phase should be test suite cleanup." & " Got " & phase_to_string(get_phase) & ".");
+    phase := get_phase;
+    check(c, phase = test_suite_cleanup_phase, "Phase should be test suite cleanup." & " Got " & phase_to_string(phase) & ".");
     test_runner_cleanup(runner, disable_simulation_exit => true);
-    check(c, get_phase = test_runner_exit_phase, "Phase should be test runner exit" & " Got " & phase_to_string(get_phase) & ".");
+    phase := get_phase;
+    check(c, phase = test_runner_exit_phase, "Phase should be test runner exit" & " Got " & phase_to_string(phase) & ".");
 
     ---------------------------------------------------------------------------
     --banner("Should be possible to exit a test case or test suite with an error message that can be caught afterwards.");


### PR DESCRIPTION
Been working with @LarsAsplund to make these fixes.

Two issues were present:
1. Issue with Aldec simulator interpretation of VHDL when a comparison with the result of a function was an argument to `check`
2. Issue with Aldec simulator script generation where a non-numeric exit status from VUnit (e.g. "Z") would cause the script to fail because of a TCL syntax error.