### PR TITLE
Fixes commas in Modelsim generics. Closes #280.

### DIFF
--- a/vunit/modelsim_interface.py
+++ b/vunit/modelsim_interface.py
@@ -435,7 +435,8 @@ def encode_generic_value(value):
     s_value = str(value)
     if " " in s_value:
         return '{"%s"}' % s_value
-
+    if "," in s_value:
+        return '"%s"' % s_value
     return s_value
 
 


### PR DESCRIPTION
Modelsim interface needs to enclose strings for generic values containing spaces and commas in quotes or quotes and braces. 
Strings with a space require braces and quotes eg. `'{"x y"}'` or `'{"x, y"}'`. 
String with a comma but no space must have quotes but no braces eg. `'"x,y"'`.
String with neither comma or space require no braces or quotes eg. `'xy'`.