### PR TITLE
add requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+colorama


### PR DESCRIPTION
In order to use `language: python` in travis-ci, without tox, a `requirements.txt` file is required (to get colorama installed).