### PR TITLE
Log output of failed vsim startup to stderr

### DIFF
--- a/vunit/persistent_tcl_shell.py
+++ b/vunit/persistent_tcl_shell.py
@@ -50,7 +50,7 @@ class PersistentTclShell(object):
         except Process.NonZeroExitCode:
             # Print output if background vsim process startup failed
             LOGGER.error("Failed to start re-usable background process")
-            print(consumer.output)
+            LOGGER.error(consumer.output)
             raise
         return process
 


### PR DESCRIPTION
Especially useful when you're not running VUnit interactively as you usually inspect stdout and stderr differently.