### PR TITLE
Adding axi stream signals

### DIFF
--- a/vunit/vhdl/verification_components/src/axi_stream_master.vhd
+++ b/vunit/vhdl/verification_components/src/axi_stream_master.vhd
@@ -22,7 +22,12 @@ entity axi_stream_master is
     tvalid : out std_logic := '0';
     tready : in std_logic;
     tdata : out std_logic_vector(data_length(master)-1 downto 0) := (others => '0');
-    tlast : out std_logic := '0');
+    tlast : out std_logic := '0';
+    tkeep : out std_logic_vector(data_length(master)/8-1 downto 0) := (others => '0');
+    tstrb : out std_logic_vector(data_length(master)/8-1 downto 0) := (others => '0');
+    tid : out std_logic_vector(id_length(master)-1 downto 0) := (others => '0');
+    tdest : out std_logic_vector(dest_length(master)-1 downto 0) := (others => '0');
+    tuser : out std_logic_vector(user_length(master)-1 downto 0) := (others => '0'));
 end entity;
 
 architecture a of axi_stream_master is
@@ -41,12 +46,22 @@ begin
       tdata <= pop_std_ulogic_vector(msg);
       if msg_type = push_axi_stream_msg then
         tlast <= pop_std_ulogic(msg);
+        tkeep <= pop_std_ulogic_vector(msg);
+        tstrb <= pop_std_ulogic_vector(msg);
+        tid <= pop_std_ulogic_vector(msg);
+        tdest <= pop_std_ulogic_vector(msg);
+        tuser <= pop_std_ulogic_vector(msg);
       else
         if pop_boolean(msg) then
           tlast <= '1';
         else
           tlast <= '0';
         end if;
+        tkeep <= (others => '1');
+        tstrb <= (others => '1');
+        tid <= (others => '0');
+        tdest <= (others => '0');
+        tuser <= (others => '0');
       end if;
       wait until (tvalid and tready) = '1' and rising_edge(aclk);
       tvalid <= '0';

--- a/vunit/vhdl/verification_components/src/axi_stream_pkg.vhd
+++ b/vunit/vhdl/verification_components/src/axi_stream_pkg.vhd
@@ -18,22 +18,40 @@ package axi_stream_pkg is
   type axi_stream_master_t is record
     p_actor : actor_t;
     p_data_length : natural;
+    p_id_length : natural;
+    p_dest_length : natural;
+    p_user_length : natural;
     p_logger : logger_t;
   end record;
 
   type axi_stream_slave_t is record
     p_actor : actor_t;
     p_data_length : natural;
+    p_id_length : natural;
+    p_dest_length : natural;
+    p_user_length : natural;
     p_logger : logger_t;
   end record;
 
   constant axi_stream_logger : logger_t := get_logger("vunit_lib:axi_stream_pkg");
   impure function new_axi_stream_master(data_length : natural;
+                                        id_length : natural;
+                                        dest_length : natural;
+                                        user_length : natural;
                                         logger : logger_t := axi_stream_logger) return axi_stream_master_t;
   impure function new_axi_stream_slave(data_length : natural;
+                                       id_length : natural;
+                                       dest_length : natural;
+                                       user_length : natural;
                                        logger : logger_t := axi_stream_logger) return axi_stream_slave_t;
   impure function data_length(master : axi_stream_master_t) return natural;
   impure function data_length(master : axi_stream_slave_t) return natural;
+  impure function id_length(master : axi_stream_master_t) return natural;
+  impure function id_length(master : axi_stream_slave_t) return natural;
+  impure function dest_length(master : axi_stream_master_t) return natural;
+  impure function dest_length(master : axi_stream_slave_t) return natural;
+  impure function user_length(master : axi_stream_master_t) return natural;
+  impure function user_length(master : axi_stream_slave_t) return natural;
   impure function as_stream(master : axi_stream_master_t) return stream_master_t;
   impure function as_stream(slave : axi_stream_slave_t) return stream_slave_t;
 
@@ -49,18 +67,30 @@ end package;
 package body axi_stream_pkg is
 
   impure function new_axi_stream_master(data_length : natural;
+                                        id_length : natural;
+                                        dest_length : natural;
+                                        user_length : natural;
                                         logger : logger_t := axi_stream_logger) return axi_stream_master_t is
   begin
     return (p_actor => new_actor,
             p_data_length => data_length,
+            p_id_length => id_length,
+            p_dest_length => dest_length,
+            p_user_length => user_length,
             p_logger => logger);
   end;
 
   impure function new_axi_stream_slave(data_length : natural;
+                                       id_length : natural;
+                                       dest_length : natural;
+                                       user_length : natural;
                                        logger : logger_t := axi_stream_logger) return axi_stream_slave_t is
   begin
     return (p_actor => new_actor,
             p_data_length => data_length,
+            p_id_length => id_length,
+            p_dest_length => dest_length,
+            p_user_length => user_length,
             p_logger => logger);
   end;
 
@@ -72,6 +102,36 @@ package body axi_stream_pkg is
   impure function data_length(master : axi_stream_slave_t) return natural is
   begin
     return master.p_data_length;
+  end;
+
+  impure function id_length(master : axi_stream_master_t) return natural is
+  begin
+    return master.p_id_length;
+  end;
+
+  impure function id_length(master : axi_stream_slave_t) return natural is
+  begin
+    return master.p_id_length;
+  end;
+
+  impure function dest_length(master : axi_stream_master_t) return natural is
+  begin
+    return master.p_dest_length;
+  end;
+
+  impure function dest_length(master : axi_stream_slave_t) return natural is
+  begin
+    return master.p_dest_length;
+  end;
+
+  impure function user_length(master : axi_stream_master_t) return natural is
+  begin
+    return master.p_user_length;
+  end;
+
+  impure function user_length(master : axi_stream_slave_t) return natural is
+  begin
+    return master.p_user_length;
   end;
 
   impure function as_stream(master : axi_stream_master_t) return stream_master_t is
@@ -87,12 +147,22 @@ package body axi_stream_pkg is
   procedure push_axi_stream(signal net : inout network_t;
                             axi_stream : axi_stream_master_t;
                             tdata : std_logic_vector;
-                            tlast : std_logic := '1') is
+                            tlast : std_logic := '1';
+                            tkeep : std_logic_vector := (others => '1');
+                            tstrb : std_logic_vector := (others => '1')
+                            tid : std_logic_vector := (others => '0');
+                            tdest : std_logic_vector := (others => '0');
+                            tuser : std_logic_vector := (others => '0')) is
     variable msg : msg_t := new_msg(push_axi_stream_msg);
     constant normalized_data : std_logic_vector(tdata'length-1 downto 0) := tdata;
   begin
     push_std_ulogic_vector(msg, normalized_data);
     push_std_ulogic(msg, tlast);
+    push_std_ulogic_vector(msg, tkeep);
+    push_std_ulogic_vector(msg, tstrb);
+    push_std_ulogic_vector(msg, tid);
+    push_std_ulogic_vector(msg, tdest);
+    push_std_ulogic_vector(msg, tuser);
     send(net, axi_stream.p_actor, msg);
   end;
 

--- a/vunit/vhdl/verification_components/src/axi_stream_slave.vhd
+++ b/vunit/vhdl/verification_components/src/axi_stream_slave.vhd
@@ -21,12 +21,12 @@ entity axi_stream_slave is
     tvalid : in std_logic;
     tready : out std_logic := '0';
     tdata : in std_logic_vector(data_length(slave)-1 downto 0);
-    tlast : in std_logic := '1');
-    tkeep : in std_logic_vector(data_length(master)/8-1 downto 0) := (others => '0');
-    tstrb : in std_logic_vector(data_length(master)/8-1 downto 0) := (others => '0');
-    tid : in std_logic_vector(id_length(master)-1 downto 0) := (others => '0');
-    tdest : in std_logic_vector(dest_length(master)-1 downto 0) := (others => '0');
-    tuser : in std_logic_vector(user_length(master)-1 downto 0) := (others => '0');
+    tlast : in std_logic := '1';
+    tkeep : in std_logic_vector(data_length(slave)/8-1 downto 0) := (others => '0');
+    tstrb : in std_logic_vector(data_length(slave)/8-1 downto 0) := (others => '0');
+    tid : in std_logic_vector(id_length(slave)-1 downto 0) := (others => '0');
+    tdest : in std_logic_vector(dest_length(slave)-1 downto 0) := (others => '0');
+    tuser : in std_logic_vector(user_length(slave)-1 downto 0) := (others => '0'));
 end entity;
 
 architecture a of axi_stream_slave is
@@ -38,7 +38,7 @@ begin
     receive(net, slave.p_actor, msg);
     msg_type := message_type(msg);
 
-    if msg_type = stream_pop_msg or msg_type = push_axi_stream_msg then
+    if msg_type = stream_pop_msg or msg_type = pop_axi_stream_msg then
       tready <= '1';
       wait until (tvalid and tready) = '1' and rising_edge(aclk);
       tready <= '0';

--- a/vunit/vhdl/verification_components/src/axi_stream_slave.vhd
+++ b/vunit/vhdl/verification_components/src/axi_stream_slave.vhd
@@ -22,6 +22,11 @@ entity axi_stream_slave is
     tready : out std_logic := '0';
     tdata : in std_logic_vector(data_length(slave)-1 downto 0);
     tlast : in std_logic := '1');
+    tkeep : in std_logic_vector(data_length(master)/8-1 downto 0) := (others => '0');
+    tstrb : in std_logic_vector(data_length(master)/8-1 downto 0) := (others => '0');
+    tid : in std_logic_vector(id_length(master)-1 downto 0) := (others => '0');
+    tdest : in std_logic_vector(dest_length(master)-1 downto 0) := (others => '0');
+    tuser : in std_logic_vector(user_length(master)-1 downto 0) := (others => '0');
 end entity;
 
 architecture a of axi_stream_slave is
@@ -33,17 +38,26 @@ begin
     receive(net, slave.p_actor, msg);
     msg_type := message_type(msg);
 
-    if msg_type = stream_pop_msg then
+    if msg_type = stream_pop_msg or msg_type = push_axi_stream_msg then
       tready <= '1';
       wait until (tvalid and tready) = '1' and rising_edge(aclk);
       tready <= '0';
 
       reply_msg := new_msg;
       push_std_ulogic_vector(reply_msg, tdata);
-      if tlast = '0' then
-        push_boolean(reply_msg,false);
+      if msg_type = stream_pop_msg then
+        if tlast = '0' then
+          push_boolean(reply_msg,false);
+        else
+          push_boolean(reply_msg,true);
+        end if;
       else
-        push_boolean(reply_msg,true);
+        push_std_ulogic(reply_msg,tlast);
+        push_std_ulogic_vector(reply_msg,tkeep);
+        push_std_ulogic_vector(reply_msg,tstrb);
+        push_std_ulogic_vector(reply_msg,tid);
+        push_std_ulogic_vector(reply_msg,tdest);
+        push_std_ulogic_vector(reply_msg,tuser);
       end if;
       reply(net, msg, reply_msg);
     else


### PR DESCRIPTION
This adds in the rest of the AXI Stream signals (TKEEP, TSTRB, TID, TDEST, and TUSER).  It expands on the existing AXI Stream VC, keeping support for the generic stream VC but also expanding the AXI Stream Master VCI and adding the AXI Stream Slave VCI.