### PR TITLE
Make integer_array_t metadata get-functions public

### DIFF
--- a/vunit/vhdl/array/src/integer_array_pkg.vhd
+++ b/vunit/vhdl/array/src/integer_array_pkg.vhd
@@ -62,6 +62,16 @@ package integer_array_pkg is
   procedure deallocate(variable arr : inout integer_array_t);
   impure function is_null(arr : integer_array_t) return boolean;
 
+  impure function length(arr : integer_array_t) return integer;
+  impure function width(arr : integer_array_t) return integer;
+  impure function height(arr : integer_array_t) return integer;
+  impure function depth(arr : integer_array_t) return integer;
+  impure function bit_width(arr : integer_array_t) return integer;
+  impure function is_signed(arr : integer_array_t) return boolean;
+  impure function bytes_per_word(arr : integer_array_t) return integer;
+  impure function lower_limit(arr : integer_array_t) return integer;
+  impure function upper_limit(arr : integer_array_t) return integer;
+                                     
   impure function get(arr : integer_array_t; idx : integer) return integer;
   impure function get(arr : integer_array_t; x,y : integer) return integer;
   impure function get(arr : integer_array_t; x,y,z : integer) return integer;


### PR DESCRIPTION
To avoid accessing data structure internals thus breaking abstraction.