### PR TITLE
fix delayed simulator selection

### DIFF
--- a/vunit/simulator_factory.py
+++ b/vunit/simulator_factory.py
@@ -101,14 +101,13 @@ class SimulatorFactory(object):
         Select simulator class, either from VUNIT_SIMULATOR environment variable
         or the first available
         """
-        environ_name = "VUNIT_SIMULATOR"
-
-        available_simulators = self.available_simulators()
+        available_simulators = self._detect_available_simulators()
         name_mapping = {simulator_class.name: simulator_class for simulator_class in self.supported_simulators()}
         if not available_simulators:
             raise RuntimeError("No available simulator detected. "
                                "Simulator executables must be available in PATH environment variable.")
 
+        environ_name = "VUNIT_SIMULATOR"
         if environ_name in os.environ:
             simulator_name = os.environ[environ_name]
             if simulator_name not in name_mapping:
@@ -136,21 +135,20 @@ class SimulatorFactory(object):
             sim.add_arguments(parser)
 
     def __init__(self):
-        self._available_simulators = [simulator_class
-                                      for simulator_class in self.supported_simulators()
-                                      if simulator_class.is_available()]
         self._compile_options = self._extract_compile_options()
         self._sim_options = self._extract_sim_options()
 
-    def available_simulators(self):
+    def _detect_available_simulators(self):
         """
-        Return a list of available simulators
+        Detect available simulators and return a list
         """
-        return self._available_simulators
+        return [simulator_class
+                for simulator_class in self.supported_simulators()
+                if simulator_class.is_available()]
 
     @property
     def has_simulator(self):
-        return len(self._available_simulators) > 0
+        return bool(self._detect_available_simulators())
 
 
 SIMULATOR_FACTORY = SimulatorFactory()


### PR DESCRIPTION
In [this](https://github.com/VUnit/vunit/commit/8cf71ea4389bb6c6c1eafca63e5b111964d5ee41) commit the simulator selection is delayed until VUnit class instantiation, instead of executing it during the package import. However, the `simulator_factory` is still created when the package is imported. Therefore, simulator detection is executed on the PATH available at import time, even if the selection is done later.

This PR moves content of then `__init__` function/method from `simulator_factory` to a new function named `detect_available_simulators`. The new function is called first in `__init__` and once again in `select_simulator`.
