### PR TITLE
Print out remaining number of tests when pressing ctrl-c

### DIFF
--- a/vunit/test/unit/test_test_report.py
+++ b/vunit/test/unit/test_test_report.py
@@ -58,6 +58,28 @@ Elapsed time was 1.0 seconds
         self.assertRaises(KeyError,
                           report.result_of, "invalid_test")
 
+    def test_report_with_missing_tests(self):
+        report = self._report_with_missing_tests()
+        report.set_real_total_time(1.0)
+        self.assertEqual(self.report_to_str(report), """\
+==== Summary ========================
+{gi}pass{x} passed_test0 (1.0 seconds)
+{gi}pass{x} passed_test1 (2.0 seconds)
+=====================================
+{gi}pass{x} 2 of 2
+=====================================
+Total time was 3.0 seconds
+Elapsed time was 1.0 seconds
+=====================================
+{gi}All passed!{x}
+{rgi}WARNING: Expected to run 3 tests, but only ran 2 tests{x}
+""")
+        self.assertTrue(report.all_ok())
+        self.assertTrue(report.result_of("passed_test0").passed)
+        self.assertTrue(report.result_of("passed_test1").passed)
+        self.assertRaises(KeyError,
+                          report.result_of, "invalid_test")
+        
     def test_report_with_failed_tests(self):
         report = self._report_with_some_failed_tests()
         report.set_real_total_time(12.0)
@@ -200,8 +222,19 @@ Elapsed time was 3.0 seconds
                           output_file_name=self.output_file_name)
         report.add_result("passed_test1", PASSED, time=2.0,
                           output_file_name=self.output_file_name)
+        report.set_expected_num_tests(2)
         return report
 
+    def _report_with_missing_tests(self):
+        " @returns A report with all passed tests "
+        report = self._new_report()
+        report.add_result("passed_test0", PASSED, time=1.0,
+                          output_file_name=self.output_file_name)
+        report.add_result("passed_test1", PASSED, time=2.0,
+                          output_file_name=self.output_file_name)
+        report.set_expected_num_tests(3)
+        return report
+    
     def _report_with_some_failed_tests(self):
         " @returns A report with some failed tests "
         report = self._new_report()
@@ -211,6 +244,7 @@ Elapsed time was 3.0 seconds
                           output_file_name=self.output_file_name)
         report.add_result("failed_test1", FAILED, time=3.0,
                           output_file_name=self.output_file_name)
+        report.set_expected_num_tests(3)
         return report
 
     def _report_with_some_skipped_tests(self):
@@ -222,6 +256,7 @@ Elapsed time was 3.0 seconds
                           output_file_name=self.output_file_name)
         report.add_result("failed_test", FAILED, time=3.0,
                           output_file_name=self.output_file_name)
+        report.set_expected_num_tests(3)
         return report
 
     def _new_report(self):

--- a/vunit/test/unit/test_test_report.py
+++ b/vunit/test/unit/test_test_report.py
@@ -79,7 +79,7 @@ Elapsed time was 1.0 seconds
         self.assertTrue(report.result_of("passed_test1").passed)
         self.assertRaises(KeyError,
                           report.result_of, "invalid_test")
-        
+
     def test_report_with_failed_tests(self):
         report = self._report_with_some_failed_tests()
         report.set_real_total_time(12.0)
@@ -234,7 +234,7 @@ Elapsed time was 3.0 seconds
                           output_file_name=self.output_file_name)
         report.set_expected_num_tests(3)
         return report
-    
+
     def _report_with_some_failed_tests(self):
         " @returns A report with some failed tests "
         report = self._new_report()

--- a/vunit/test_report.py
+++ b/vunit/test_report.py
@@ -27,12 +27,19 @@ class TestReport(object):
         self._test_names_in_order = []
         self._printer = printer
         self._real_total_time = 0.0
+        self._expected_num_tests = 0
 
     def set_real_total_time(self, real_total_time):
         """
         Set the real total execution time
         """
         self._real_total_time = real_total_time
+
+    def set_expected_num_tests(self, expected_num_tests):
+        """
+        Set the number of tests that we expect to run
+        """
+        self._expected_num_tests = expected_num_tests
 
     def num_tests(self):
         """
@@ -112,6 +119,8 @@ class TestReport(object):
             self._printer.write("No tests were run!", fg="rgi")
             self._printer.write("\n")
             return
+        
+
 
         prefix = "==== Summary "
         max_len = max(len(test.name) for test in all_tests)
@@ -150,6 +159,13 @@ class TestReport(object):
         else:
             self._printer.write("All passed!", fg='gi')
         self._printer.write("\n")
+
+        if len(all_tests) < self._expected_num_tests:
+            self._printer.write("WARNING: Expected to run %d tests, but only ran %d tests" % (self._expected_num_tests, len(all_tests)), fg='rgi')
+        elif len(all_tests) > self._expected_num_tests:
+            self._printer.write("ERROR: Ran more tests than expected (%d > %d)" % (len(all_tests), self._expected_num_tests), fg='ri')
+        self._printer.write("\n")
+        
 
     def _split(self):
         """

--- a/vunit/test_report.py
+++ b/vunit/test_report.py
@@ -119,8 +119,6 @@ class TestReport(object):
             self._printer.write("No tests were run!", fg="rgi")
             self._printer.write("\n")
             return
-        
-
 
         prefix = "==== Summary "
         max_len = max(len(test.name) for test in all_tests)
@@ -161,11 +159,13 @@ class TestReport(object):
         self._printer.write("\n")
 
         if len(all_tests) < self._expected_num_tests:
-            self._printer.write("WARNING: Expected to run %d tests, but only ran %d tests" % (self._expected_num_tests, len(all_tests)), fg='rgi')
+            self._printer.write("WARNING: Expected to run %d tests, but only ran %d tests"
+                                % (self._expected_num_tests, len(all_tests)), fg='rgi')
+            self._printer.write("\n")
         elif len(all_tests) > self._expected_num_tests:
-            self._printer.write("ERROR: Ran more tests than expected (%d > %d)" % (len(all_tests), self._expected_num_tests), fg='ri')
-        self._printer.write("\n")
-        
+            self._printer.write("ERROR: Ran more tests than expected (%d > %d)" %
+                                (len(all_tests), self._expected_num_tests), fg='ri')
+            self._printer.write("\n")
 
     def _split(self):
         """

--- a/vunit/test_report.py
+++ b/vunit/test_report.py
@@ -158,13 +158,10 @@ class TestReport(object):
             self._printer.write("All passed!", fg='gi')
         self._printer.write("\n")
 
+        assert len(all_tests) <= self._expected_num_tests
         if len(all_tests) < self._expected_num_tests:
             self._printer.write("WARNING: Expected to run %d tests, but only ran %d tests"
                                 % (self._expected_num_tests, len(all_tests)), fg='rgi')
-            self._printer.write("\n")
-        elif len(all_tests) > self._expected_num_tests:
-            self._printer.write("ERROR: Ran more tests than expected (%d > %d)" %
-                                (len(all_tests), self._expected_num_tests), fg='ri')
             self._printer.write("\n")
 
     def _split(self):

--- a/vunit/test_runner.py
+++ b/vunit/test_runner.py
@@ -51,6 +51,8 @@ class TestRunner(object):  # pylint: disable=too-many-instance-attributes
             print("Running %i tests" % num_tests)
             print()
 
+        self._report.set_expected_num_tests(num_tests)
+        
         scheduler = TestScheduler(test_suites)
 
         threads = []

--- a/vunit/test_runner.py
+++ b/vunit/test_runner.py
@@ -52,7 +52,7 @@ class TestRunner(object):  # pylint: disable=too-many-instance-attributes
             print()
 
         self._report.set_expected_num_tests(num_tests)
-        
+
         scheduler = TestScheduler(test_suites)
 
         threads = []


### PR DESCRIPTION
If you start running a number of tests in VUnit and press Ctrl-C after a number of tests have passed and no tests have failed you may get the impression that all tests passed.

This is an attempt to test this by printing out a warning that the number of tests that were scheduled to run is not equal to the number of tests that were actually finished.

Caveat emptor: I'm still not a Python wizard, this works for me but I'm not saying that this is the best way to solve this problem. It should at least be able to serve as a starting point for a discussion whether this is a good feature to have in the first place.