### PR TITLE
Add verbose list option

### DIFF
--- a/vunit/test/unit/test_test_scanner.py
+++ b/vunit/test/unit/test_test_scanner.py
@@ -338,7 +338,8 @@ if run("Test_2")
             if isinstance(test2, tuple):
                 name, test_cases = test2
                 self.assertEqual(test1.name, name)
-                self.assertEqual(test1.test_cases, list(test_cases))
+                self.assertEqual(
+                    [test_case.name for test_case in test1.test_cases], list(test_cases))
             else:
                 self.assertEqual(test1.name, test2)
 

--- a/vunit/test_list.py
+++ b/vunit/test_list.py
@@ -50,7 +50,7 @@ class TestList(object):
         """
         names = []
         for test_suite in self:
-            names += test_suite.test_cases
+            names += [test_case.name for test_case in test_suite.test_cases]
         return names
 
     def __iter__(self):
@@ -72,7 +72,7 @@ class TestSuiteWrapper(object):
 
     @property
     def test_cases(self):
-        return [self._test_case.name]
+        return [self._test_case]
 
     @property
     def name(self):

--- a/vunit/test_runner.py
+++ b/vunit/test_runner.py
@@ -50,10 +50,10 @@ class TestRunner(object):  # pylint: disable=too-many-instance-attributes
 
         num_tests = 0
         for test_suite in test_suites:
-            for test_name in test_suite.test_cases:
+            for test_case in test_suite.test_cases:
                 num_tests += 1
                 if self._verbose:
-                    print("Running test: " + test_name)
+                    print("Running test: " + test_case.name)
 
         if self._verbose:
             print("Running %i tests" % num_tests)
@@ -109,8 +109,8 @@ class TestRunner(object):  # pylint: disable=too-many-instance-attributes
                 test_suite = scheduler.next()
 
                 with self._lock:
-                    for test_name in test_suite.test_cases:
-                        print("Starting %s" % test_name)
+                    for test_case in test_suite.test_cases:
+                        print("Starting %s" % test_case.name)
 
                 self._run_test_suite(test_suite, write_stdout, num_tests)
 
@@ -216,9 +216,9 @@ class TestRunner(object):  # pylint: disable=too-many-instance-attributes
         runtime = ostools.get_time() - start_time
         time_per_test = runtime / len(results)
 
-        for test_name in test_suite.test_cases:
-            status = results[test_name]
-            self._report.add_result(test_name,
+        for test_case in test_suite.test_cases:
+            status = results[test_case.name]
+            self._report.add_result(test_case.name,
                                     status,
                                     time_per_test,
                                     output_file_name)
@@ -229,8 +229,8 @@ class TestRunner(object):  # pylint: disable=too-many-instance-attributes
     def _fail_suite(test_suite):
         """ Return failure for all tests in suite """
         results = {}
-        for test_name in test_suite.test_cases:
-            results[test_name] = FAILED
+        for test_case in test_suite.test_cases:
+            results[test_case.name] = FAILED
         return results
 
 

--- a/vunit/test_scanner.py
+++ b/vunit/test_scanner.py
@@ -93,6 +93,8 @@ class TestScanner(object):
                                      "all" if config.name in (None, "") else None),
                         test_case=None,
                         test_bench=create_test_bench(config),
+                        file_name=entity.file_name,
+                        line=1,
                         has_runner_cfg=has_runner_cfg,
                         pre_config=config.pre_config,
                         post_check=config.post_check,
@@ -103,13 +105,14 @@ class TestScanner(object):
             for config in configurations:
                 test_list.add_suite(
                     SameSimTestSuite(name=dotjoin(create_design_unit_name(entity, architecture_name), config.name),
-                                     test_cases=run_strings,
+                                     entity=entity,
+                                     run_strings=run_strings,
                                      test_bench=create_test_bench(config),
                                      pre_config=config.pre_config,
                                      post_check=config.post_check,
                                      elaborate_only=self._elaborate_only))
         else:
-            for run_string in run_strings:
+            for (run_string,line) in run_strings:
                 scope = create_scope(entity.library_name, entity.name, run_string)
                 configurations = self._cfg.get_configurations(scope)
                 for config in configurations:
@@ -118,6 +121,8 @@ class TestScanner(object):
                             name=dotjoin(create_design_unit_name(entity, architecture_name), config.name, run_string),
                             test_case=run_string,
                             test_bench=create_test_bench(config),
+                            file_name=entity.file_name,
+                            line=line,
                             has_runner_cfg=has_runner_cfg,
                             pre_config=config.pre_config,
                             post_check=config.post_check,

--- a/vunit/test_suites.py
+++ b/vunit/test_suites.py
@@ -91,17 +91,23 @@ class SameSimTestCase(object):
     A test case in a SameSimTestSuite
     """
 
-    def __init__(self, name, file_name, line):
+    def __init__(self, name, file_name, line, run_string):
         self._name = name
         self._file_name = file_name
         self._line = line
+        self._run_string = run_string
 
     @property
     def name(self):
         return self._name
 
+    @property
     def descriptor(self):
         return ':'.join([self._file_name, self._line, self._name])
+    
+    @property
+    def run_string(self):
+        return self._run_string
 
 
 class SameSimTestSuite(object):
@@ -119,7 +125,7 @@ class SameSimTestSuite(object):
                  elaborate_only=False):
         self._name = name
         self._entity = entity
-        self._test_cases = [SameSimTestCase(self._full_name(run_string), entity.file_name, line)
+        self._test_cases = [SameSimTestCase(self._full_name(run_string), entity.file_name, line, run_string)
                             for run_string, line in run_strings]
         self._test_bench = test_bench
         self._pre_config = pre_config
@@ -145,8 +151,8 @@ class SameSimTestSuite(object):
         Keep tests which pattern return False if no remaining tests
         """
         # TODO: Tests
-        self._test_cases = [test_case.name for test_case in self._test_cases
-                            if test_filter(self._full_name(test_case.name))]
+        self._test_cases = [test_case for test_case in self._test_cases
+                            if test_filter(test_case.name)]
         return len(self._test_cases) > 0
 
     def run(self, output_path):
@@ -157,7 +163,7 @@ class SameSimTestSuite(object):
             return False
 
         runner_cfg = {
-            "enabled_test_cases": ",".join([encode_test_case(test_case) for test_case in self._test_cases]),
+            "enabled_test_cases": ",".join([encode_test_case(test_case.run_string) for test_case in self._test_cases]),
             "output path": output_path.replace("\\", "/") + "/",
             "active python runner": True,
         }

--- a/vunit/ui.py
+++ b/vunit/ui.py
@@ -742,8 +742,11 @@ avoid location preprocessing of other functions sharing name with a VUnit log or
         test_suites = self._create_tests(simulator_if)
 
         for test_suite in test_suites:
-            for name in test_suite.test_cases:
-                print(name)
+            for test_case in test_suite.test_cases:
+                if self._verbose:
+                    print(test_case.discriptor)
+                else:
+                    print(test_case.name)
         print("Listed %i tests" % test_suites.num_tests())
         return True
 

--- a/vunit/vhdl_parser.py
+++ b/vunit/vhdl_parser.py
@@ -966,4 +966,4 @@ def remove_comments(code):
     """
     Return the code with comments removed
     """
-    return re.sub(r'--[^\n]*', '', code)
+    return re.sub(r'--.+$', '', code)


### PR DESCRIPTION
This pull-request adds support for an advanced version of the list generation command. This list contains also the file and the line, where the test could be found.

Therefor I added some information to the testcase classes and changed some properties. Additionally the run_string parser is line based now und returns the run_string with the line number.

I developed this to support editor integration and I might think about some more commits to make the output more easy to parse.