### PR TITLE
Add a command-line argument that can turn off the catching of excepti…

### DIFF
--- a/vunit/test_runner.py
+++ b/vunit/test_runner.py
@@ -28,7 +28,8 @@ class TestRunner(object):  # pylint: disable=too-many-instance-attributes
     """
     Administer the execution of a list of test suites
     """
-    def __init__(self, report, output_path, verbose=False, num_threads=1):
+    def __init__(self, report, output_path, verbose=False, num_threads=1,
+                 dont_catch_exceptions=False):
         self._lock = threading.Lock()
         self._local = threading.local()
         self._report = report
@@ -37,6 +38,7 @@ class TestRunner(object):  # pylint: disable=too-many-instance-attributes
         self._num_threads = num_threads
         self._stdout = sys.stdout
         self._stderr = sys.stderr
+        self._dont_catch_exceptions = dont_catch_exceptions
 
     def run(self, test_suites):
         """
@@ -159,6 +161,8 @@ class TestRunner(object):  # pylint: disable=too-many-instance-attributes
         except KeyboardInterrupt:
             raise
         except:  # pylint: disable=bare-except
+            if self._dont_catch_exceptions:
+                raise
             traceback.print_exc()
             results = self._fail_suite(test_suite)
         finally:

--- a/vunit/ui.py
+++ b/vunit/ui.py
@@ -311,8 +311,7 @@ class VUnit(object):  # pylint: disable=too-many-instance-attributes, too-many-p
                  compile_builtins=True,
                  num_threads=1,
                  exit_0=False,
-                 dont_catch_exceptions=False,
-                 ):
+                 dont_catch_exceptions=False):
 
         self._configure_logging(log_level)
         self._elaborate_only = elaborate_only

--- a/vunit/ui.py
+++ b/vunit/ui.py
@@ -289,7 +289,8 @@ class VUnit(object):  # pylint: disable=too-many-instance-attributes, too-many-p
                    compile_builtins=compile_builtins,
                    simulator_factory=SimulatorFactory(args),
                    num_threads=args.num_threads,
-                   exit_0=args.exit_0)
+                   exit_0=args.exit_0,
+                   dont_catch_exceptions=args.dont_catch_exceptions)
 
     def __init__(self,  # pylint: disable=too-many-locals, too-many-arguments
                  output_path,
@@ -309,7 +310,9 @@ class VUnit(object):  # pylint: disable=too-many-instance-attributes, too-many-p
                  vhdl_standard='2008',
                  compile_builtins=True,
                  num_threads=1,
-                 exit_0=False):
+                 exit_0=False,
+                 dont_catch_exceptions=False,
+                 ):
 
         self._configure_logging(log_level)
         self._elaborate_only = elaborate_only
@@ -342,6 +345,7 @@ class VUnit(object):  # pylint: disable=too-many-instance-attributes, too-many-p
         self._create_project()
         self._num_threads = num_threads
         self._exit_0 = exit_0
+        self._dont_catch_exceptions = dont_catch_exceptions
 
         self._test_bench_list = TestBenchList()
 
@@ -733,6 +737,8 @@ avoid location preprocessing of other functions sharing name with a VUnit log or
         except SystemExit:
             exit(1)
         except:  # pylint: disable=bare-except
+            if self._dont_catch_exceptions:
+                raise
             traceback.print_exc()
             exit(1)
 
@@ -861,7 +867,8 @@ avoid location preprocessing of other functions sharing name with a VUnit log or
         runner = TestRunner(report,
                             join(self._output_path, "test_output"),
                             verbose=self._verbose,
-                            num_threads=self._num_threads)
+                            num_threads=self._num_threads,
+                            dont_catch_exceptions=self._dont_catch_exceptions)
         runner.run(test_cases)
 
     def _post_process(self, report):

--- a/vunit/vunit_cli.py
+++ b/vunit/vunit_cli.py
@@ -124,6 +124,12 @@ def _create_argument_parser(description=None, for_documentation=False):
                         help=('Exit with code 0 even if a test failed. '
                               'Still exits with code 1 on fatal errors such as compilation failure'))
 
+    parser.add_argument('--dont-catch-exceptions',
+                        default=False,
+                        action="store_true",
+                        help=('Let exceptions bubble up all the way. '
+                              'Useful when running with "python -m pdb".'))
+
     parser.add_argument('-v', '--verbose', action="store_true",
                         default=False,
                         help='Print test output immediately and not only when failure')


### PR DESCRIPTION
The commit adds a command line options --dont-catch-exceptions which prevents exceptions that are raised in the test from being caught.
I use this so that when I run "python -m pdb -c continue my_test.py" I drop into the REPL when I hit an exception and can easily debug.