### PR TITLE
Possible fix for #161

### DIFF
--- a/vunit/vhdl/string_ops/src/string_ops.vhd
+++ b/vunit/vhdl/string_ops/src/string_ops.vhd
@@ -306,15 +306,15 @@ package body string_ops is
     constant cnt : in natural := natural'high)
     return string is
     constant n_occurences : natural := count(s, old_segment);
-    function string_length_after_replace return natural is
-      variable n_replacements : natural := n_occurences;
+    function string_length_after_replace (constant n_occurences_i : natural) return natural is
+      variable n_replacements : natural := n_occurences_i;
     begin
       if cnt < n_replacements  then
         n_replacements := cnt;
       end if;
       return s'length + n_replacements * (new_segment'length - old_segment'length);
     end;
-    variable ret_val : string(1 to string_length_after_replace);
+    variable ret_val : string(1 to string_length_after_replace(n_occurences));
     variable replaced_substrings : natural := 0;
     variable i,j : natural := 1;
     variable s_int : string(1 to s'length) := s;


### PR DESCRIPTION
This has fixed issue #161 for ModelSim DE 10.1a on my setup.

In file `vunit/vhdl/string_ops/src/string_ops.vhd` it seems that ModelSim was getting confused with `string_length_after_replace` being created inside the `replace` function.

I'm not sure why this was coded this way since `string_length_after_replace` doesn't need to be dynamic to this point, but I guess it's personal style. Either way, I made the fewest changes as possible.

Let me know what you guys think.