### PR TITLE
Added a 'public' function to return the list of the tests.

### DIFF
--- a/vunit/ui.py
+++ b/vunit/ui.py
@@ -854,6 +854,19 @@ class VUnit(object):  # pylint: disable=too-many-instance-attributes, too-many-p
         return SourceFileList([SourceFile(source_file, self._project, self)
                                for source_file in source_files])
 
+    def get_tests(self):
+        """
+        Return the tests in a list
+        """
+        tests = []
+        simulator_if = None
+        test_suites = self._create_tests(simulator_if)
+
+        for test_suite in test_suites:
+            for name in test_suite.test_cases:
+                tests.append(name)
+        return tests
+
 
 class Library(object):
     """


### PR DESCRIPTION
Although this can be retrieved with the argument --list, the output isn't usable to be used in Python (e.g. run.py).
When calling this function before the vu.main(), it is possible to e.g. create the needed testvectors for the selected tests inside the run.py script.