### PR TITLE
ensure quoted generics

### DIFF
--- a/vunit/ghdl_interface.py
+++ b/vunit/ghdl_interface.py
@@ -196,7 +196,7 @@ class GHDLInterface(SimulatorInterface):
         cmd += config.sim_options.get("ghdl.sim_flags", [])
 
         for name, value in config.generics.items():
-            cmd += ['-g%s=%s' % (name, value)]
+            cmd += ['\'-g%s=%s\'' % (name, value)]
 
         cmd += ['--assert-level=%s' % config.vhdl_assert_stop_level]
 


### PR DESCRIPTION
Fixes a quoting issue when a script is used between VUnit and the executables. See [#324](https://github.com/VUnit/vunit/issues/324#issuecomment-382729779).