### PR TITLE
Declare global variable 'aldec' in vunit_load, in order to fix the Matlab interface.

### DIFF
--- a/vunit/rivierapro_interface.py
+++ b/vunit/rivierapro_interface.py
@@ -247,6 +247,7 @@ class RivieraProInterface(VsimSimulatorMixin, SimulatorInterface):
 
         tcl = """
 proc vunit_load {{}} {{
+    # Make the variable 'aldec' visible; otherwise, the Matlab interface is broken because vsim does not find the library aldec_matlab_cosim.
     global aldec
     set vsim_failed [catch {{
         eval vsim {{{vsim_flags}}}

--- a/vunit/rivierapro_interface.py
+++ b/vunit/rivierapro_interface.py
@@ -247,7 +247,8 @@ class RivieraProInterface(VsimSimulatorMixin, SimulatorInterface):
 
         tcl = """
 proc vunit_load {{}} {{
-    # Make the variable 'aldec' visible; otherwise, the Matlab interface is broken because vsim does not find the library aldec_matlab_cosim.
+    # Make the variable 'aldec' visible; otherwise, the Matlab interface
+    # is broken because vsim does not find the library aldec_matlab_cosim.
     global aldec
     set vsim_failed [catch {{
         eval vsim {{{vsim_flags}}}

--- a/vunit/rivierapro_interface.py
+++ b/vunit/rivierapro_interface.py
@@ -247,6 +247,7 @@ class RivieraProInterface(VsimSimulatorMixin, SimulatorInterface):
 
         tcl = """
 proc vunit_load {{}} {{
+    global aldec
     set vsim_failed [catch {{
         eval vsim {{{vsim_flags}}}
     }}]


### PR DESCRIPTION
Attempting to use the interface between Riviera-PRO and Matlab from a VUnit-testbench currently leads to the following error:
VHPI: Loading library '$ALDEC/bin/aldec_matlab_cosim.dll'
VHPI: The target platform of the "$ALDEC/bin/aldec_matlab_cosim.dll" library cannot be identified. The library may be missing, corrupted, or its format is incorrect.

The problem is that the variable 'aldec' is not visible from within the function vunit_load. This is fixed by declaring the variable as global.