### PR TITLE
Wishbone BFM

### DIFF
--- a/vunit/vhdl/verification_components/run.py
+++ b/vunit/vhdl/verification_components/run.py
@@ -6,6 +6,7 @@
 
 from os.path import join, dirname
 from vunit import VUnit
+from itertools import product
 
 root = dirname(__file__)
 
@@ -14,4 +15,27 @@ ui.add_random()
 ui.add_verification_components()
 lib = ui.library("vunit_lib")
 lib.add_source_files(join(root, "test", "*.vhd"))
+
+
+def gen_wb_slave_tests(obj, dat_width, num_cycles, max_ack_dly):
+    for dat_width, num_cycles, max_ack_dly \
+		in product(dat_width, num_cycles, max_ack_dly):
+        config_name = "dat_width=%i,num_cycles=%i,max_ack_dly=%i" % \
+        	(dat_width, num_cycles, max_ack_dly)
+        obj.add_config(name=config_name,
+                       generics=dict(
+                           dat_width=dat_width,
+                           adr_width=8,
+                           max_ack_dly=max_ack_dly,
+                           rand_stall=False,
+                           num_cycles=num_cycles))
+
+
+tb_wishbone_slave = lib.test_bench("tb_wishbone_slave")
+
+for test in tb_wishbone_slave.get_tests():
+    gen_wb_slave_tests(test, [8, 32], [1, 10], [0, 1, 2])
+
 ui.main()
+
+

--- a/vunit/vhdl/verification_components/run.py
+++ b/vunit/vhdl/verification_components/run.py
@@ -17,43 +17,47 @@ lib = ui.library("vunit_lib")
 lib.add_source_files(join(root, "test", "*.vhd"))
 
 
-def gen_wb_slave_tests(obj, dat_width, num_cycles, max_ack_dly, rand_stall):
-    for dat_width, num_cycles, max_ack_dly, rand_stall \
-    in product(dat_width, num_cycles, max_ack_dly, rand_stall):
-        config_name = "dat_width=%i,num_cycles=%i,max_ack_dly=%i,rand_stall=%s" % \
-          (dat_width, num_cycles, max_ack_dly, rand_stall)
+def encode(tb_cfg):
+    return ", ".join(["%s:%s" % (key, str(tb_cfg[key])) for key in tb_cfg])
+
+def gen_wb_slave_tests(obj, dat_width, num_cycles, ack_prob, rand_stall):
+    for dat_width, num_cycles, ack_prob, rand_stall \
+    in product(dat_width, num_cycles, ack_prob, rand_stall):
+        tb_cfg = dict(
+                dat_width=dat_width,
+                adr_width=32,
+                ack_prob=ack_prob,
+                rand_stall=rand_stall,
+                num_cycles=num_cycles
+                )
+        config_name = encode(tb_cfg)
         obj.add_config(name=config_name,
-                       generics=dict(
-                           dat_width=dat_width,
-                           adr_width=32,
-                           max_ack_dly=max_ack_dly,
-                           rand_stall=rand_stall,
-                           num_cycles=num_cycles))
+                       generics=dict(encoded_tb_cfg=encode(tb_cfg)))
 
 
 tb_wishbone_slave = lib.test_bench("tb_wishbone_slave")
 
 for test in tb_wishbone_slave.get_tests():
-    gen_wb_slave_tests(test, [8, 32], [1, 64], [0, 1, 2], [False, True])
+    gen_wb_slave_tests(test, [8, 32], [1, 64], [0.3, 1.0], [False, True])
 
 
-def gen_wb_master_tests(obj, dat_width, num_cycles, max_ack_dly, rand_stall):
-    for dat_width, num_cycles, max_ack_dly, rand_stall \
-    in product(dat_width, num_cycles, max_ack_dly, rand_stall):
-        config_name = "dat_width=%i,num_cycles=%i,max_ack_dly=%i,rand_stall=%s" % \
-          (dat_width, num_cycles, max_ack_dly, rand_stall)
+def gen_wb_master_tests(obj, dat_width, num_cycles, ack_prob, rand_stall):
+    for dat_width, num_cycles, ack_prob, rand_stall \
+    in product(dat_width, num_cycles, ack_prob, rand_stall):
+        config_name = "dat_width=%i,num_cycles=%i,ack_prob=%i,rand_stall=%s" % \
+          (dat_width, num_cycles, ack_prob, rand_stall)
         obj.add_config(name=config_name,
                        generics=dict(
                            dat_width=dat_width,
                            adr_width=32,
-                           max_ack_dly=max_ack_dly,
+                           ack_prob=ack_prob,
                            rand_stall=rand_stall,
                            num_cycles=num_cycles))
 
 tb_wishbone_master = lib.test_bench("tb_wishbone_master")
 
 for test in tb_wishbone_master.get_tests():
-    gen_wb_master_tests(test, [8], [1, 64], [0, 1, 2], [False, True])
+    gen_wb_master_tests(test, [8], [1, 64], [0.3, 1.0], [False, True])
 
 
 ui.main()

--- a/vunit/vhdl/verification_components/run.py
+++ b/vunit/vhdl/verification_components/run.py
@@ -18,16 +18,16 @@ lib.add_source_files(join(root, "test", "*.vhd"))
 
 
 def encode(tb_cfg):
-    return ", ".join(["%s:%s" % (key, str(tb_cfg[key])) for key in tb_cfg])
+    return ",".join(["%s:%s" % (key, str(tb_cfg[key])) for key in tb_cfg])
 
-def gen_wb_slave_tests(obj, dat_width, num_cycles, ack_prob, rand_stall):
-    for dat_width, num_cycles, ack_prob, rand_stall \
-    in product(dat_width, num_cycles, ack_prob, rand_stall):
+def gen_wb_slave_tests(obj, dat_width, num_cycles, ack_prob, stall_prob):
+    for dat_width, num_cycles, ack_prob, stall_prob \
+    in product(dat_width, num_cycles, ack_prob, stall_prob):
         tb_cfg = dict(
                 dat_width=dat_width,
                 adr_width=32,
                 ack_prob=ack_prob,
-                rand_stall=rand_stall,
+                stall_prob=stall_prob,
                 num_cycles=num_cycles
                 )
         config_name = encode(tb_cfg)
@@ -38,7 +38,7 @@ def gen_wb_slave_tests(obj, dat_width, num_cycles, ack_prob, rand_stall):
 tb_wishbone_slave = lib.test_bench("tb_wishbone_slave")
 
 for test in tb_wishbone_slave.get_tests():
-    gen_wb_slave_tests(test, [8, 32], [1, 64], [0.3, 1.0], [False, True])
+    gen_wb_slave_tests(test, [8, 32], [1, 64], [0.3, 1.0], [0.4, 0.0])
 
 
 def gen_wb_master_tests(obj, dat_width, num_cycles, ack_prob, rand_stall):

--- a/vunit/vhdl/verification_components/run.py
+++ b/vunit/vhdl/verification_components/run.py
@@ -20,7 +20,7 @@ lib.add_source_files(join(root, "test", "*.vhd"))
 def encode(tb_cfg):
     return ",".join(["%s:%s" % (key, str(tb_cfg[key])) for key in tb_cfg])
 
-def gen_wb_slave_tests(obj, dat_width, num_cycles, ack_prob, stall_prob):
+def gen_wb_tests(obj, dat_width, num_cycles, ack_prob, stall_prob):
     for dat_width, num_cycles, ack_prob, stall_prob \
     in product(dat_width, num_cycles, ack_prob, stall_prob):
         tb_cfg = dict(
@@ -38,26 +38,13 @@ def gen_wb_slave_tests(obj, dat_width, num_cycles, ack_prob, stall_prob):
 tb_wishbone_slave = lib.test_bench("tb_wishbone_slave")
 
 for test in tb_wishbone_slave.get_tests():
-    gen_wb_slave_tests(test, [8, 32], [1, 64], [0.3, 1.0], [0.4, 0.0])
+    gen_wb_tests(test, [8, 32], [1, 64], [0.3, 1.0], [0.4, 0.0])
 
-
-def gen_wb_master_tests(obj, dat_width, num_cycles, ack_prob, rand_stall):
-    for dat_width, num_cycles, ack_prob, rand_stall \
-    in product(dat_width, num_cycles, ack_prob, rand_stall):
-        config_name = "dat_width=%i,num_cycles=%i,ack_prob=%i,rand_stall=%s" % \
-          (dat_width, num_cycles, ack_prob, rand_stall)
-        obj.add_config(name=config_name,
-                       generics=dict(
-                           dat_width=dat_width,
-                           adr_width=32,
-                           ack_prob=ack_prob,
-                           rand_stall=rand_stall,
-                           num_cycles=num_cycles))
 
 tb_wishbone_master = lib.test_bench("tb_wishbone_master")
 
 for test in tb_wishbone_master.get_tests():
-    gen_wb_master_tests(test, [8], [1, 64], [0.3, 1.0], [False, True])
+    gen_wb_tests(test, [8, 32], [1, 64], [0.3, 1.0], [0.4, 0.0])
 
 
 ui.main()

--- a/vunit/vhdl/verification_components/run.py
+++ b/vunit/vhdl/verification_components/run.py
@@ -25,7 +25,7 @@ def gen_wb_slave_tests(obj, dat_width, num_cycles, max_ack_dly, rand_stall):
         obj.add_config(name=config_name,
                        generics=dict(
                            dat_width=dat_width,
-                           adr_width=8,
+                           adr_width=32,
                            max_ack_dly=max_ack_dly,
                            rand_stall=rand_stall,
                            num_cycles=num_cycles))
@@ -34,7 +34,27 @@ def gen_wb_slave_tests(obj, dat_width, num_cycles, max_ack_dly, rand_stall):
 tb_wishbone_slave = lib.test_bench("tb_wishbone_slave")
 
 for test in tb_wishbone_slave.get_tests():
-    gen_wb_slave_tests(test, [8, 32], [1, 10], [0, 1, 2], [False, True])
+    gen_wb_slave_tests(test, [8, 32], [1, 64], [0, 1, 2], [False, True])
+
+
+def gen_wb_master_tests(obj, dat_width, num_cycles, max_ack_dly, rand_stall):
+    for dat_width, num_cycles, max_ack_dly, rand_stall \
+		in product(dat_width, num_cycles, max_ack_dly, rand_stall):
+        config_name = "dat_width=%i,num_cycles=%i,max_ack_dly=%i,rand_stall=%s" % \
+        	(dat_width, num_cycles, max_ack_dly, rand_stall)
+        obj.add_config(name=config_name,
+                       generics=dict(
+                           dat_width=dat_width,
+                           adr_width=32,
+                           max_ack_dly=max_ack_dly,
+                           rand_stall=rand_stall,
+                           num_cycles=num_cycles))
+
+tb_wishbone_master = lib.test_bench("tb_wishbone_master")
+
+for test in tb_wishbone_master.get_tests():
+    gen_wb_master_tests(test, [8], [1, 64], [0, 1, 2], [False, True])
+
 
 ui.main()
 

--- a/vunit/vhdl/verification_components/run.py
+++ b/vunit/vhdl/verification_components/run.py
@@ -20,16 +20,15 @@ lib.add_source_files(join(root, "test", "*.vhd"))
 def encode(tb_cfg):
     return ",".join(["%s:%s" % (key, str(tb_cfg[key])) for key in tb_cfg])
 
+
 def gen_wb_tests(obj, dat_width, num_cycles, ack_prob, stall_prob):
-    for dat_width, num_cycles, ack_prob, stall_prob \
-    in product(dat_width, num_cycles, ack_prob, stall_prob):
+    for dat_width, num_cycles, ack_prob, stall_prob in product(dat_width, num_cycles, ack_prob, stall_prob):
         tb_cfg = dict(
-                dat_width=dat_width,
-                adr_width=32,
-                ack_prob=ack_prob,
-                stall_prob=stall_prob,
-                num_cycles=num_cycles
-                )
+            dat_width=dat_width,
+            adr_width=32,
+            ack_prob=ack_prob,
+            stall_prob=stall_prob,
+            num_cycles=num_cycles)
         config_name = encode(tb_cfg)
         obj.add_config(name=config_name,
                        generics=dict(encoded_tb_cfg=encode(tb_cfg)))
@@ -48,5 +47,3 @@ for test in tb_wishbone_master.get_tests():
 
 
 ui.main()
-
-

--- a/vunit/vhdl/verification_components/run.py
+++ b/vunit/vhdl/verification_components/run.py
@@ -19,9 +19,9 @@ lib.add_source_files(join(root, "test", "*.vhd"))
 
 def gen_wb_slave_tests(obj, dat_width, num_cycles, max_ack_dly, rand_stall):
     for dat_width, num_cycles, max_ack_dly, rand_stall \
-		in product(dat_width, num_cycles, max_ack_dly, rand_stall):
+    in product(dat_width, num_cycles, max_ack_dly, rand_stall):
         config_name = "dat_width=%i,num_cycles=%i,max_ack_dly=%i,rand_stall=%s" % \
-        	(dat_width, num_cycles, max_ack_dly, rand_stall)
+          (dat_width, num_cycles, max_ack_dly, rand_stall)
         obj.add_config(name=config_name,
                        generics=dict(
                            dat_width=dat_width,
@@ -39,9 +39,9 @@ for test in tb_wishbone_slave.get_tests():
 
 def gen_wb_master_tests(obj, dat_width, num_cycles, max_ack_dly, rand_stall):
     for dat_width, num_cycles, max_ack_dly, rand_stall \
-		in product(dat_width, num_cycles, max_ack_dly, rand_stall):
+    in product(dat_width, num_cycles, max_ack_dly, rand_stall):
         config_name = "dat_width=%i,num_cycles=%i,max_ack_dly=%i,rand_stall=%s" % \
-        	(dat_width, num_cycles, max_ack_dly, rand_stall)
+          (dat_width, num_cycles, max_ack_dly, rand_stall)
         obj.add_config(name=config_name,
                        generics=dict(
                            dat_width=dat_width,

--- a/vunit/vhdl/verification_components/run.py
+++ b/vunit/vhdl/verification_components/run.py
@@ -17,24 +17,24 @@ lib = ui.library("vunit_lib")
 lib.add_source_files(join(root, "test", "*.vhd"))
 
 
-def gen_wb_slave_tests(obj, dat_width, num_cycles, max_ack_dly):
-    for dat_width, num_cycles, max_ack_dly \
-		in product(dat_width, num_cycles, max_ack_dly):
-        config_name = "dat_width=%i,num_cycles=%i,max_ack_dly=%i" % \
-        	(dat_width, num_cycles, max_ack_dly)
+def gen_wb_slave_tests(obj, dat_width, num_cycles, max_ack_dly, rand_stall):
+    for dat_width, num_cycles, max_ack_dly, rand_stall \
+		in product(dat_width, num_cycles, max_ack_dly, rand_stall):
+        config_name = "dat_width=%i,num_cycles=%i,max_ack_dly=%i,rand_stall=%s" % \
+        	(dat_width, num_cycles, max_ack_dly, rand_stall)
         obj.add_config(name=config_name,
                        generics=dict(
                            dat_width=dat_width,
                            adr_width=8,
                            max_ack_dly=max_ack_dly,
-                           rand_stall=False,
+                           rand_stall=rand_stall,
                            num_cycles=num_cycles))
 
 
 tb_wishbone_slave = lib.test_bench("tb_wishbone_slave")
 
 for test in tb_wishbone_slave.get_tests():
-    gen_wb_slave_tests(test, [8, 32], [1, 10], [0, 1, 2])
+    gen_wb_slave_tests(test, [8, 32], [1, 10], [0, 1, 2], [False, True])
 
 ui.main()
 

--- a/vunit/vhdl/verification_components/src/wishbone_master.vhd
+++ b/vunit/vhdl/verification_components/src/wishbone_master.vhd
@@ -14,6 +14,7 @@ use ieee.std_logic_1164.all;
 use work.queue_pkg.all;
 use work.bus_master_pkg.all;
 context work.com_context;
+use work.com_types_pkg.all;
 use work.logger_pkg.all;
 use work.check_pkg.all;
 
@@ -49,15 +50,15 @@ begin
     variable msg_type : msg_type_t;
     variable status : com_status_t;
   begin
-      -- Cannot use receive, as it deletes the message
-      --receive(net, bus_handle.p_actor, request_msg);
-      wait_for_message(net, bus_handle.p_actor, status);
-      get_message(net, bus_handle.p_actor, request_msg);
+      request_msg := null_msg;
+      receive(net, bus_handle.p_actor, request_msg);
       msg_type := message_type(request_msg);
       if msg_type = bus_read_msg then
         push(rd_request_queue, request_msg);
+        request_msg := null_msg;
       elsif msg_type = bus_write_msg then
         push(wr_request_queue, request_msg);
+        request_msg := null_msg;
       else
         unexpected_msg_type(msg_type);
       end if;

--- a/vunit/vhdl/verification_components/src/wishbone_master.vhd
+++ b/vunit/vhdl/verification_components/src/wishbone_master.vhd
@@ -48,11 +48,9 @@ begin
     stb <= '0';
     wait until rising_edge(clk);
     loop
-      trace(bus_handle.p_logger, "blocking on receive");
       receive(net, bus_handle.p_actor, request_msg);
       msg_type := message_type(request_msg);
       if msg_type = bus_read_msg then
-		trace(bus_handle.p_logger, "got bus read msg");      
         adr <= pop_std_ulogic_vector(request_msg);
         cyc <= '1';
         stb <= '1';
@@ -64,7 +62,6 @@ begin
         pending_acks := pending_acks +1;
 
       elsif msg_type = bus_write_msg then
-		trace(bus_handle.p_logger, "got bus write msg");            
         adr <= pop_std_ulogic_vector(request_msg);
         dat_o <= pop_std_ulogic_vector(request_msg);
         sel <= pop_std_ulogic_vector(request_msg);
@@ -80,7 +77,6 @@ begin
 
       elsif msg_type = bus_ack_msg then
         -- TODO bus errors detection
-        trace(bus_handle.p_logger, "Got bus ack msg");
         received_acks := received_acks +1;
         if pending_acks = received_acks then
           -- End of wb cycle
@@ -108,12 +104,10 @@ begin
       push_std_ulogic_vector(reply_msg, dat_i);
       reply(net, request_msg, reply_msg);
       delete(request_msg);
-      trace("Sent msg to bus_master_pkg");
     end if;
     -- Response main that ack is received
     ack_msg := new_msg(bus_ack_msg);
     send(net, bus_handle.p_actor, ack_msg);
-    trace("Sent msg to main");
   end loop;
   end process;
 end architecture;

--- a/vunit/vhdl/verification_components/src/wishbone_master.vhd
+++ b/vunit/vhdl/verification_components/src/wishbone_master.vhd
@@ -5,7 +5,7 @@
 -- Slawomir Siluk slaweksiluk@gazeta.pl 2018
 -- Wishbome Master BFM for pipelined block transfers
 -- TODO:
---  * Random strobe option
+--  * Random strobe?
 library ieee;
 use ieee.std_logic_1164.all;
 
@@ -71,7 +71,6 @@ begin
     variable received_acks : natural := 0;
     variable rd_cycle : boolean;
     variable wr_cycle : boolean;
-    variable ack_mock : boolean;
   begin
     cyc <= '0';
     stb <= '0';
@@ -118,7 +117,7 @@ begin
           received_acks := 0;
           rd_cycle := false;
           wr_cycle := false;
-	      wait until rising_edge(clk);
+          wait until rising_edge(clk);
         end if;
 
       -- No cycles, juest sleep
@@ -130,7 +129,6 @@ begin
 
   acknowladge : process
     variable request_msg, reply_msg, ack_msg : msg_t;
-    variable ack_mock : boolean;
   begin
     wait until ack = '1' and rising_edge(clk);
     info(bus_handle.p_logger, "ack");
@@ -142,7 +140,7 @@ begin
       reply(net, request_msg, reply_msg);
     end if;
     delete(request_msg);
-    -- Response main that ack is received
+    -- Response main sequencer that ack is received
     ack_msg := new_msg(bus_ack_msg);
     send(net, wb_master_ack_actor, ack_msg);
   end process;

--- a/vunit/vhdl/verification_components/src/wishbone_master.vhd
+++ b/vunit/vhdl/verification_components/src/wishbone_master.vhd
@@ -37,7 +37,7 @@ end entity;
 architecture a of wishbone_master is
   constant request_queue : queue_t := new_queue;
   constant bus_ack_msg   : msg_type_t := new_msg_type("wb master ack msg");
-  constant wb_master_ack_actor : actor_t := new_actor("wb master ack actor");  
+  constant wb_master_ack_actor : actor_t := new_actor("wb master ack actor");
 begin
   main : process
     variable request_msg, reply_msg : msg_t;
@@ -53,7 +53,7 @@ begin
       -- Cannot use receive, as it deletes the message
       --receive(net, bus_handle.p_actor, request_msg);
       wait_for_message(net, bus_handle.p_actor, status);
-      get_message(net, bus_handle.p_actor, request_msg);      
+      get_message(net, bus_handle.p_actor, request_msg);
       msg_type := message_type(request_msg);
       if msg_type = bus_read_msg then
         adr <= pop_std_ulogic_vector(request_msg);
@@ -87,7 +87,6 @@ begin
           info(bus_handle.p_logger, "finished wb cycle");
           -- End of wb cycle
           cyc <= '0';
-          --wait until rising_edge(clk);
           pending_acks := 0;
           received_acks := 0;
         end if;

--- a/vunit/vhdl/verification_components/src/wishbone_master.vhd
+++ b/vunit/vhdl/verification_components/src/wishbone_master.vhd
@@ -42,7 +42,7 @@ architecture a of wishbone_master is
   constant acknowledge_queue : queue_t := new_queue;
   constant ack_return_queue : queue_t := new_queue;
   constant bus_ack_msg   : msg_type_t := new_msg_type("wb master ack msg");
-  constant wb_master_ack_actor : actor_t := new_actor("wb master ack actor");
+  constant wb_master_ack_actor : actor_t := new_actor;
 begin
 
   main : process

--- a/vunit/vhdl/verification_components/src/wishbone_master.vhd
+++ b/vunit/vhdl/verification_components/src/wishbone_master.vhd
@@ -121,7 +121,7 @@ begin
           wait until rising_edge(clk);
         end if;
 
-      -- No cycles, juest sleep
+      -- No cycles, wait one clk period
       else
         wait until rising_edge(clk);
       end if;

--- a/vunit/vhdl/verification_components/src/wishbone_master.vhd
+++ b/vunit/vhdl/verification_components/src/wishbone_master.vhd
@@ -36,8 +36,8 @@ end entity;
 
 architecture a of wishbone_master is
   constant request_queue : queue_t := new_queue;
-  constant bus_ack_msg   : msg_type_t := new_msg_type("ack bus");
-  constant wb_master_ack_actor : actor_t := new_actor("wb master ack");  
+  constant bus_ack_msg   : msg_type_t := new_msg_type("wb master ack msg");
+  constant wb_master_ack_actor : actor_t := new_actor("wb master ack actor");  
 begin
   main : process
     variable request_msg, reply_msg : msg_t;
@@ -80,9 +80,10 @@ begin
         -- TODO bus errors detection
         received_acks := received_acks +1;
         if pending_acks = received_acks then
+          info(bus_handle.p_logger, "finished wb cycle");
           -- End of wb cycle
           cyc <= '0';
-          wait until rising_edge(clk);
+          --wait until rising_edge(clk);
           pending_acks := 0;
           received_acks := 0;
         end if;

--- a/vunit/vhdl/verification_components/src/wishbone_master.vhd
+++ b/vunit/vhdl/verification_components/src/wishbone_master.vhd
@@ -44,13 +44,13 @@ begin
     variable msg_type : msg_type_t;
     variable pending_acks : natural := 0;
     variable received_acks : natural := 0;
-    variable status		: com_status_t;
+    variable status : com_status_t;
   begin
     cyc <= '0';
     stb <= '0';
     wait until rising_edge(clk);
     loop
-    	-- Cannot use receive, as it deletes the message
+      -- Cannot use receive, as it deletes the message
       --receive(net, bus_handle.p_actor, request_msg);
       wait_for_message(net, bus_handle.p_actor, status);
       get_message(net, bus_handle.p_actor, request_msg);      
@@ -108,8 +108,8 @@ begin
       reply_msg := new_msg(sender => wb_master_ack_actor);
       push_std_ulogic_vector(reply_msg, dat_i);
       reply(net, request_msg, reply_msg);
-      delete(request_msg);
     end if;
+    delete(request_msg);
     -- Response main that ack is received
     ack_msg := new_msg(bus_ack_msg);
     send(net, bus_handle.p_actor, ack_msg);

--- a/vunit/vhdl/verification_components/src/wishbone_master.vhd
+++ b/vunit/vhdl/verification_components/src/wishbone_master.vhd
@@ -37,6 +37,7 @@ end entity;
 architecture a of wishbone_master is
   constant request_queue : queue_t := new_queue;
   constant bus_ack_msg   : msg_type_t := new_msg_type("ack bus");
+  constant wb_master_ack_actor : actor_t := new_actor("wb master ack");  
 begin
   main : process
     variable request_msg, reply_msg : msg_t;
@@ -100,7 +101,7 @@ begin
     request_msg := pop(request_queue);
     -- Reply only on read
     if we = '0' then
-      reply_msg := new_msg;
+      reply_msg := new_msg(sender => wb_master_ack_actor);
       push_std_ulogic_vector(reply_msg, dat_i);
       reply(net, request_msg, reply_msg);
       delete(request_msg);

--- a/vunit/vhdl/verification_components/src/wishbone_master.vhd
+++ b/vunit/vhdl/verification_components/src/wishbone_master.vhd
@@ -3,8 +3,11 @@
 -- You can obtain one at http://mozilla.org/MPL/2.0/.
 --
 -- Slawomir Siluk slaweksiluk@gazeta.pl 2018
--- Wishbome Master Single Pipelined Bus Functional Model
--- Wb M S P BFM
+-- Wishbome Master Block Pipelined Bus Functional Model
+-- TODO:
+-- - stall input
+-- - how to handle read req msg received while some writes
+--   are still in progress?
 
 
 library ieee;

--- a/vunit/vhdl/verification_components/src/wishbone_master.vhd
+++ b/vunit/vhdl/verification_components/src/wishbone_master.vhd
@@ -48,10 +48,11 @@ begin
     stb <= '0';
     wait until rising_edge(clk);
     loop
-      info(bus_handle.p_logger, "blocking on receive");
+      trace(bus_handle.p_logger, "blocking on receive");
       receive(net, bus_handle.p_actor, request_msg);
       msg_type := message_type(request_msg);
       if msg_type = bus_read_msg then
+		trace(bus_handle.p_logger, "got bus read msg");      
         adr <= pop_std_ulogic_vector(request_msg);
         cyc <= '1';
         stb <= '1';
@@ -63,6 +64,7 @@ begin
         pending_acks := pending_acks +1;
 
       elsif msg_type = bus_write_msg then
+		trace(bus_handle.p_logger, "got bus write msg");            
         adr <= pop_std_ulogic_vector(request_msg);
         dat_o <= pop_std_ulogic_vector(request_msg);
         sel <= pop_std_ulogic_vector(request_msg);
@@ -78,7 +80,7 @@ begin
 
       elsif msg_type = bus_ack_msg then
         -- TODO bus errors detection
-        info("Got bus ack msg");
+        trace(bus_handle.p_logger, "Got bus ack msg");
         received_acks := received_acks +1;
         if pending_acks = received_acks then
           -- End of wb cycle
@@ -106,12 +108,12 @@ begin
       push_std_ulogic_vector(reply_msg, dat_i);
       reply(net, request_msg, reply_msg);
       delete(request_msg);
-      info("Sent msg to bus_master_pkg");
+      trace("Sent msg to bus_master_pkg");
     end if;
     -- Response main that ack is received
     ack_msg := new_msg(bus_ack_msg);
     send(net, bus_handle.p_actor, ack_msg);
-    info("Sent msg to main");
+    trace("Sent msg to main");
   end loop;
   end process;
 end architecture;

--- a/vunit/vhdl/verification_components/src/wishbone_master.vhd
+++ b/vunit/vhdl/verification_components/src/wishbone_master.vhd
@@ -44,12 +44,16 @@ begin
     variable msg_type : msg_type_t;
     variable pending_acks : natural := 0;
     variable received_acks : natural := 0;
+    variable status		: com_status_t;
   begin
     cyc <= '0';
     stb <= '0';
     wait until rising_edge(clk);
     loop
-      receive(net, bus_handle.p_actor, request_msg);
+    	-- Cannot use receive, as it deletes the message
+      --receive(net, bus_handle.p_actor, request_msg);
+      wait_for_message(net, bus_handle.p_actor, status);
+      get_message(net, bus_handle.p_actor, request_msg);      
       msg_type := message_type(request_msg);
       if msg_type = bus_read_msg then
         adr <= pop_std_ulogic_vector(request_msg);

--- a/vunit/vhdl/verification_components/src/wishbone_master.vhd
+++ b/vunit/vhdl/verification_components/src/wishbone_master.vhd
@@ -1,0 +1,117 @@
+-- This Source Code Form is subject to the terms of the Mozilla Public
+-- License, v. 2.0. If a copy of the MPL was not distributed with this file,
+-- You can obtain one at http://mozilla.org/MPL/2.0/.
+--
+-- Slawomir Siluk slaweksiluk@gazeta.pl 2018
+-- Wishbome Master Single Pipelined Bus Functional Model
+-- Wb M S P BFM
+
+
+library ieee;
+use ieee.std_logic_1164.all;
+
+--use work.axi_pkg.all;
+use work.queue_pkg.all;
+use work.bus_master_pkg.all;
+--use work.axi_private_pkg.all;
+context work.com_context;
+use work.logger_pkg.all;
+
+entity wishbone_master is
+  generic (
+    bus_handle : bus_master_t
+    );
+  port (
+    clk   : in std_logic;
+    adr   : out std_logic_vector;
+    dat_i : in  std_logic_vector;
+    dat_o : out std_logic_vector;
+    sel   : out std_logic_vector;
+    cyc   : out std_logic;
+    stb   : out std_logic;
+    we    : out std_logic;
+    ack   : in  std_logic
+    );
+end entity;
+
+architecture a of wishbone_master is
+  constant request_queue : queue_t := new_queue;
+  constant bus_ack_msg   : msg_type_t := new_msg_type("ack bus");
+begin
+  main : process
+    variable request_msg, reply_msg : msg_t;
+    variable msg_type : msg_type_t;
+    variable pending_acks : natural := 0;
+    variable received_acks : natural := 0;
+  begin
+    cyc <= '0';
+    stb <= '0';
+    wait until rising_edge(clk);
+    loop
+      verbose(bus_handle.p_logger, "blocking on receive");
+      receive(net, bus_handle.p_actor, request_msg);
+      msg_type := message_type(request_msg);
+      if msg_type = bus_read_msg then
+        adr <= pop_std_ulogic_vector(request_msg);
+        cyc <= '1';
+        stb <= '1';
+        we <= '0';
+        wait until rising_edge(clk);
+        stb <= '0';
+
+        push(request_queue, request_msg);
+        pending_acks := pending_acks +1;
+
+      elsif msg_type = bus_write_msg then
+        adr <= pop_std_ulogic_vector(request_msg);
+        dat_o <= pop_std_ulogic_vector(request_msg);
+        sel <= pop_std_ulogic_vector(request_msg);
+
+        cyc <= '1';
+        stb <= '1';
+        we <= '1';
+        wait until rising_edge(clk);
+        stb <= '0';
+
+        push(request_queue, request_msg);
+        pending_acks := pending_acks +1;
+
+      elsif msg_type = bus_ack_msg then
+        -- TODO bus errors detection
+        info("Got bus ack msg");
+        received_acks := received_acks +1;
+        if pending_acks = received_acks then
+          -- End of wb cycle
+          cyc <= '0';
+          wait until rising_edge(clk);
+          pending_acks := 0;
+          received_acks := 0;
+        end if;
+      else
+        unexpected_msg_type(msg_type);
+      end if;
+    end loop;
+  end process;
+
+  acknowladge : process
+    variable request_msg, reply_msg, ack_msg : msg_t;
+    variable msg_type : msg_type_t;
+  begin
+  loop
+    wait until ack = '1' and rising_edge(clk);
+    request_msg := pop(request_queue);
+    -- Reply only on read
+    if we = '0' then
+      reply_msg := new_msg;
+      push_std_ulogic_vector(reply_msg, dat_i);
+      reply(net, request_msg, reply_msg);
+      delete(request_msg);
+      info("Sent msg to bus_master_pkg");
+    end if;
+    -- Response main that ack is received
+    ack_msg := new_msg(bus_ack_msg);
+    send(net, bus_handle.p_actor, ack_msg);
+    info("Sent msg to main");
+  end loop;
+  end process;
+end architecture;

--- a/vunit/vhdl/verification_components/src/wishbone_master.vhd
+++ b/vunit/vhdl/verification_components/src/wishbone_master.vhd
@@ -2,17 +2,17 @@
 -- License, v. 2.0. If a copy of the MPL was not distributed with this file,
 -- You can obtain one at http://mozilla.org/MPL/2.0/.
 --
--- Slawomir Siluk slaweksiluk@gazeta.pl 2018
+-- Copyright (c) 2017-2018, Lars Asplund lars.anders.asplund@gmail.com
+-- Author Slawomir Siluk slaweksiluk@gazeta.pl
 -- Wishbome Master BFM for pipelined block transfers
 -- TODO:
 --  * Random strobe?
+
 library ieee;
 use ieee.std_logic_1164.all;
 
---use work.axi_pkg.all;
 use work.queue_pkg.all;
 use work.bus_master_pkg.all;
---use work.axi_private_pkg.all;
 context work.com_context;
 use work.logger_pkg.all;
 use work.check_pkg.all;
@@ -127,7 +127,7 @@ begin
     end loop;
   end process;
 
-  acknowladge : process
+  acknowledge : process
     variable request_msg, reply_msg, ack_msg : msg_t;
   begin
     wait until ack = '1' and rising_edge(clk);

--- a/vunit/vhdl/verification_components/src/wishbone_master.vhd
+++ b/vunit/vhdl/verification_components/src/wishbone_master.vhd
@@ -48,7 +48,7 @@ begin
     stb <= '0';
     wait until rising_edge(clk);
     loop
-      verbose(bus_handle.p_logger, "blocking on receive");
+      info(bus_handle.p_logger, "blocking on receive");
       receive(net, bus_handle.p_actor, request_msg);
       msg_type := message_type(request_msg);
       if msg_type = bus_read_msg then

--- a/vunit/vhdl/verification_components/src/wishbone_master.vhd
+++ b/vunit/vhdl/verification_components/src/wishbone_master.vhd
@@ -97,7 +97,6 @@ begin
     variable request_msg, reply_msg, ack_msg : msg_t;
     variable msg_type : msg_type_t;
   begin
-  loop
     wait until ack = '1' and rising_edge(clk);
     request_msg := pop(request_queue);
     -- Reply only on read
@@ -110,6 +109,5 @@ begin
     -- Response main that ack is received
     ack_msg := new_msg(bus_ack_msg);
     send(net, bus_handle.p_actor, ack_msg);
-  end loop;
   end process;
 end architecture;

--- a/vunit/vhdl/verification_components/src/wishbone_pkg.vhd
+++ b/vunit/vhdl/verification_components/src/wishbone_pkg.vhd
@@ -1,0 +1,45 @@
+-- This Source Code Form is subject to the terms of the Mozilla Public
+-- License, v. 2.0. If a copy of the MPL was not distributed with this file,
+-- You can obtain one at http://mozilla.org/MPL/2.0/.
+--
+-- Copyright (c) 2017-2018, Lars Asplund lars.anders.asplund@gmail.com
+-- Author Slawomir Siluk slaweksiluk@gazeta.pl
+library ieee;
+use ieee.std_logic_1164.all;
+
+use work.queue_pkg.all;
+use work.logger_pkg.all;
+use work.memory_pkg.all;
+context work.com_context;
+
+package wishbone_pkg is
+
+  type wishbone_slave_t is record
+    -- Private
+    p_actor : actor_t;
+    p_ack_actor : actor_t;
+    p_memory : memory_t;
+    p_logger : logger_t;
+  end record;
+
+  constant wishbone_slave_logger : logger_t := get_logger("vunit_lib:wishbone_slave_pkg");
+  impure function new_wishbone_slave(
+    memory : memory_t;
+    logger : logger_t := wishbone_slave_logger)
+    return wishbone_slave_t;
+
+end package;
+package body wishbone_pkg is
+
+  impure function new_wishbone_slave(
+    memory : memory_t;
+    logger : logger_t := wishbone_slave_logger)
+    return wishbone_slave_t is
+  begin
+    return (p_actor => new_actor,
+            p_ack_actor => new_actor,
+            p_memory => to_vc_interface(memory, logger),
+            p_logger => logger);
+  end;
+
+end package body;

--- a/vunit/vhdl/verification_components/src/wishbone_pkg.vhd
+++ b/vunit/vhdl/verification_components/src/wishbone_pkg.vhd
@@ -15,6 +15,7 @@ context work.com_context;
 package wishbone_pkg is
 
   type wishbone_slave_t is record
+  	ack_high_probability : real range 0.0 to 1.0;
     -- Private
     p_actor : actor_t;
     p_ack_actor : actor_t;
@@ -25,6 +26,7 @@ package wishbone_pkg is
   constant wishbone_slave_logger : logger_t := get_logger("vunit_lib:wishbone_slave_pkg");
   impure function new_wishbone_slave(
     memory : memory_t;
+    ack_high_probability : real := 1.0;
     logger : logger_t := wishbone_slave_logger)
     return wishbone_slave_t;
 
@@ -33,13 +35,16 @@ package body wishbone_pkg is
 
   impure function new_wishbone_slave(
     memory : memory_t;
+    ack_high_probability : real := 1.0;
     logger : logger_t := wishbone_slave_logger)
     return wishbone_slave_t is
   begin
     return (p_actor => new_actor,
             p_ack_actor => new_actor,
             p_memory => to_vc_interface(memory, logger),
-            p_logger => logger);
+            p_logger => logger,
+            ack_high_probability => ack_high_probability
+        );
   end;
 
 end package body;

--- a/vunit/vhdl/verification_components/src/wishbone_pkg.vhd
+++ b/vunit/vhdl/verification_components/src/wishbone_pkg.vhd
@@ -15,7 +15,8 @@ context work.com_context;
 package wishbone_pkg is
 
   type wishbone_slave_t is record
-  	ack_high_probability : real range 0.0 to 1.0;
+    ack_high_probability : real range 0.0 to 1.0;
+    stall_high_probability : real range 0.0 to 1.0;
     -- Private
     p_actor : actor_t;
     p_ack_actor : actor_t;
@@ -27,6 +28,7 @@ package wishbone_pkg is
   impure function new_wishbone_slave(
     memory : memory_t;
     ack_high_probability : real := 1.0;
+    stall_high_probability : real := 0.0;
     logger : logger_t := wishbone_slave_logger)
     return wishbone_slave_t;
 
@@ -36,6 +38,7 @@ package body wishbone_pkg is
   impure function new_wishbone_slave(
     memory : memory_t;
     ack_high_probability : real := 1.0;
+    stall_high_probability : real := 0.0;
     logger : logger_t := wishbone_slave_logger)
     return wishbone_slave_t is
   begin
@@ -43,7 +46,8 @@ package body wishbone_pkg is
             p_ack_actor => new_actor,
             p_memory => to_vc_interface(memory, logger),
             p_logger => logger,
-            ack_high_probability => ack_high_probability
+            ack_high_probability => ack_high_probability,
+            stall_high_probability => stall_high_probability
         );
   end;
 

--- a/vunit/vhdl/verification_components/src/wishbone_slave.vhd
+++ b/vunit/vhdl/verification_components/src/wishbone_slave.vhd
@@ -11,7 +11,7 @@
 -- - err and rty responses
 -- - variable memory size (currenlty 1024Bytes)
 -- - variable address range
--- - consider passing memory object to slave instead of 
+-- - consider passing memory object to slave instead of
 --   create it locally
 
 library ieee;
@@ -43,10 +43,10 @@ end entity;
 
 architecture a of wishbone_slave is
 
-	constant ack_actor 		: actor_t := new_actor("slave ack actor");
-  constant slave_logger : logger_t := get_logger("slave");
-  constant slave_write_msg   : msg_type_t := new_msg_type("wb slave write");  
-  constant slave_read_msg   : msg_type_t := new_msg_type("wb slave read");  
+  constant ack_actor        : actor_t := new_actor("slave ack actor");
+  constant slave_logger     : logger_t := get_logger("slave");
+  constant slave_write_msg  : msg_type_t := new_msg_type("wb slave write");
+  constant slave_read_msg   : msg_type_t := new_msg_type("wb slave read");
 begin
 
   show(slave_logger, display_handler, verbose);
@@ -60,14 +60,12 @@ begin
       wr_request_msg := new_msg(slave_write_msg);
       -- For write address and data is passed to ack proc
       push_integer(wr_request_msg, to_integer(unsigned(adr)));
-      push_std_ulogic_vector(wr_request_msg, dat_i);      
+      push_std_ulogic_vector(wr_request_msg, dat_i);
       send(net, ack_actor, wr_request_msg);
     elsif we = '0' then
       rd_request_msg := new_msg(slave_read_msg);
       -- For read, only address is passed to ack proc
-			info(slave_logger, "push_integer");
       push_integer(rd_request_msg, to_integer(unsigned(adr)));
-			info(slave_logger, "send");
       send(net, ack_actor, rd_request_msg);
     end if;
   end process;
@@ -78,7 +76,7 @@ begin
     variable data : std_logic_vector(dat_i'range);
     variable addr : natural;
     variable memory : memory_t := new_memory;
-    variable buf : buffer_t := allocate(memory, 1024);        
+    variable buf : buffer_t := allocate(memory, 1024);
   begin
     ack <= '0';
     receive(net, ack_actor, request_msg);
@@ -87,17 +85,14 @@ begin
     if msg_type = slave_write_msg then
       addr := pop_integer(request_msg);
       data := pop_std_ulogic_vector(request_msg);
-      write_word(memory, addr, data);      	
+      write_word(memory, addr, data);
       ack <= '1';
       wait until rising_edge(clk);
       ack <= '0';
 
     elsif msg_type = slave_read_msg then
       data := (others => '0');
-			-- error: pop from empty queue 
-			info(slave_logger, "pop_integer");
-			addr := pop_integer(request_msg);
-			info(slave_logger, "read word");
+      addr := pop_integer(request_msg);
       data := read_word(memory, addr, 1);
       dat_o <= data;
       ack <= '1';

--- a/vunit/vhdl/verification_components/src/wishbone_slave.vhd
+++ b/vunit/vhdl/verification_components/src/wishbone_slave.vhd
@@ -83,14 +83,15 @@ begin
     if msg_type = bus_write_msg then
       addr := pop_integer(request_msg);
       data := pop_std_ulogic_vector(request_msg);
-      --write_word(memory, addr, data);      	
+      write_word(memory, addr, data);      	
       ack <= '1';
       wait until rising_edge(clk);
       ack <= '0';
 
     elsif msg_type = bus_read_msg then
+      data := (others => '0');
       addr := pop_integer(request_msg);
-      --data := read_word(memory, addr, dat_o'length/8);
+      data := read_word(memory, addr, 2);
       dat_o <= data;
       ack <= '1';
       wait until rising_edge(clk);

--- a/vunit/vhdl/verification_components/src/wishbone_slave.vhd
+++ b/vunit/vhdl/verification_components/src/wishbone_slave.vhd
@@ -11,6 +11,8 @@
 -- - err and rty responses
 -- - variable memory size (currenlty 1024Bytes)
 -- - variable address range
+-- - consider passing memory object to slave instead of 
+--   create it locally
 
 library ieee;
 use ieee.std_logic_1164.all;

--- a/vunit/vhdl/verification_components/src/wishbone_slave.vhd
+++ b/vunit/vhdl/verification_components/src/wishbone_slave.vhd
@@ -100,6 +100,9 @@ begin
       for i in 1 to rnd.RandInt(0, max_ack_dly) loop
         wait until rising_edge(clk);
       end loop;
+      while rnd.Uniform(0.0, 1.0) > wishbone_slave.ack_high_probability loop
+        wait until rising_edge(clk);
+      end loop;
       dat_o <= data;
       ack <= '1';
       wait until rising_edge(clk);

--- a/vunit/vhdl/verification_components/src/wishbone_slave.vhd
+++ b/vunit/vhdl/verification_components/src/wishbone_slave.vhd
@@ -65,7 +65,9 @@ begin
     elsif we = '0' then
       rd_request_msg := new_msg(slave_read_msg);
       -- For read, only address is passed to ack proc
+			info(slave_logger, "push_integer");
       push_integer(rd_request_msg, to_integer(unsigned(adr)));
+			info(slave_logger, "send");
       send(net, ack_actor, rd_request_msg);
     end if;
   end process;
@@ -92,9 +94,11 @@ begin
 
     elsif msg_type = slave_read_msg then
       data := (others => '0');
-			-- error: pop from empty queue below
-      --addr := pop_integer(request_msg);
-      data := read_word(memory, addr, 2);
+			-- error: pop from empty queue 
+			info(slave_logger, "pop_integer");
+			addr := pop_integer(request_msg);
+			info(slave_logger, "read word");
+      data := read_word(memory, addr, 1);
       dat_o <= data;
       ack <= '1';
       wait until rising_edge(clk);

--- a/vunit/vhdl/verification_components/src/wishbone_slave.vhd
+++ b/vunit/vhdl/verification_components/src/wishbone_slave.vhd
@@ -41,10 +41,10 @@ end entity;
 
 architecture a of wishbone_slave is
 
-	constant ack_actor 		: actor_t := new_actor("ack_actor");
+	constant ack_actor 		: actor_t := new_actor("slave ack actor");
   constant slave_logger : logger_t := get_logger("slave");
-  constant bus_write_msg   : msg_type_t := new_msg_type("wb bus write");  
-  constant bus_read_msg   : msg_type_t := new_msg_type("wb bus read");  
+  constant bus_write_msg   : msg_type_t := new_msg_type("wb slave write");  
+  constant bus_read_msg   : msg_type_t := new_msg_type("wb slave read");  
 begin
 
   show(slave_logger, display_handler, verbose);

--- a/vunit/vhdl/verification_components/src/wishbone_slave.vhd
+++ b/vunit/vhdl/verification_components/src/wishbone_slave.vhd
@@ -7,7 +7,6 @@
 -- TODO:
 -- - wb sel
 -- - stall (random)
--- - random ack delay
 -- - err and rty responses
 -- - variable memory size (currenlty 1024Bytes)
 -- - variable address range
@@ -41,6 +40,7 @@ entity wishbone_slave is
     cyc   : in std_logic;
     stb   : in std_logic;
     we    : in std_logic;
+    stall : out std_logic;
     ack   : out  std_logic
     );
 end entity;
@@ -59,7 +59,7 @@ begin
     variable wr_request_msg : msg_t;
     variable rd_request_msg : msg_t;
   begin
-    wait until (cyc and stb) = '1' and rising_edge(clk);
+    wait until (cyc and stb) = '1' and stall = '0' and rising_edge(clk);
     if we = '1' then
       wr_request_msg := new_msg(slave_write_msg);
       -- For write address and data is passed to ack proc
@@ -114,4 +114,18 @@ begin
       unexpected_msg_type(msg_type);
     end if;
   end process;
+
+  stall_stim_gen: if rand_stall generate
+    signal stall_l    : std_logic := '0';
+    begin
+    stall_stim: process
+      variable rnd : RandomPType;
+    begin
+      wait until rising_edge(clk) and cyc = '1';
+      stall_l <= rnd.RandSlv(1, 1)(0);
+    end process;
+    stall <= stall_l;
+  else generate
+    stall <= '0';
+  end generate;
 end architecture;

--- a/vunit/vhdl/verification_components/src/wishbone_slave.vhd
+++ b/vunit/vhdl/verification_components/src/wishbone_slave.vhd
@@ -45,8 +45,8 @@ architecture a of wishbone_slave is
 
 	constant ack_actor 		: actor_t := new_actor("slave ack actor");
   constant slave_logger : logger_t := get_logger("slave");
-  constant bus_write_msg   : msg_type_t := new_msg_type("wb slave write");  
-  constant bus_read_msg   : msg_type_t := new_msg_type("wb slave read");  
+  constant slave_write_msg   : msg_type_t := new_msg_type("wb slave write");  
+  constant slave_read_msg   : msg_type_t := new_msg_type("wb slave read");  
 begin
 
   show(slave_logger, display_handler, verbose);
@@ -57,13 +57,13 @@ begin
   begin
     wait until (cyc and stb) = '1' and rising_edge(clk);
     if we = '1' then
-      wr_request_msg := new_msg(bus_write_msg);
+      wr_request_msg := new_msg(slave_write_msg);
       -- For write address and data is passed to ack proc
       push_integer(wr_request_msg, to_integer(unsigned(adr)));
       push_std_ulogic_vector(wr_request_msg, dat_i);      
       send(net, ack_actor, wr_request_msg);
     elsif we = '0' then
-      rd_request_msg := new_msg(bus_read_msg);
+      rd_request_msg := new_msg(slave_read_msg);
       -- For read, only address is passed to ack proc
       push_integer(rd_request_msg, to_integer(unsigned(adr)));
       send(net, ack_actor, rd_request_msg);
@@ -82,7 +82,7 @@ begin
     receive(net, ack_actor, request_msg);
     msg_type := message_type(request_msg);
 
-    if msg_type = bus_write_msg then
+    if msg_type = slave_write_msg then
       addr := pop_integer(request_msg);
       data := pop_std_ulogic_vector(request_msg);
       write_word(memory, addr, data);      	
@@ -90,9 +90,10 @@ begin
       wait until rising_edge(clk);
       ack <= '0';
 
-    elsif msg_type = bus_read_msg then
+    elsif msg_type = slave_read_msg then
       data := (others => '0');
-      addr := pop_integer(request_msg);
+			-- error: pop from empty queue below
+      --addr := pop_integer(request_msg);
       data := read_word(memory, addr, 2);
       dat_o <= data;
       ack <= '1';

--- a/vunit/vhdl/verification_components/src/wishbone_slave.vhd
+++ b/vunit/vhdl/verification_components/src/wishbone_slave.vhd
@@ -86,7 +86,7 @@ begin
       addr := pop_integer(request_msg);
       data := pop_std_ulogic_vector(request_msg);
       write_word(wishbone_slave.p_memory, addr, data);
-      for i in 1 to rnd.RandInt(0, max_ack_dly) loop
+      while rnd.Uniform(0.0, 1.0) > wishbone_slave.ack_high_probability loop
         wait until rising_edge(clk);
       end loop;
       ack <= '1';

--- a/vunit/vhdl/verification_components/src/wishbone_slave.vhd
+++ b/vunit/vhdl/verification_components/src/wishbone_slave.vhd
@@ -5,13 +5,13 @@
 -- Slawomir Siluk slaweksiluk@gazeta.pl 2018
 -- Wishbone slave wrapper for Vunit memory VC
 -- TODO:
--- - wb sel
--- - stall (random)
--- - err and rty responses
--- - variable memory size (currenlty 1024Bytes)
--- - variable address range
--- - consider passing memory object to slave instead of
---   create it locally
+-- * wb sel
+-- * err and rty responses
+-- * Memory:
+--    - variable memory size (currenlty 1024Bytes)
+--    - variable address range
+--    - consider passing memory object to slave instead of
+--      create it locally
 
 library ieee;
 use ieee.std_logic_1164.all;

--- a/vunit/vhdl/verification_components/src/wishbone_slave.vhd
+++ b/vunit/vhdl/verification_components/src/wishbone_slave.vhd
@@ -2,7 +2,8 @@
 -- License, v. 2.0. If a copy of the MPL was not distributed with this file,
 -- You can obtain one at http://mozilla.org/MPL/2.0/.
 --
--- Slawomir Siluk slaweksiluk@gazeta.pl 2018
+-- Copyright (c) 2017-2018, Lars Asplund lars.anders.asplund@gmail.com
+-- Author Slawomir Siluk slaweksiluk@gazeta.pl
 -- Wishbone slave wrapper for Vunit memory VC
 -- TODO:
 -- * wb sel
@@ -17,10 +18,8 @@ library ieee;
 use ieee.std_logic_1164.all;
 use ieee.numeric_std.all;
 
-library vunit_lib;
-context vunit_lib.vunit_context;
+context work.vunit_context;
 context work.com_context;
-
 use work.memory_pkg.all;
 
 library osvvm;

--- a/vunit/vhdl/verification_components/test/tb_wishbone_master.gtkw
+++ b/vunit/vhdl/verification_components/test/tb_wishbone_master.gtkw
@@ -1,0 +1,33 @@
+[*]
+[*] GTKWave Analyzer v3.3.86 (w)1999-2017 BSI
+[*] Sat Jan 27 19:20:41 2018
+[*]
+[dumpfile] "/home/slawek/git/github/vunit/vunit/vhdl/verification_components/vunit_out/test_output/vunit_lib.tb_wishbone_master.Test_block_read_202b7531a60c370a612dc5673435d50d290a40aa/ghdl/wave.ghw"
+[dumpfile_mtime] "Sat Jan 27 19:20:28 2018"
+[dumpfile_size] 2167
+[savefile] "/home/slawek/git/github/vunit/vunit/vhdl/verification_components/test/tb_wishbone_master.gtkw"
+[timestart] 0
+[size] 1000 600
+[pos] -1 -1
+*-26.057610 25000000 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1
+[treeopen] top.
+[treeopen] top.tb_wishbone_master.
+[sst_width] 225
+[signals_width] 202
+[sst_expanded] 1
+[sst_vpaned_height] 278
+@28
+top.tb_wishbone_master.dut.cyc
+top.tb_wishbone_master.dut.stb
+top.tb_wishbone_master.dut.ack
+top.tb_wishbone_master.dut.we
+top.tb_wishbone_master.dut.clk
+#{top.tb_wishbone_master.sel[1:0]} top.tb_wishbone_master.sel[1] top.tb_wishbone_master.sel[0]
+@22
+#{top.tb_wishbone_master.dat_o[15:0]} top.tb_wishbone_master.dat_o[15] top.tb_wishbone_master.dat_o[14] top.tb_wishbone_master.dat_o[13] top.tb_wishbone_master.dat_o[12] top.tb_wishbone_master.dat_o[11] top.tb_wishbone_master.dat_o[10] top.tb_wishbone_master.dat_o[9] top.tb_wishbone_master.dat_o[8] top.tb_wishbone_master.dat_o[7] top.tb_wishbone_master.dat_o[6] top.tb_wishbone_master.dat_o[5] top.tb_wishbone_master.dat_o[4] top.tb_wishbone_master.dat_o[3] top.tb_wishbone_master.dat_o[2] top.tb_wishbone_master.dat_o[1] top.tb_wishbone_master.dat_o[0]
+#{top.tb_wishbone_master.dat_i[15:0]} top.tb_wishbone_master.dat_i[15] top.tb_wishbone_master.dat_i[14] top.tb_wishbone_master.dat_i[13] top.tb_wishbone_master.dat_i[12] top.tb_wishbone_master.dat_i[11] top.tb_wishbone_master.dat_i[10] top.tb_wishbone_master.dat_i[9] top.tb_wishbone_master.dat_i[8] top.tb_wishbone_master.dat_i[7] top.tb_wishbone_master.dat_i[6] top.tb_wishbone_master.dat_i[5] top.tb_wishbone_master.dat_i[4] top.tb_wishbone_master.dat_i[3] top.tb_wishbone_master.dat_i[2] top.tb_wishbone_master.dat_i[1] top.tb_wishbone_master.dat_i[0]
+#{top.tb_wishbone_master.adr[3:0]} top.tb_wishbone_master.adr[3] top.tb_wishbone_master.adr[2] top.tb_wishbone_master.adr[1] top.tb_wishbone_master.adr[0]
+@421
+top.tb_wishbone_master.slave_index
+[pattern_trace] 1
+[pattern_trace] 0

--- a/vunit/vhdl/verification_components/test/tb_wishbone_master.gtkw
+++ b/vunit/vhdl/verification_components/test/tb_wishbone_master.gtkw
@@ -1,15 +1,15 @@
 [*]
 [*] GTKWave Analyzer v3.3.86 (w)1999-2017 BSI
-[*] Sat Jan 27 19:20:41 2018
+[*] Fri Mar  2 13:57:11 2018
 [*]
-[dumpfile] "/home/slawek/git/github/vunit/vunit/vhdl/verification_components/vunit_out/test_output/vunit_lib.tb_wishbone_master.Test_block_read_202b7531a60c370a612dc5673435d50d290a40aa/ghdl/wave.ghw"
-[dumpfile_mtime] "Sat Jan 27 19:20:28 2018"
-[dumpfile_size] 2167
-[savefile] "/home/slawek/git/github/vunit/vunit/vhdl/verification_components/test/tb_wishbone_master.gtkw"
+[dumpfile] "/home/lab-buddy/git/github/vunit/vunit/vhdl/verification_components/vunit_out/test_output/vunit_lib.tb_wishbone_master.dat_width=8,num_cycles=10,max_ack_dly=1,rand_stall=True.wr_block_rd_block_8906412844b894c70796945e7fb1d829a571874f/ghdl/wave.ghw"
+[dumpfile_mtime] "Fri Mar  2 13:56:52 2018"
+[dumpfile_size] 3234
+[savefile] "/home/lab-buddy/git/github/vunit/vunit/vhdl/verification_components/test/tb_wishbone_master.gtkw"
 [timestart] 0
 [size] 1000 600
 [pos] -1 -1
-*-26.057610 25000000 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1
+*-26.057610 91400000 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1
 [treeopen] top.
 [treeopen] top.tb_wishbone_master.
 [sst_width] 225
@@ -20,14 +20,15 @@
 top.tb_wishbone_master.dut.cyc
 top.tb_wishbone_master.dut.stb
 top.tb_wishbone_master.dut.ack
+@29
+top.tb_wishbone_master.stall
+@28
 top.tb_wishbone_master.dut.we
 top.tb_wishbone_master.dut.clk
-#{top.tb_wishbone_master.sel[1:0]} top.tb_wishbone_master.sel[1] top.tb_wishbone_master.sel[0]
+#{top.tb_wishbone_master.sel[1:0]} top.tb_wishbone_master.sel[0]
 @22
-#{top.tb_wishbone_master.dat_o[15:0]} top.tb_wishbone_master.dat_o[15] top.tb_wishbone_master.dat_o[14] top.tb_wishbone_master.dat_o[13] top.tb_wishbone_master.dat_o[12] top.tb_wishbone_master.dat_o[11] top.tb_wishbone_master.dat_o[10] top.tb_wishbone_master.dat_o[9] top.tb_wishbone_master.dat_o[8] top.tb_wishbone_master.dat_o[7] top.tb_wishbone_master.dat_o[6] top.tb_wishbone_master.dat_o[5] top.tb_wishbone_master.dat_o[4] top.tb_wishbone_master.dat_o[3] top.tb_wishbone_master.dat_o[2] top.tb_wishbone_master.dat_o[1] top.tb_wishbone_master.dat_o[0]
-#{top.tb_wishbone_master.dat_i[15:0]} top.tb_wishbone_master.dat_i[15] top.tb_wishbone_master.dat_i[14] top.tb_wishbone_master.dat_i[13] top.tb_wishbone_master.dat_i[12] top.tb_wishbone_master.dat_i[11] top.tb_wishbone_master.dat_i[10] top.tb_wishbone_master.dat_i[9] top.tb_wishbone_master.dat_i[8] top.tb_wishbone_master.dat_i[7] top.tb_wishbone_master.dat_i[6] top.tb_wishbone_master.dat_i[5] top.tb_wishbone_master.dat_i[4] top.tb_wishbone_master.dat_i[3] top.tb_wishbone_master.dat_i[2] top.tb_wishbone_master.dat_i[1] top.tb_wishbone_master.dat_i[0]
+#{top.tb_wishbone_master.dat_o[15:0]} top.tb_wishbone_master.dat_o[7] top.tb_wishbone_master.dat_o[6] top.tb_wishbone_master.dat_o[5] top.tb_wishbone_master.dat_o[4] top.tb_wishbone_master.dat_o[3] top.tb_wishbone_master.dat_o[2] top.tb_wishbone_master.dat_o[1] top.tb_wishbone_master.dat_o[0]
+#{top.tb_wishbone_master.dat_i[15:0]} top.tb_wishbone_master.dat_i[7] top.tb_wishbone_master.dat_i[6] top.tb_wishbone_master.dat_i[5] top.tb_wishbone_master.dat_i[4] top.tb_wishbone_master.dat_i[3] top.tb_wishbone_master.dat_i[2] top.tb_wishbone_master.dat_i[1] top.tb_wishbone_master.dat_i[0]
 #{top.tb_wishbone_master.adr[3:0]} top.tb_wishbone_master.adr[3] top.tb_wishbone_master.adr[2] top.tb_wishbone_master.adr[1] top.tb_wishbone_master.adr[0]
-@421
-top.tb_wishbone_master.slave_index
 [pattern_trace] 1
 [pattern_trace] 0

--- a/vunit/vhdl/verification_components/test/tb_wishbone_master.vhd
+++ b/vunit/vhdl/verification_components/test/tb_wishbone_master.vhd
@@ -20,7 +20,7 @@ use osvvm.RandomPkg.all;
 
 entity tb_wishbone_master is
   generic (
-  	runner_cfg : string;
+    runner_cfg : string;
     dat_width : positive := 8;
     adr_width : positive := 4;
     num_cycles : positive := 1;

--- a/vunit/vhdl/verification_components/test/tb_wishbone_master.vhd
+++ b/vunit/vhdl/verification_components/test/tb_wishbone_master.vhd
@@ -98,11 +98,11 @@ begin
             std_logic_vector(to_unsigned(i, dat_i'length)));
       end loop;
 
+      -- Sleeping is needed to avoid wr and rd cycles coalescing
       info(tb_logger, "Sleeping...");
       for i in 1 to num_block_cycles loop
         wait until ack = '1' and rising_edge(clk);
       end loop;
-      wait for 100 ns;
       wait until rising_edge(clk);
 
       info(tb_logger, "Reading...");
@@ -110,35 +110,14 @@ begin
         read_bus(net, bus_handle, i, rd_ref(i));
       end loop;
 
-      wait until rising_edge(clk);
-      wait until rising_edge(clk);
-      wait until rising_edge(clk);
-      wait for 100 ns;
-
       trace(tb_logger, "Get reads by references...");
       for i in 0 to num_block_cycles-1 loop
         await_read_bus_reply(net, rd_ref(i), tmp);
-        --check_equal(tmp, std_logic_vector(to_unsigned(i, dat_i'length)), "read data");
+        check_equal(tmp, std_logic_vector(to_unsigned(i, dat_i'length)), "read data");
       end loop;
-    -- With references
---    elsif run("WR block") then
---      for i in 0 to num_block_cycles-1 loop
---        write_bus(net, bus_handle, i,
---            std_logic_vector(to_unsigned(i, dat_i'length)));
---      end loop;
-
---      trace(tb_logger, "Test block read");
---      for i in 0 to num_block_cycles-1 loop
---        read_bus(net, bus_handle, i, rd_ref(i));
---      end loop;
---      trace(tb_logger, "Get data by its references");
---      for i in 0 to num_block_cycles-1 loop
---        await_read_bus_reply(net, rd_ref(i), tmp);
---        check_equal(tmp, std_logic_vector(to_unsigned(i, dat_i'length)), "read data");
---      end loop;
     end if;
 
-    wait for 1000 ns;
+    wait for 10 ns;
     test_runner_cleanup(runner);
     wait;
   end process;

--- a/vunit/vhdl/verification_components/test/tb_wishbone_master.vhd
+++ b/vunit/vhdl/verification_components/test/tb_wishbone_master.vhd
@@ -62,7 +62,7 @@ begin
 	  wait until rising_edge(clk);
 
     if run("Test single write, read") then
-      trace(tb_logger, "RW single test");    
+      trace(tb_logger, "Single address write and read test");    
       write_bus(net, bus_handle, 0, value);
       
       wait for 50 ns;

--- a/vunit/vhdl/verification_components/test/tb_wishbone_master.vhd
+++ b/vunit/vhdl/verification_components/test/tb_wishbone_master.vhd
@@ -95,10 +95,11 @@ begin
     variable rd_request_msg : msg_t;
   begin
     wait for 1 ns;
-    if enabled("Test single write") then
+    if enabled("Test single write") or enabled("Test block write") then
       info("Wait on write cycle start");
       wait until (cyc and stb and we) = '1' and rising_edge(clk);
       check_equal(adr, std_logic_vector'(x"e"), "adr");
+      wr_request_msg := new_msg(bus_write_msg);
       send(net, ack_actor, wr_request_msg);
 
     elsif enabled("Test single read") or enabled("Test block read") then
@@ -107,13 +108,6 @@ begin
       check_equal(adr, std_logic_vector'(x"e"), "adr");
       rd_request_msg := new_msg(bus_read_msg);
       send(net, ack_actor, rd_request_msg);
-
-    elsif enabled("Test block write") then
-      verbose(slave_logger, "Wait on write cycle start");
-      wait until (cyc and stb and we) = '1' and rising_edge(clk);
-      check_equal(adr, std_logic_vector'(x"e"), "adr");
-      wr_request_msg := new_msg(bus_write_msg);
-      send(net, ack_actor, wr_request_msg);
 
     end if;
   end process;

--- a/vunit/vhdl/verification_components/test/tb_wishbone_master.vhd
+++ b/vunit/vhdl/verification_components/test/tb_wishbone_master.vhd
@@ -59,9 +59,12 @@ begin
     wait until rising_edge(clk);
 
     if run("wr single rd single") then
+      info(tb_logger, "Writing...");
       write_bus(net, bus_handle, 0, value);
       wait until ack = '1' and rising_edge(clk);
       wait until rising_edge(clk);
+      wait for 100 ns;
+      info(tb_logger, "Reading...");
       read_bus(net, bus_handle, 0, tmp);
       check_equal(tmp, value, "read data");
 --    elsif run("wr block") then
@@ -107,18 +110,19 @@ begin
         read_bus(net, bus_handle, i, rd_ref(i));
       end loop;
 
-      trace(tb_logger, "Get reads by references...");
+      info(tb_logger, "Get reads by references...");
       for i in 0 to num_block_cycles-1 loop
         await_read_bus_reply(net, rd_ref(i), tmp);
         check_equal(tmp, std_logic_vector(to_unsigned(i, dat_i'length)), "read data");
       end loop;
     end if;
 
-    wait for 10 ns;
+    info(tb_logger, "Done, quit...");
+    wait for 50 ns;
     test_runner_cleanup(runner);
     wait;
   end process;
-  test_runner_watchdog(runner, 100 us);
+  test_runner_watchdog(runner, 300 ns);
   set_format(display_handler, verbose, true);
   show(tb_logger, display_handler, verbose);
   show(default_logger, display_handler, verbose);

--- a/vunit/vhdl/verification_components/test/tb_wishbone_master.vhd
+++ b/vunit/vhdl/verification_components/test/tb_wishbone_master.vhd
@@ -9,11 +9,10 @@ library ieee;
 use ieee.std_logic_1164.all;
 use ieee.numeric_std.all;
 
-library vunit_lib;
-context vunit_lib.vunit_context;
+context work.vunit_context;
 context work.com_context;
-
-use work.axi_pkg.all;
+use work.memory_pkg.all;
+use work.wishbone_pkg.all;
 use work.bus_master_pkg.all;
 
 library osvvm;
@@ -47,6 +46,10 @@ architecture a of tb_wishbone_master is
   constant tb_logger : logger_t := get_logger("tb");
   constant bus_handle : bus_master_t := new_bus(data_length => dat_width,
       address_length => adr_width, logger => master_logger);
+
+  constant memory : memory_t := new_memory;
+  constant buf : buffer_t := allocate(memory, num_cycles * sel'length);
+  constant wishbone_slave : wishbone_slave_t := new_wishbone_slave(memory => memory);
 
 begin
 
@@ -147,6 +150,7 @@ begin
 
   dut_slave : entity work.wishbone_slave
     generic map (
+      wishbone_slave => wishbone_slave,
       max_ack_dly => max_ack_dly,
       rand_stall => rand_stall
     )

--- a/vunit/vhdl/verification_components/test/tb_wishbone_master.vhd
+++ b/vunit/vhdl/verification_components/test/tb_wishbone_master.vhd
@@ -59,6 +59,12 @@ begin
     variable rd_ref : bus_reference_arr_t;
   begin
     test_runner_setup(runner, runner_cfg);
+    set_format(display_handler, verbose, true);
+    show(tb_logger, display_handler, verbose);
+    show(default_logger, display_handler, verbose);
+    show(master_logger, display_handler, verbose);
+    show(com_logger, display_handler, verbose);
+
     wait until rising_edge(clk);
 
     if run("wr single rd single") then
@@ -122,12 +128,6 @@ begin
     wait;
   end process;
   test_runner_watchdog(runner, 100 us);
-  set_format(display_handler, verbose, true);
-  show(tb_logger, display_handler, verbose);
-  show(default_logger, display_handler, verbose);
-  show(master_logger, display_handler, verbose);
-  show(com_logger, display_handler, verbose);
-
 
   dut : entity work.wishbone_master
     generic map (

--- a/vunit/vhdl/verification_components/test/tb_wishbone_master.vhd
+++ b/vunit/vhdl/verification_components/test/tb_wishbone_master.vhd
@@ -1,0 +1,136 @@
+-- This Source Code Form is subject to the terms of the Mozilla Public
+-- License, v. 2.0. If a copy of the MPL was not distributed with this file,
+-- You can obtain one at http://mozilla.org/MPL/2.0/.
+--
+-- Copyright (c) 2017, Lars Asplund lars.anders.asplund@gmail.com
+
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.numeric_std.all;
+
+library vunit_lib;
+context vunit_lib.vunit_context;
+context work.com_context;
+
+use work.axi_pkg.all;
+use work.bus_master_pkg.all;
+
+library osvvm;
+use osvvm.RandomPkg.all;
+
+entity tb_wishbone_master is
+  generic (runner_cfg : string);
+end entity;
+
+architecture a of tb_wishbone_master is
+  constant dat_width    : positive := 16;
+  constant adr_width    : positive := 4;
+
+  signal clk    : std_logic := '0';
+  signal adr    : std_logic_vector(adr_width-1 downto 0);
+  signal dat_i  : std_logic_vector(dat_width-1 downto 0);
+  signal dat_o  : std_logic_vector(dat_width-1 downto 0);
+  signal sel   : std_logic_vector(dat_width/8 -1 downto 0);
+  signal cyc   : std_logic := '0';
+  signal stb   : std_logic := '0';
+  signal we    : std_logic := '0';
+  signal ack   : std_logic := '0';
+
+  constant bus_handle : bus_master_t := new_bus(data_length => dat_width,
+      address_length => adr_width);
+	constant ack_actor 		: actor_t := new_actor("ack_actor");
+  constant logger : logger_t := get_logger("slave_ack");
+
+begin
+
+  main : process
+    variable tmp : std_logic_vector(dat_i'range);
+  begin
+    test_runner_setup(runner, runner_cfg);
+	wait until rising_edge(clk);
+    if run("Test single write") then
+      write_bus(net, bus_handle, x"e", x"abcd");
+    elsif run("Test single read") then
+      info("Start read test");
+      read_bus(net, bus_handle, x"e", tmp);
+      info("Check equal");
+      check_equal(tmp, std_logic_vector'(x"5566"), "read data");
+    end if;
+
+    wait for 200 ns;
+    test_runner_cleanup(runner);
+    wait;
+  end process;
+  test_runner_watchdog(runner, 100 us);
+  set_format(display_handler, verbose, true);
+  show(logger, display_handler, verbose);
+  -- Show log messages from the logger of the specified log_levels to this handler
+--  procedure show(logger : logger_t;
+--                 log_handler : log_handler_t;
+--                 log_levels : log_level_vec_t;
+--                 include_children : boolean := true);
+
+  slave : process
+    variable wr_request_msg : msg_t := new_msg(bus_write_msg);
+    variable rd_request_msg : msg_t := new_msg(bus_read_msg);
+  begin
+    wait for 1 ns;
+    if enabled("Test single write") then
+      info("Wait on write cycle start");
+      wait until (cyc and stb and we) = '1' and rising_edge(clk);
+      check_equal(adr, std_logic_vector'(x"e"), "adr");
+      send(net, ack_actor, wr_request_msg);
+
+    elsif enabled("Test single read") then
+      info("Wait on read cycle start");
+      wait until (cyc and stb) = '1' and we = '0' and rising_edge(clk);
+      check_equal(adr, std_logic_vector'(x"e"), "adr");
+      send(net, ack_actor, rd_request_msg);
+    end if;
+  end process;
+
+  support_ack : process
+    variable request_msg : msg_t;
+    variable msg_type : msg_type_t;
+  begin
+    verbose(logger, "Support ack: blocking on receive");
+    receive(net, ack_actor, request_msg);
+    msg_type := message_type(request_msg);
+
+    if msg_type = bus_write_msg then
+      ack <= '1';
+      wait until rising_edge(clk);
+      ack <= '0';
+      check_equal(dat_o, std_logic_vector'(x"abcd"), "dat_o");
+      verbose(logger, "Write cycle passed");
+
+    elsif msg_type = bus_read_msg then
+      dat_i <= x"5566";
+      ack <= '1';
+      wait until rising_edge(clk);
+      ack <= '0';
+      verbose(logger, "Read cycle passed");
+
+    else
+      unexpected_msg_type(msg_type);
+    end if;
+  end process;
+
+  dut : entity work.wishbone_master
+    generic map (
+      bus_handle => bus_handle)
+    port map (
+      clk   => clk,
+      adr   => adr,
+      dat_i => dat_i,
+      dat_o => dat_o,
+      sel   => sel,
+      cyc   => cyc,
+      stb   => stb,
+      we    => we,
+      ack   => ack
+    );
+
+  clk <= not clk after 5 ns;
+
+end architecture;

--- a/vunit/vhdl/verification_components/test/tb_wishbone_master.vhd
+++ b/vunit/vhdl/verification_components/test/tb_wishbone_master.vhd
@@ -150,9 +150,7 @@ begin
 
   dut_slave : entity work.wishbone_slave
     generic map (
-      wishbone_slave => wishbone_slave,
-      max_ack_dly => max_ack_dly,
-      rand_stall => rand_stall
+      wishbone_slave => wishbone_slave
     )
     port map (
       clk   => clk,

--- a/vunit/vhdl/verification_components/test/tb_wishbone_master.vhd
+++ b/vunit/vhdl/verification_components/test/tb_wishbone_master.vhd
@@ -59,30 +59,27 @@ begin
     variable rd_ref : bus_reference_arr_t;
   begin
     test_runner_setup(runner, runner_cfg);
-	  wait until rising_edge(clk);
+    wait until rising_edge(clk);
 
     if run("wr single rd single") then
       write_bus(net, bus_handle, 0, value);
-      
       wait until ack = '1' and rising_edge(clk);
       wait until rising_edge(clk);
       read_bus(net, bus_handle, 0, tmp);
       check_equal(tmp, value, "read data");
-      
 --    elsif run("wr block") then
 --      -- TODO not sure if is allowed to toggle signal we during
 --      -- wishbone single cycle
 --      write_bus(net, bus_handle, 0, value);
 --      read_bus(net, bus_handle, 0, tmp);
 --      check_equal(tmp, value, "read data");
-      
     elsif run("wr block rd single") then
       info(tb_logger, "Writing...");
       for i in 0 to num_block_cycles-1 loop
         write_bus(net, bus_handle, i,
             std_logic_vector(to_unsigned(i, dat_i'length)));
       end loop;
-      
+
       for i in 1 to num_block_cycles loop
         wait until ack = '1' and rising_edge(clk);
       end loop;
@@ -100,7 +97,7 @@ begin
         write_bus(net, bus_handle, i,
             std_logic_vector(to_unsigned(i, dat_i'length)));
       end loop;
-      
+
       info(tb_logger, "Sleeping...");
       for i in 1 to num_block_cycles loop
         wait until ack = '1' and rising_edge(clk);
@@ -117,13 +114,13 @@ begin
       wait until rising_edge(clk);
       wait until rising_edge(clk);
       wait for 100 ns;
-	
+
       trace(tb_logger, "Get reads by references...");
       for i in 0 to num_block_cycles-1 loop
         await_read_bus_reply(net, rd_ref(i), tmp);
         --check_equal(tmp, std_logic_vector(to_unsigned(i, dat_i'length)), "read data");
       end loop;
-	  -- With references
+    -- With references
 --    elsif run("WR block") then
 --      for i in 0 to num_block_cycles-1 loop
 --        write_bus(net, bus_handle, i,
@@ -151,7 +148,7 @@ begin
   show(default_logger, display_handler, verbose);
   show(master_logger, display_handler, verbose);
   show(com_logger, display_handler, verbose);
-  
+
 
   dut : entity work.wishbone_master
     generic map (
@@ -167,7 +164,7 @@ begin
       we    => we,
       ack   => ack
     );
-    
+
   dut_slave : entity work.wishbone_slave
     port map (
       clk   => clk,
@@ -179,7 +176,7 @@ begin
       stb   => stb,
       we    => we,
       ack   => ack
-    );    
+    );
 
   clk <= not clk after 5 ns;
 

--- a/vunit/vhdl/verification_components/test/tb_wishbone_master.vhd
+++ b/vunit/vhdl/verification_components/test/tb_wishbone_master.vhd
@@ -42,18 +42,17 @@ architecture a of tb_wishbone_master is
   signal we    : std_logic := '0';
   signal ack   : std_logic := '0';
 
-  constant bus_handle : bus_master_t := new_bus(data_length => dat_width,
-      address_length => adr_width);
-	constant ack_actor 		: actor_t := new_actor("ack_actor");
+  constant master_logger : logger_t := get_logger("master");
   constant tb_logger : logger_t := get_logger("tb");
-  constant slave_logger : logger_t := get_logger("slave");
-  signal slave_index : natural := 0;
+  constant bus_handle : bus_master_t := new_bus(data_length => dat_width,
+      address_length => adr_width, logger => master_logger);
 
   constant num_block_cycles : natural := 4;
 begin
 
   main_stim : process
     variable tmp : std_logic_vector(dat_i'range);
+    variable value : std_logic_vector(dat_i'range) := x"abcd";
     variable bus_rd_ref1 : bus_reference_t;
     variable bus_rd_ref2 : bus_reference_t;
     type bus_reference_arr_t is array (0 to num_block_cycles-1) of bus_reference_t;
@@ -61,88 +60,45 @@ begin
   begin
     test_runner_setup(runner, runner_cfg);
 	  wait until rising_edge(clk);
-    if run("Test block write") then
-      verbose(tb_logger, "Test block write");
+
+    if run("Test single write, read") then
+      trace(tb_logger, "RW single test");    
+      write_bus(net, bus_handle, 0, value);
+      
+      wait for 50 ns;
+      read_bus(net, bus_handle, 0, tmp);
+      check_equal(tmp, value, "read data");
+	  
+    elsif run("Test block write") then
+      trace(tb_logger, "Test block write");
       for i in 0 to num_block_cycles-1 loop
         write_bus(net, bus_handle, i,
             std_logic_vector(to_unsigned(i, dat_i'length)));
       end loop;
 
     elsif run("Test block read") then
-      verbose(tb_logger, "Test block read");
+      trace(tb_logger, "Test block read");
       for i in 0 to num_block_cycles-1 loop
         read_bus(net, bus_handle, i, rd_ref(i));
       end loop;
-      verbose(tb_logger, "Get data by its references");
+      trace(tb_logger, "Get data by its references");
       for i in 0 to num_block_cycles-1 loop
         await_read_bus_reply(net, rd_ref(i), tmp);
         check_equal(tmp, std_logic_vector(to_unsigned(i, dat_i'length)), "read data");
       end loop;
     end if;
 
-    wait until rising_edge(clk) and slave_index >= num_block_cycles-1;
-    wait for 100 ns;
+    wait for 1000 ns;
     test_runner_cleanup(runner);
     wait;
   end process;
   test_runner_watchdog(runner, 100 us);
   set_format(display_handler, verbose, true);
-  show(slave_logger, display_handler, verbose);
   show(tb_logger, display_handler, verbose);
   show(default_logger, display_handler, verbose);
-
-  slave : process
-    variable wr_request_msg : msg_t;
-    variable rd_request_msg : msg_t;
-  begin
-    wait until (cyc and stb) = '1' and rising_edge(clk);
-    if we = '1' then
-      verbose(slave_logger, "Write cycle start");
-      check_equal(adr, std_logic_vector(to_unsigned(slave_index, adr'length)), "adr");
-      check_equal(dat_o, std_logic_vector(to_unsigned(slave_index, dat_o'length)), "dat_o");
-      wr_request_msg := new_msg(bus_write_msg);
-      send(net, ack_actor, wr_request_msg);
-      slave_index <= slave_index +1;
-    elsif we = '0' then
-      verbose(slave_logger, "Read cycle start");
-      check_equal(adr, std_logic_vector(to_unsigned(slave_index, adr'length)), "adr");
-      rd_request_msg := new_msg(bus_read_msg);
-      push_std_ulogic_vector(rd_request_msg,
-              std_logic_vector(to_unsigned(slave_index, dat_o'length)));
-      send(net, ack_actor, rd_request_msg);
-      slave_index <= slave_index +1;
-    end if;
-  end process;
-
-  slave_ack : process
-    variable request_msg : msg_t;
-    variable msg_type : msg_type_t;
-    variable data : std_logic_vector(dat_i'range);
-  begin
-    verbose(slave_logger, "Slave ack: blocking on receive");
-    receive(net, ack_actor, request_msg);
-    msg_type := message_type(request_msg);
-
-    if msg_type = bus_write_msg then
-      verbose(slave_logger, "Start ack write");
-      ack <= '1';
-      wait until rising_edge(clk);
-      ack <= '0';
-      verbose(slave_logger, "Write cycle passed");
-
-    elsif msg_type = bus_read_msg then
-      verbose(slave_logger, "Start ack read");
-      data := pop_std_ulogic_vector(request_msg);
-      dat_i <= data;
-      ack <= '1';
-      wait until rising_edge(clk);
-      ack <= '0';
-      verbose(slave_logger, "Read cycle passed");
-
-    else
-      unexpected_msg_type(msg_type);
-    end if;
-  end process;
+  show(master_logger, display_handler, verbose);
+  show(com_logger, display_handler, verbose);
+  
 
   dut : entity work.wishbone_master
     generic map (
@@ -158,6 +114,19 @@ begin
       we    => we,
       ack   => ack
     );
+    
+  dut_slave : entity work.wishbone_slave
+    port map (
+      clk   => clk,
+      adr   => adr,
+      dat_i => dat_o,
+      dat_o => dat_i,
+      sel   => sel,
+      cyc   => cyc,
+      stb   => stb,
+      we    => we,
+      ack   => ack
+    );    
 
   clk <= not clk after 5 ns;
 

--- a/vunit/vhdl/verification_components/test/tb_wishbone_master.vhd
+++ b/vunit/vhdl/verification_components/test/tb_wishbone_master.vhd
@@ -2,8 +2,9 @@
 -- License, v. 2.0. If a copy of the MPL was not distributed with this file,
 -- You can obtain one at http://mozilla.org/MPL/2.0/.
 --
--- Slawomir Siluk slaweksiluk@gazeta.pl 2018
--- TODO:
+-- Copyright (c) 2017-2018, Lars Asplund lars.anders.asplund@gmail.com
+-- Author Slawomir Siluk slaweksiluk@gazeta.pl
+
 library ieee;
 use ieee.std_logic_1164.all;
 use ieee.numeric_std.all;

--- a/vunit/vhdl/verification_components/test/tb_wishbone_master.vhd
+++ b/vunit/vhdl/verification_components/test/tb_wishbone_master.vhd
@@ -4,12 +4,9 @@
 --
 -- Slawomir Siluk slaweksiluk@gazeta.pl 2018
 -- TODO:
--- - stall
 -- - generic num_block_cycles
--- - generic ack delay
--- - random ack 0/1
--- - fix slave_index when reading
-
+-- - generic adr and dat width
+-- - generic random test
 library ieee;
 use ieee.std_logic_1164.all;
 use ieee.numeric_std.all;

--- a/vunit/vhdl/verification_components/test/tb_wishbone_master.vhd
+++ b/vunit/vhdl/verification_components/test/tb_wishbone_master.vhd
@@ -4,9 +4,6 @@
 --
 -- Slawomir Siluk slaweksiluk@gazeta.pl 2018
 -- TODO:
--- - generic num_block_cycles
--- - generic adr and dat width
--- - generic random test
 library ieee;
 use ieee.std_logic_1164.all;
 use ieee.numeric_std.all;
@@ -22,12 +19,17 @@ library osvvm;
 use osvvm.RandomPkg.all;
 
 entity tb_wishbone_master is
-  generic (runner_cfg : string);
+  generic (
+  	runner_cfg : string;
+    dat_width : positive := 8;
+    adr_width : positive := 4;
+    num_cycles : positive := 1;
+    max_ack_dly : natural := 0;
+    rand_stall : boolean := false
+  );
 end entity;
 
 architecture a of tb_wishbone_master is
-  constant dat_width    : positive := 8;
-  constant adr_width    : positive := 4;
 
   signal clk    : std_logic := '0';
   signal adr    : std_logic_vector(adr_width-1 downto 0);
@@ -37,6 +39,7 @@ architecture a of tb_wishbone_master is
   signal cyc   : std_logic := '0';
   signal stb   : std_logic := '0';
   signal we    : std_logic := '0';
+  signal stall : std_logic := '0';
   signal ack   : std_logic := '0';
 
   constant master_logger : logger_t := get_logger("master");
@@ -44,7 +47,6 @@ architecture a of tb_wishbone_master is
   constant bus_handle : bus_master_t := new_bus(data_length => dat_width,
       address_length => adr_width, logger => master_logger);
 
-  constant num_block_cycles : natural := 3;
 begin
 
   main_stim : process
@@ -52,7 +54,7 @@ begin
     variable value : std_logic_vector(dat_i'range) := x"ab";
     variable bus_rd_ref1 : bus_reference_t;
     variable bus_rd_ref2 : bus_reference_t;
-    type bus_reference_arr_t is array (0 to num_block_cycles-1) of bus_reference_t;
+    type bus_reference_arr_t is array (0 to num_cycles-1) of bus_reference_t;
     variable rd_ref : bus_reference_arr_t;
   begin
     test_runner_setup(runner, runner_cfg);
@@ -75,43 +77,39 @@ begin
 --      check_equal(tmp, value, "read data");
     elsif run("wr block rd single") then
       info(tb_logger, "Writing...");
-      for i in 0 to num_block_cycles-1 loop
+      for i in 0 to num_cycles-1 loop
         write_bus(net, bus_handle, i,
             std_logic_vector(to_unsigned(i, dat_i'length)));
       end loop;
 
-      for i in 1 to num_block_cycles loop
+      for i in 1 to num_cycles loop
         wait until ack = '1' and rising_edge(clk);
       end loop;
       wait until rising_edge(clk);
 
       info(tb_logger, "Reading...");
-      for i in 0 to num_block_cycles-1 loop
+      for i in 0 to num_cycles-1 loop
         read_bus(net, bus_handle, i, tmp);
         check_equal(tmp, std_logic_vector(to_unsigned(i, dat_i'length)), "read data");
       end loop;
 
     elsif run("wr block rd block") then
       info(tb_logger, "Writing...");
-      for i in 0 to num_block_cycles-1 loop
+      for i in 0 to num_cycles-1 loop
         write_bus(net, bus_handle, i,
             std_logic_vector(to_unsigned(i, dat_i'length)));
       end loop;
 
       -- Sleeping is needed to avoid wr and rd cycles coalescing
-      info(tb_logger, "Sleeping...");
-      for i in 1 to num_block_cycles loop
-        wait until ack = '1' and rising_edge(clk);
-      end loop;
       wait until rising_edge(clk);
 
       info(tb_logger, "Reading...");
-      for i in 0 to num_block_cycles-1 loop
+      for i in 0 to num_cycles-1 loop
         read_bus(net, bus_handle, i, rd_ref(i));
       end loop;
 
       info(tb_logger, "Get reads by references...");
-      for i in 0 to num_block_cycles-1 loop
+      for i in 0 to num_cycles-1 loop
         await_read_bus_reply(net, rd_ref(i), tmp);
         check_equal(tmp, std_logic_vector(to_unsigned(i, dat_i'length)), "read data");
       end loop;
@@ -122,7 +120,7 @@ begin
     test_runner_cleanup(runner);
     wait;
   end process;
-  test_runner_watchdog(runner, 300 ns);
+  test_runner_watchdog(runner, 100 us);
   set_format(display_handler, verbose, true);
   show(tb_logger, display_handler, verbose);
   show(default_logger, display_handler, verbose);
@@ -142,10 +140,15 @@ begin
       cyc   => cyc,
       stb   => stb,
       we    => we,
+      stall => stall,
       ack   => ack
     );
 
   dut_slave : entity work.wishbone_slave
+    generic map (
+      max_ack_dly => max_ack_dly,
+      rand_stall => rand_stall
+    )
     port map (
       clk   => clk,
       adr   => adr,
@@ -155,6 +158,7 @@ begin
       cyc   => cyc,
       stb   => stb,
       we    => we,
+      stall => stall,
       ack   => ack
     );
 

--- a/vunit/vhdl/verification_components/test/tb_wishbone_slave.gtkw
+++ b/vunit/vhdl/verification_components/test/tb_wishbone_slave.gtkw
@@ -1,22 +1,22 @@
 [*]
-[*] GTKWave Analyzer v3.3.87 (w)1999-2017 BSI
-[*] Wed Feb 28 21:33:12 2018
+[*] GTKWave Analyzer v3.3.86 (w)1999-2017 BSI
+[*] Fri Mar  2 12:29:34 2018
 [*]
-[dumpfile] "/home/slawek/git/github/vunit/vunit/vhdl/verification_components/vunit_out/test_output/vunit_lib.tb_wishbone_slave.wr_block_rd_block_9299cb5829de68ec2d1a816f945c59f74bce7d5a/ghdl/wave.ghw"
-[dumpfile_mtime] "Wed Feb 28 21:32:32 2018"
-[dumpfile_size] 2317
-[savefile] "/home/slawek/git/github/vunit/vunit/vhdl/verification_components/test/tb_wishbone_slave.gtkw"
+[dumpfile] "/home/lab-buddy/git/github/vunit/vunit/vhdl/verification_components/vunit_out/test_output/vunit_lib.tb_wishbone_slave.dat_width=32,num_cycles=10,max_ack_dly=2,rand_stall=True.wr_block_rd_block_097cc82731bc1f8cd59fd3bc8a333be1d1e478e3/ghdl/wave.ghw"
+[dumpfile_mtime] "Fri Mar  2 12:28:10 2018"
+[dumpfile_size] 2434
+[savefile] "/home/lab-buddy/git/github/vunit/vunit/vhdl/verification_components/test/tb_wishbone_slave.gtkw"
 [timestart] 0
-[size] 1000 600
+[size] 1646 870
 [pos] -1 -1
-*-28.000000 115000000 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1
+*-25.000000 85500000 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1
 [treeopen] top.
 [treeopen] top.tb_wishbone_slave.
 [treeopen] top.tb_wishbone_slave.dut_slave.
 [sst_width] 227
 [signals_width] 141
 [sst_expanded] 1
-[sst_vpaned_height] 143
+[sst_vpaned_height] 237
 @28
 top.tb_wishbone_slave.dut_slave.clk
 top.tb_wishbone_slave.dut_slave.cyc
@@ -30,7 +30,8 @@ top.tb_wishbone_slave.dut_slave.sel[0]
 #{top.tb_wishbone_slave.dut_slave.adr[3:0]} top.tb_wishbone_slave.dut_slave.adr[3] top.tb_wishbone_slave.dut_slave.adr[2] top.tb_wishbone_slave.dut_slave.adr[1] top.tb_wishbone_slave.dut_slave.adr[0]
 @420
 top.tb_wishbone_slave.wr_ack_cnt
-@421
 top.tb_wishbone_slave.rd_ack_cnt
+@29
+top.tb_wishbone_slave.stall
 [pattern_trace] 1
 [pattern_trace] 0

--- a/vunit/vhdl/verification_components/test/tb_wishbone_slave.gtkw
+++ b/vunit/vhdl/verification_components/test/tb_wishbone_slave.gtkw
@@ -1,19 +1,19 @@
 [*]
-[*] GTKWave Analyzer v3.3.86 (w)1999-2017 BSI
-[*] Tue Feb 27 09:22:11 2018
+[*] GTKWave Analyzer v3.3.87 (w)1999-2017 BSI
+[*] Wed Feb 28 21:33:12 2018
 [*]
-[dumpfile] "/home/lab-buddy/git/github/vunit/vunit/vhdl/verification_components/vunit_out/test_output/vunit_lib.tb_wishbone_slave.wr_block_rd_block_9299cb5829de68ec2d1a816f945c59f74bce7d5a/ghdl/wave.ghw"
-[dumpfile_mtime] "Tue Feb 27 09:21:02 2018"
-[dumpfile_size] 2216
-[savefile] "/home/lab-buddy/git/github/vunit/vunit/vhdl/verification_components/test/tb_wishbone_slave.gtkw"
+[dumpfile] "/home/slawek/git/github/vunit/vunit/vhdl/verification_components/vunit_out/test_output/vunit_lib.tb_wishbone_slave.wr_block_rd_block_9299cb5829de68ec2d1a816f945c59f74bce7d5a/ghdl/wave.ghw"
+[dumpfile_mtime] "Wed Feb 28 21:32:32 2018"
+[dumpfile_size] 2317
+[savefile] "/home/slawek/git/github/vunit/vunit/vhdl/verification_components/test/tb_wishbone_slave.gtkw"
 [timestart] 0
 [size] 1000 600
 [pos] -1 -1
-*-28.000000 165000000 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1
+*-28.000000 115000000 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1
 [treeopen] top.
 [treeopen] top.tb_wishbone_slave.
 [treeopen] top.tb_wishbone_slave.dut_slave.
-[sst_width] 224
+[sst_width] 227
 [signals_width] 141
 [sst_expanded] 1
 [sst_vpaned_height] 143
@@ -27,7 +27,10 @@ top.tb_wishbone_slave.dut_slave.sel[0]
 @22
 #{top.tb_wishbone_slave.dut_slave.dat_o[7:0]} top.tb_wishbone_slave.dut_slave.dat_o[7] top.tb_wishbone_slave.dut_slave.dat_o[6] top.tb_wishbone_slave.dut_slave.dat_o[5] top.tb_wishbone_slave.dut_slave.dat_o[4] top.tb_wishbone_slave.dut_slave.dat_o[3] top.tb_wishbone_slave.dut_slave.dat_o[2] top.tb_wishbone_slave.dut_slave.dat_o[1] top.tb_wishbone_slave.dut_slave.dat_o[0]
 #{top.tb_wishbone_slave.dut_slave.dat_i[7:0]} top.tb_wishbone_slave.dut_slave.dat_i[7] top.tb_wishbone_slave.dut_slave.dat_i[6] top.tb_wishbone_slave.dut_slave.dat_i[5] top.tb_wishbone_slave.dut_slave.dat_i[4] top.tb_wishbone_slave.dut_slave.dat_i[3] top.tb_wishbone_slave.dut_slave.dat_i[2] top.tb_wishbone_slave.dut_slave.dat_i[1] top.tb_wishbone_slave.dut_slave.dat_i[0]
-@23
 #{top.tb_wishbone_slave.dut_slave.adr[3:0]} top.tb_wishbone_slave.dut_slave.adr[3] top.tb_wishbone_slave.dut_slave.adr[2] top.tb_wishbone_slave.dut_slave.adr[1] top.tb_wishbone_slave.dut_slave.adr[0]
+@420
+top.tb_wishbone_slave.wr_ack_cnt
+@421
+top.tb_wishbone_slave.rd_ack_cnt
 [pattern_trace] 1
 [pattern_trace] 0

--- a/vunit/vhdl/verification_components/test/tb_wishbone_slave.gtkw
+++ b/vunit/vhdl/verification_components/test/tb_wishbone_slave.gtkw
@@ -1,0 +1,33 @@
+[*]
+[*] GTKWave Analyzer v3.3.86 (w)1999-2017 BSI
+[*] Tue Feb 27 09:22:11 2018
+[*]
+[dumpfile] "/home/lab-buddy/git/github/vunit/vunit/vhdl/verification_components/vunit_out/test_output/vunit_lib.tb_wishbone_slave.wr_block_rd_block_9299cb5829de68ec2d1a816f945c59f74bce7d5a/ghdl/wave.ghw"
+[dumpfile_mtime] "Tue Feb 27 09:21:02 2018"
+[dumpfile_size] 2216
+[savefile] "/home/lab-buddy/git/github/vunit/vunit/vhdl/verification_components/test/tb_wishbone_slave.gtkw"
+[timestart] 0
+[size] 1000 600
+[pos] -1 -1
+*-28.000000 165000000 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1
+[treeopen] top.
+[treeopen] top.tb_wishbone_slave.
+[treeopen] top.tb_wishbone_slave.dut_slave.
+[sst_width] 224
+[signals_width] 141
+[sst_expanded] 1
+[sst_vpaned_height] 143
+@28
+top.tb_wishbone_slave.dut_slave.clk
+top.tb_wishbone_slave.dut_slave.cyc
+top.tb_wishbone_slave.dut_slave.stb
+top.tb_wishbone_slave.dut_slave.ack
+top.tb_wishbone_slave.dut_slave.we
+top.tb_wishbone_slave.dut_slave.sel[0]
+@22
+#{top.tb_wishbone_slave.dut_slave.dat_o[7:0]} top.tb_wishbone_slave.dut_slave.dat_o[7] top.tb_wishbone_slave.dut_slave.dat_o[6] top.tb_wishbone_slave.dut_slave.dat_o[5] top.tb_wishbone_slave.dut_slave.dat_o[4] top.tb_wishbone_slave.dut_slave.dat_o[3] top.tb_wishbone_slave.dut_slave.dat_o[2] top.tb_wishbone_slave.dut_slave.dat_o[1] top.tb_wishbone_slave.dut_slave.dat_o[0]
+#{top.tb_wishbone_slave.dut_slave.dat_i[7:0]} top.tb_wishbone_slave.dut_slave.dat_i[7] top.tb_wishbone_slave.dut_slave.dat_i[6] top.tb_wishbone_slave.dut_slave.dat_i[5] top.tb_wishbone_slave.dut_slave.dat_i[4] top.tb_wishbone_slave.dut_slave.dat_i[3] top.tb_wishbone_slave.dut_slave.dat_i[2] top.tb_wishbone_slave.dut_slave.dat_i[1] top.tb_wishbone_slave.dut_slave.dat_i[0]
+@23
+#{top.tb_wishbone_slave.dut_slave.adr[3:0]} top.tb_wishbone_slave.dut_slave.adr[3] top.tb_wishbone_slave.dut_slave.adr[2] top.tb_wishbone_slave.dut_slave.adr[1] top.tb_wishbone_slave.dut_slave.adr[0]
+[pattern_trace] 1
+[pattern_trace] 0

--- a/vunit/vhdl/verification_components/test/tb_wishbone_slave.vhd
+++ b/vunit/vhdl/verification_components/test/tb_wishbone_slave.vhd
@@ -37,6 +37,7 @@ architecture a of tb_wishbone_slave is
   signal cyc   : std_logic := '0';
   signal stb   : std_logic := '0';
   signal we    : std_logic := '0';
+  signal stall : std_logic := '0';
   signal ack   : std_logic := '0';
 
 
@@ -62,7 +63,7 @@ begin
         we  <= '1';
         adr <= std_logic_vector(to_unsigned(i*(sel'length), adr'length));
         dat_i <= std_logic_vector(to_unsigned(i, dat_i'length));
-        wait until rising_edge(clk);
+        wait until rising_edge(clk) and stall = '0';
       end loop;
       stb <= '0';
       wait until wr_ack_cnt = num_cycles;
@@ -76,7 +77,7 @@ begin
         stb <= '1';
         we  <= '0';
         adr <= std_logic_vector(to_unsigned(i*(sel'length), adr'length));
-        wait until rising_edge(clk);
+        wait until rising_edge(clk) and stall = '0';
       end loop;
       stb <= '0';
       wait until rising_edge(clk) and rd_ack_cnt = num_cycles-1;
@@ -121,6 +122,7 @@ begin
       cyc   => cyc,
       stb   => stb,
       we    => we,
+      stall => stall,
       ack   => ack
     );
 

--- a/vunit/vhdl/verification_components/test/tb_wishbone_slave.vhd
+++ b/vunit/vhdl/verification_components/test/tb_wishbone_slave.vhd
@@ -48,6 +48,10 @@ begin
     variable value : std_logic_vector(dat_i'range) := (others => '1');
   begin
     test_runner_setup(runner, runner_cfg);
+    set_format(display_handler, verbose, true);
+    show(tb_logger, display_handler, verbose);
+    show(default_logger, display_handler, verbose);
+    show(com_logger, display_handler, verbose);
     wait until rising_edge(clk);
 
 
@@ -85,10 +89,6 @@ begin
     wait;
   end process;
   test_runner_watchdog(runner, 100 us);
-  set_format(display_handler, verbose, true);
-  show(tb_logger, display_handler, verbose);
-  show(default_logger, display_handler, verbose);
-  show(com_logger, display_handler, verbose);
 
   wr_ack: process
   begin

--- a/vunit/vhdl/verification_components/test/tb_wishbone_slave.vhd
+++ b/vunit/vhdl/verification_components/test/tb_wishbone_slave.vhd
@@ -16,19 +16,12 @@ use ieee.numeric_std.all;
 
 library vunit_lib;
 context vunit_lib.vunit_context;
-context work.com_context;
 
-use work.axi_pkg.all;
-use work.bus_master_pkg.all;
-
-library osvvm;
-use osvvm.RandomPkg.all;
-
-entity tb_wishbone_master is
+entity tb_wishbone_slave is
   generic (runner_cfg : string);
 end entity;
 
-architecture a of tb_wishbone_master is
+architecture a of tb_wishbone_slave is
   constant dat_width    : positive := 8;
   constant adr_width    : positive := 4;
 
@@ -42,10 +35,8 @@ architecture a of tb_wishbone_master is
   signal we    : std_logic := '0';
   signal ack   : std_logic := '0';
 
-  constant master_logger : logger_t := get_logger("master");
+
   constant tb_logger : logger_t := get_logger("tb");
-  constant bus_handle : bus_master_t := new_bus(data_length => dat_width,
-      address_length => adr_width, logger => master_logger);
 
   constant num_block_cycles : natural := 3;
 begin
@@ -53,10 +44,6 @@ begin
   main_stim : process
     variable tmp : std_logic_vector(dat_i'range);
     variable value : std_logic_vector(dat_i'range) := x"ab";
-    variable bus_rd_ref1 : bus_reference_t;
-    variable bus_rd_ref2 : bus_reference_t;
-    type bus_reference_arr_t is array (0 to num_block_cycles-1) of bus_reference_t;
-    variable rd_ref : bus_reference_arr_t;
   begin
     test_runner_setup(runner, runner_cfg);
 	  wait until rising_edge(clk);

--- a/vunit/vhdl/verification_components/test/tb_wishbone_slave.vhd
+++ b/vunit/vhdl/verification_components/test/tb_wishbone_slave.vhd
@@ -8,7 +8,6 @@
 -- - generic num_block_cycles
 -- - generic ack delay
 -- - random ack 0/1
--- - fix slave_index when reading
 
 library ieee;
 use ieee.std_logic_1164.all;

--- a/vunit/vhdl/verification_components/test/tb_wishbone_slave.vhd
+++ b/vunit/vhdl/verification_components/test/tb_wishbone_slave.vhd
@@ -3,11 +3,6 @@
 -- You can obtain one at http://mozilla.org/MPL/2.0/.
 --
 -- Slawomir Siluk slaweksiluk@gazeta.pl 2018
--- TODO:
--- - stall
--- - generic num_cycles
--- - generic ack delay
--- - random ack 0/1
 
 library ieee;
 use ieee.std_logic_1164.all;

--- a/vunit/vhdl/verification_components/test/tb_wishbone_slave.vhd
+++ b/vunit/vhdl/verification_components/test/tb_wishbone_slave.vhd
@@ -16,6 +16,7 @@ use ieee.numeric_std.all;
 
 library vunit_lib;
 context vunit_lib.vunit_context;
+context work.com_context;
 
 entity tb_wishbone_slave is
   generic (runner_cfg : string);
@@ -26,10 +27,10 @@ architecture a of tb_wishbone_slave is
   constant adr_width    : positive := 4;
 
   signal clk    : std_logic := '0';
-  signal adr    : std_logic_vector(adr_width-1 downto 0);
-  signal dat_i  : std_logic_vector(dat_width-1 downto 0);
-  signal dat_o  : std_logic_vector(dat_width-1 downto 0);
-  signal sel   : std_logic_vector(dat_width/8 -1 downto 0);
+  signal adr    : std_logic_vector(adr_width-1 downto 0) := (others => '0');
+  signal dat_i  : std_logic_vector(dat_width-1 downto 0) := (others => '0');
+  signal dat_o  : std_logic_vector(dat_width-1 downto 0) := (others => '0');
+  signal sel   : std_logic_vector(dat_width/8 -1 downto 0) := (others => '1');
   signal cyc   : std_logic := '0';
   signal stb   : std_logic := '0';
   signal we    : std_logic := '0';
@@ -48,119 +49,56 @@ begin
     test_runner_setup(runner, runner_cfg);
 	  wait until rising_edge(clk);
 
-    if run("wr single rd single") then
-      write_bus(net, bus_handle, 0, value);
-      
-      wait until ack = '1' and rising_edge(clk);
-      wait until rising_edge(clk);
-      read_bus(net, bus_handle, 0, tmp);
-      check_equal(tmp, value, "read data");
-      
---    elsif run("wr block") then
---      -- TODO not sure if is allowed to toggle signal we during
---      -- wishbone single cycle
---      write_bus(net, bus_handle, 0, value);
---      read_bus(net, bus_handle, 0, tmp);
---      check_equal(tmp, value, "read data");
-      
-    elsif run("wr block rd single") then
+
+    if run("wr block rd block") then
       info(tb_logger, "Writing...");
       for i in 0 to num_block_cycles-1 loop
-        write_bus(net, bus_handle, i,
-            std_logic_vector(to_unsigned(i, dat_i'length)));
+				cyc <= '1';
+				stb <= '1';
+				we	<= '1';
+				adr <= std_logic_vector(to_unsigned(i, adr'length));
+				dat_i <= std_logic_vector(to_unsigned(i, dat_i'length));
+				wait until rising_edge(clk);
       end loop;
-      
-      for i in 1 to num_block_cycles loop
-        wait until ack = '1' and rising_edge(clk);
-      end loop;
-      wait until rising_edge(clk);
-
-      info(tb_logger, "Reading...");
-      for i in 0 to num_block_cycles-1 loop
-        read_bus(net, bus_handle, i, tmp);
-        check_equal(tmp, std_logic_vector(to_unsigned(i, dat_i'length)), "read data");
-      end loop;
-
-    elsif run("wr block rd block") then
-      info(tb_logger, "Writing...");
-      for i in 0 to num_block_cycles-1 loop
-        write_bus(net, bus_handle, i,
-            std_logic_vector(to_unsigned(i, dat_i'length)));
-      end loop;
+			cyc <= '0';
+			stb <= '0';
+			wait until rising_edge(clk);      
       
       info(tb_logger, "Sleeping...");
-      for i in 1 to num_block_cycles loop
-        wait until ack = '1' and rising_edge(clk);
-      end loop;
       wait for 100 ns;
       wait until rising_edge(clk);
 
       info(tb_logger, "Reading...");
       for i in 0 to num_block_cycles-1 loop
-        read_bus(net, bus_handle, i, rd_ref(i));
+				cyc <= '1';
+				stb <= '1';
+				we	<= '0';
+				adr <= std_logic_vector(to_unsigned(i, adr'length));
+				--info(tb_logger, "dat_o="&to_hstring(dat_o));
+				--check_equal(dat_o, std_logic_vector(to_unsigned(i, dat_o'length)), "dat_o");
+				wait until rising_edge(clk);
       end loop;
-
-      wait until rising_edge(clk);
-      wait until rising_edge(clk);
-      wait until rising_edge(clk);
-      wait for 100 ns;
-	
-      trace(tb_logger, "Get reads by references...");
-      for i in 0 to num_block_cycles-1 loop
-        await_read_bus_reply(net, rd_ref(i), tmp);
-        --check_equal(tmp, std_logic_vector(to_unsigned(i, dat_i'length)), "read data");
-      end loop;
-	  -- With references
---    elsif run("WR block") then
---      for i in 0 to num_block_cycles-1 loop
---        write_bus(net, bus_handle, i,
---            std_logic_vector(to_unsigned(i, dat_i'length)));
---      end loop;
-
---      trace(tb_logger, "Test block read");
---      for i in 0 to num_block_cycles-1 loop
---        read_bus(net, bus_handle, i, rd_ref(i));
---      end loop;
---      trace(tb_logger, "Get data by its references");
---      for i in 0 to num_block_cycles-1 loop
---        await_read_bus_reply(net, rd_ref(i), tmp);
---        check_equal(tmp, std_logic_vector(to_unsigned(i, dat_i'length)), "read data");
---      end loop;
+			cyc <= '0';
+			stb <= '0';
     end if;
 
-    wait for 1000 ns;
+    wait for 200 ns;
     test_runner_cleanup(runner);
     wait;
   end process;
-  test_runner_watchdog(runner, 100 us);
+  test_runner_watchdog(runner, 1 us);
   set_format(display_handler, verbose, true);
   show(tb_logger, display_handler, verbose);
   show(default_logger, display_handler, verbose);
-  show(master_logger, display_handler, verbose);
   show(com_logger, display_handler, verbose);
   
-
-  dut : entity work.wishbone_master
-    generic map (
-      bus_handle => bus_handle)
-    port map (
-      clk   => clk,
-      adr   => adr,
-      dat_i => dat_i,
-      dat_o => dat_o,
-      sel   => sel,
-      cyc   => cyc,
-      stb   => stb,
-      we    => we,
-      ack   => ack
-    );
     
   dut_slave : entity work.wishbone_slave
     port map (
       clk   => clk,
       adr   => adr,
-      dat_i => dat_o,
-      dat_o => dat_i,
+      dat_i => dat_i,
+      dat_o => dat_o,
       sel   => sel,
       cyc   => cyc,
       stb   => stb,

--- a/vunit/vhdl/verification_components/test/tb_wishbone_slave.vhd
+++ b/vunit/vhdl/verification_components/test/tb_wishbone_slave.vhd
@@ -47,39 +47,39 @@ begin
     variable value : std_logic_vector(dat_i'range) := x"ab";
   begin
     test_runner_setup(runner, runner_cfg);
-	  wait until rising_edge(clk);
+    wait until rising_edge(clk);
 
 
     if run("wr block rd block") then
       info(tb_logger, "Writing...");
       for i in 0 to num_block_cycles-1 loop
-				cyc <= '1';
-				stb <= '1';
-				we	<= '1';
-				adr <= std_logic_vector(to_unsigned(i, adr'length));
-				dat_i <= std_logic_vector(to_unsigned(i, dat_i'length));
-				wait until rising_edge(clk);
+        cyc <= '1';
+        stb <= '1';
+        we  <= '1';
+        adr <= std_logic_vector(to_unsigned(i, adr'length));
+        dat_i <= std_logic_vector(to_unsigned(i, dat_i'length));
+        wait until rising_edge(clk);
       end loop;
-			cyc <= '0';
-			stb <= '0';
-			wait until rising_edge(clk);      
-      
+      cyc <= '0';
+      stb <= '0';
+      wait until rising_edge(clk);
+
       info(tb_logger, "Sleeping...");
       wait for 100 ns;
       wait until rising_edge(clk);
 
       info(tb_logger, "Reading...");
       for i in 0 to num_block_cycles-1 loop
-				cyc <= '1';
-				stb <= '1';
-				we	<= '0';
-				adr <= std_logic_vector(to_unsigned(i, adr'length));
-				--info(tb_logger, "dat_o="&to_hstring(dat_o));
-				--check_equal(dat_o, std_logic_vector(to_unsigned(i, dat_o'length)), "dat_o");
-				wait until rising_edge(clk);
+        cyc <= '1';
+        stb <= '1';
+        we  <= '0';
+        adr <= std_logic_vector(to_unsigned(i, adr'length));
+        --info(tb_logger, "dat_o="&to_hstring(dat_o));
+        --check_equal(dat_o, std_logic_vector(to_unsigned(i, dat_o'length)), "dat_o");
+        wait until rising_edge(clk);
       end loop;
-			cyc <= '0';
-			stb <= '0';
+      cyc <= '0';
+      stb <= '0';
     end if;
 
     wait for 200 ns;
@@ -91,8 +91,8 @@ begin
   show(tb_logger, display_handler, verbose);
   show(default_logger, display_handler, verbose);
   show(com_logger, display_handler, verbose);
-  
-    
+
+
   dut_slave : entity work.wishbone_slave
     port map (
       clk   => clk,
@@ -104,7 +104,7 @@ begin
       stb   => stb,
       we    => we,
       ack   => ack
-    );    
+    );
 
   clk <= not clk after 5 ns;
 

--- a/vunit/vhdl/verification_components/test/tb_wishbone_slave.vhd
+++ b/vunit/vhdl/verification_components/test/tb_wishbone_slave.vhd
@@ -2,7 +2,8 @@
 -- License, v. 2.0. If a copy of the MPL was not distributed with this file,
 -- You can obtain one at http://mozilla.org/MPL/2.0/.
 --
--- Slawomir Siluk slaweksiluk@gazeta.pl 2018
+-- Copyright (c) 2017-2018, Lars Asplund lars.anders.asplund@gmail.com
+-- Author Slawomir Siluk slaweksiluk@gazeta.pl
 
 library ieee;
 use ieee.std_logic_1164.all;

--- a/vunit/vhdl/verification_components/test/tb_wishbone_slave.vhd
+++ b/vunit/vhdl/verification_components/test/tb_wishbone_slave.vhd
@@ -28,7 +28,7 @@ architecture a of tb_wishbone_slave is
     adr_width : positive;
     num_cycles : positive;
     ack_prob : real;
-    rand_stall : boolean;
+    stall_prob : real;
   end record tb_cfg_t;
 
   impure function decode(encoded_tb_cfg : string) return tb_cfg_t is
@@ -37,7 +37,7 @@ architecture a of tb_wishbone_slave is
             adr_width => positive'value(get(encoded_tb_cfg, "adr_width")),
             num_cycles => positive'value(get(encoded_tb_cfg, "num_cycles")),
             ack_prob => real'value(get(encoded_tb_cfg, "ack_prob")),
-            rand_stall => boolean'value(get(encoded_tb_cfg, "rand_stall")));
+            stall_prob => real'value(get(encoded_tb_cfg, "stall_prob")));
   end function decode;
 
   constant tb_cfg : tb_cfg_t := decode(encoded_tb_cfg);
@@ -62,7 +62,10 @@ architecture a of tb_wishbone_slave is
   constant memory : memory_t := new_memory;
   constant buf : buffer_t := allocate(memory, tb_cfg.num_cycles * sel'length);
   constant wishbone_slave : wishbone_slave_t :=
-      new_wishbone_slave(memory => memory, ack_high_probability => tb_cfg.ack_prob);
+      new_wishbone_slave(memory => memory,
+        ack_high_probability => tb_cfg.ack_prob,
+        stall_high_probability => tb_cfg.stall_prob
+      );
 begin
 
   main_stim : process
@@ -128,8 +131,7 @@ begin
 
   dut_slave : entity work.wishbone_slave
     generic map (
-      wishbone_slave => wishbone_slave,
-      rand_stall => tb_cfg.rand_stall
+      wishbone_slave => wishbone_slave
     )
     port map (
       clk   => clk,

--- a/vunit/vhdl/verification_components/test/tb_wishbone_slave.vhd
+++ b/vunit/vhdl/verification_components/test/tb_wishbone_slave.vhd
@@ -9,9 +9,10 @@ library ieee;
 use ieee.std_logic_1164.all;
 use ieee.numeric_std.all;
 
-library vunit_lib;
-context vunit_lib.vunit_context;
+context work.vunit_context;
 context work.com_context;
+use work.memory_pkg.all;
+use work.wishbone_pkg.all;
 
 entity tb_wishbone_slave is
   generic (
@@ -41,6 +42,10 @@ architecture a of tb_wishbone_slave is
 
   signal wr_ack_cnt    : natural range 0 to num_cycles;
   signal rd_ack_cnt    : natural range 0 to num_cycles;
+
+  constant memory : memory_t := new_memory;
+  constant buf : buffer_t := allocate(memory, num_cycles * sel'length);
+  constant wishbone_slave : wishbone_slave_t := new_wishbone_slave(memory => memory);
 begin
 
   main_stim : process
@@ -106,6 +111,7 @@ begin
 
   dut_slave : entity work.wishbone_slave
     generic map (
+      wishbone_slave => wishbone_slave,
       max_ack_dly => max_ack_dly,
       rand_stall => rand_stall
     )

--- a/vunit/vhdl/verification_components/test/tb_wishbone_slave.vhd
+++ b/vunit/vhdl/verification_components/test/tb_wishbone_slave.vhd
@@ -83,7 +83,7 @@ begin
     test_runner_cleanup(runner);
     wait;
   end process;
-  test_runner_watchdog(runner, 1 us);
+  test_runner_watchdog(runner, 100 us);
   set_format(display_handler, verbose, true);
   show(tb_logger, display_handler, verbose);
   show(default_logger, display_handler, verbose);

--- a/vunit/vhdl/verification_components/test/tb_wishbone_slave.vhd
+++ b/vunit/vhdl/verification_components/test/tb_wishbone_slave.vhd
@@ -62,11 +62,9 @@ begin
         wait until rising_edge(clk);
       end loop;
       stb <= '0';
-      wait until rising_edge(clk) and wr_ack_cnt = num_block_cycles-1;
+      wait until wr_ack_cnt = num_block_cycles;
       cyc <= '0';
-
-      info(tb_logger, "Sleeping...");
-      wait for 100 ns;
+     
       wait until rising_edge(clk);
 
       info(tb_logger, "Reading...");


### PR DESCRIPTION
I think my implementations of Wishbone Slave and Master Bus Functional Models are ready to be reviewed. Currently only pipelined mode is supported. Read/Write cycles lengths can be 1 (Single Read/Write) or more (Block Read/Write).

### Wishbone Slave BFM
It is wrapper for Vunit memory VC. Currently memory is internal variable, but it should rather be passed as generic parameter. Manual tb with generic test cases is provided.

### Wishbone Master BFM
Receives bus write and bus read messages from main sequencer. Consecutive groups of bus write/reads messages are merged into block cycles. Cycle is finished when next message is the opposite action (e.g write command after read) or there is no more messages in actor inbox. Test bench with Master and Slave connected is provided. 

I didn't want to add new calls to bus_maser_pkg. However adding calls like: bus_write_block and bus_read_block might be good idea.