### PR TITLE
Add Avalon Stream VC's

### DIFF
--- a/vunit/vhdl/verification_components/src/avalon_sink.vhd
+++ b/vunit/vhdl/verification_components/src/avalon_sink.vhd
@@ -1,0 +1,67 @@
+-- This Source Code Form is subject to the terms of the Mozilla Public
+-- License, v. 2.0. If a copy of the MPL was not distributed with this file,
+-- You can obtain one at http://mozilla.org/MPL/2.0/.
+--
+-- Copyright (c) 2014-2018, Lars Asplund lars.anders.asplund@gmail.com
+-- Author Slawomir Siluk slaweksiluk@gazeta.pl
+-- Avalon-St Sink Verification Component
+-- TODO:
+-- - timeout error
+
+library ieee;
+use ieee.std_logic_1164.all;
+
+context work.vunit_context;
+context work.com_context;
+use work.stream_slave_pkg.all;
+use work.avalon_stream_pkg.all;
+
+library osvvm;
+use osvvm.RandomPkg.all;
+
+entity avalon_sink is
+  generic (
+    sink : avalon_sink_t);
+  port (
+    clk : in std_logic;
+    ready : out std_logic := '0';
+    valid : in std_logic;
+    data : in std_logic_vector(data_length(sink)-1 downto 0)
+  );
+end entity;
+
+architecture a of avalon_sink is
+begin
+  main : process
+    variable reply_msg, msg : msg_t;
+    variable msg_type : msg_type_t;
+    variable rnd : RandomPType;
+  begin
+    receive(net, sink.p_actor, msg);
+    msg_type := message_type(msg);
+
+    if msg_type = stream_pop_msg then
+      -- Loop till got valid data
+      loop
+        while rnd.Uniform(0.0, 1.0) > sink.ready_high_probability loop
+          wait until rising_edge(clk);
+        end loop;
+        ready <= '1';
+        wait until ready = '1' and rising_edge(clk);
+        if valid = '1' then
+          reply_msg := new_msg;
+          push_std_ulogic_vector(reply_msg, data);
+          reply(net, msg, reply_msg);
+          ready <= '0';
+          exit;
+        end if;
+        ready <= '0';
+      end loop;
+
+    else
+      unexpected_msg_type(msg_type);
+    end if;
+
+  end process;
+
+end architecture;

--- a/vunit/vhdl/verification_components/src/avalon_source.vhd
+++ b/vunit/vhdl/verification_components/src/avalon_source.vhd
@@ -1,0 +1,57 @@
+-- This Source Code Form is subject to the terms of the Mozilla Public
+-- License, v. 2.0. If a copy of the MPL was not distributed with this file,
+-- You can obtain one at http://mozilla.org/MPL/2.0/.
+--
+-- Copyright (c) 2014-2018, Lars Asplund lars.anders.asplund@gmail.com
+-- Author Slawomir Siluk slaweksiluk@gazeta.pl
+-- Avalon-St Source Verification Component
+library ieee;
+use ieee.std_logic_1164.all;
+
+context work.vunit_context;
+context work.com_context;
+use work.stream_master_pkg.all;
+use work.avalon_stream_pkg.all;
+use work.queue_pkg.all;
+use work.sync_pkg.all;
+
+library osvvm;
+use osvvm.RandomPkg.all;
+
+entity avalon_source is
+  generic (
+    source : avalon_source_t);
+  port (
+    clk : in std_logic;
+    valid : out std_logic := '0';
+    ready : in std_logic;
+    data : out std_logic_vector(data_length(source)-1 downto 0) := (others => '0')
+  );
+end entity;
+
+architecture a of avalon_source is
+begin
+  main : process
+    variable msg : msg_t;
+    variable msg_type : msg_type_t;
+    variable rnd : RandomPType;
+  begin
+    receive(net, source.p_actor, msg);
+    msg_type := message_type(msg);
+
+    handle_sync_message(net, msg_type, msg);
+
+    if msg_type = stream_push_msg then
+      while rnd.Uniform(0.0, 1.0) > source.valid_high_probability loop
+        wait until rising_edge(clk);
+      end loop;
+      valid <= '1';
+      data <= pop_std_ulogic_vector(msg);
+      wait until (valid and ready) = '1' and rising_edge(clk);
+      valid <= '0';
+    else
+      unexpected_msg_type(msg_type);
+    end if;
+  end process;
+
+end architecture;

--- a/vunit/vhdl/verification_components/src/avalon_stream_pkg.vhd
+++ b/vunit/vhdl/verification_components/src/avalon_stream_pkg.vhd
@@ -1,0 +1,99 @@
+-- This Source Code Form is subject to the terms of the Mozilla Public
+-- License, v. 2.0. If a copy of the MPL was not distributed with this file,
+-- You can obtain one at http://mozilla.org/MPL/2.0/.
+--
+-- Copyright (c) 2014-2018, Lars Asplund lars.anders.asplund@gmail.com
+
+library ieee;
+use ieee.std_logic_1164.all;
+
+use work.logger_pkg.all;
+use work.stream_master_pkg.all;
+use work.stream_slave_pkg.all;
+context work.com_context;
+context work.data_types_context;
+
+package avalon_stream_pkg is
+
+  type avalon_source_t is record
+    valid_high_probability : real range 0.0 to 1.0;
+    p_actor : actor_t;
+    p_data_length : natural;
+    p_logger : logger_t;
+  end record;
+
+  type avalon_sink_t is record
+    ready_high_probability : real range 0.0 to 1.0;
+    -- Private
+    p_actor : actor_t;
+    p_data_length : natural;
+    p_logger : logger_t;
+  end record;
+
+  constant avalon_stream_logger : logger_t := get_logger("vunit_lib:avalon_stream_pkg");
+  impure function new_avalon_source(data_length : natural;
+                                        valid_high_probability : real := 1.0;
+                                        logger : logger_t := avalon_stream_logger;
+                                        actor : actor_t := null_actor) return avalon_source_t;
+  impure function new_avalon_sink(data_length : natural;
+                                       ready_high_probability : real := 1.0;
+                                       logger : logger_t := avalon_stream_logger;
+                                       actor : actor_t := null_actor) return avalon_sink_t;
+  impure function data_length(source : avalon_source_t) return natural;
+  impure function data_length(source : avalon_sink_t) return natural;
+  impure function as_stream(source : avalon_source_t) return stream_master_t;
+  impure function as_stream(sink : avalon_sink_t) return stream_slave_t;
+
+end package;
+
+package body avalon_stream_pkg is
+
+  impure function new_avalon_source(data_length : natural;
+                                        valid_high_probability : real := 1.0;
+                                        logger : logger_t := avalon_stream_logger;
+                                        actor : actor_t := null_actor) return avalon_source_t is
+    variable p_actor : actor_t;
+  begin
+    p_actor := actor when actor /= null_actor else new_actor;
+
+    return (valid_high_probability => valid_high_probability,
+            p_actor => p_actor,
+            p_data_length => data_length,
+            p_logger => logger);
+  end;
+
+  impure function new_avalon_sink(data_length : natural;
+                                       ready_high_probability : real := 1.0;
+                                       logger : logger_t := avalon_stream_logger;
+                                       actor : actor_t := null_actor) return avalon_sink_t is
+    variable p_actor : actor_t;
+  begin
+    p_actor := actor when actor /= null_actor else new_actor;
+
+    return (ready_high_probability => ready_high_probability,
+            p_actor => p_actor,
+            p_data_length => data_length,
+            p_logger => logger);
+  end;
+
+  impure function data_length(source : avalon_source_t) return natural is
+  begin
+    return source.p_data_length;
+  end;
+
+  impure function data_length(source : avalon_sink_t) return natural is
+  begin
+    return source.p_data_length;
+  end;
+
+  impure function as_stream(source : avalon_source_t) return stream_master_t is
+  begin
+    return (p_actor => source.p_actor);
+  end;
+
+  impure function as_stream(sink : avalon_sink_t) return stream_slave_t is
+  begin
+    return (p_actor => sink.p_actor);
+  end;
+
+end package body;

--- a/vunit/vhdl/verification_components/test/tb_avalon_stream.gtkw
+++ b/vunit/vhdl/verification_components/test/tb_avalon_stream.gtkw
@@ -1,0 +1,43 @@
+[*]
+[*] GTKWave Analyzer v3.3.89 (w)1999-2018 BSI
+[*] Thu Jul 26 13:07:50 2018
+[*]
+[dumpfile] "/home/slawek/git/github/vunit/vunit/vhdl/verification_components/vunit_out/test_output/vunit_lib.tb_avalon_stream.push_delay_pop_29222108515eccc695b18c64dab4f2de296e5244/ghdl/wave.ghw"
+[dumpfile_mtime] "Thu Jul 26 13:07:39 2018"
+[dumpfile_size] 1770
+[savefile] "/home/slawek/git/github/vunit/vunit/vhdl/verification_components/test/tb_avalon_stream.gtkw"
+[timestart] 0
+[size] 1000 600
+[pos] -1 -1
+*-25.000000 47600000 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1
+[treeopen] top.
+[treeopen] top.tb_avalon_stream.
+[sst_width] 229
+[signals_width] 323
+[sst_expanded] 1
+[sst_vpaned_height] 285
+@800200
+-source
+@28
+top.tb_avalon_stream.avalon_source_vc.clk
+@22
+#{top.tb_avalon_stream.avalon_source_vc.data[7:0]} top.tb_avalon_stream.avalon_source_vc.data[7] top.tb_avalon_stream.avalon_source_vc.data[6] top.tb_avalon_stream.avalon_source_vc.data[5] top.tb_avalon_stream.avalon_source_vc.data[4] top.tb_avalon_stream.avalon_source_vc.data[3] top.tb_avalon_stream.avalon_source_vc.data[2] top.tb_avalon_stream.avalon_source_vc.data[1] top.tb_avalon_stream.avalon_source_vc.data[0]
+@28
+top.tb_avalon_stream.avalon_source_vc.valid
+top.tb_avalon_stream.avalon_source_vc.ready
+@1000200
+-source
+@800200
+-sink
+@28
+top.tb_avalon_stream.avalon_sink_vc.clk
+@22
+#{top.tb_avalon_stream.avalon_sink_vc.data[7:0]} top.tb_avalon_stream.avalon_sink_vc.data[7] top.tb_avalon_stream.avalon_sink_vc.data[6] top.tb_avalon_stream.avalon_sink_vc.data[5] top.tb_avalon_stream.avalon_sink_vc.data[4] top.tb_avalon_stream.avalon_sink_vc.data[3] top.tb_avalon_stream.avalon_sink_vc.data[2] top.tb_avalon_stream.avalon_sink_vc.data[1] top.tb_avalon_stream.avalon_sink_vc.data[0]
+@29
+top.tb_avalon_stream.avalon_sink_vc.valid
+@28
+top.tb_avalon_stream.avalon_sink_vc.ready
+@1000200
+-sink
+[pattern_trace] 1
+[pattern_trace] 0

--- a/vunit/vhdl/verification_components/test/tb_avalon_stream.vhd
+++ b/vunit/vhdl/verification_components/test/tb_avalon_stream.vhd
@@ -1,0 +1,102 @@
+-- This Source Code Form is subject to the terms of the Mozilla Public
+-- License, v. 2.0. If a copy of the MPL was not distributed with this file,
+-- You can obtain one at http://mozilla.org/MPL/2.0/.
+--
+-- Copyright (c) 2014-2018, Lars Asplund lars.anders.asplund@gmail.com
+-- Author Slawomir Siluk slaweksiluk@gazeta.pl
+
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.numeric_std.all;
+
+context work.vunit_context;
+context work.com_context;
+context work.data_types_context;
+use work.avalon_stream_pkg.all;
+use work.stream_master_pkg.all;
+use work.stream_slave_pkg.all;
+
+entity tb_avalon_stream is
+  generic (runner_cfg : string);
+end entity;
+
+architecture a of tb_avalon_stream is
+  constant avalon_source_stream : avalon_source_t :=
+    new_avalon_source(data_length => 8, valid_high_probability => 0.1);
+  constant master_stream : stream_master_t := as_stream(avalon_source_stream);
+
+  constant avalon_sink_stream : avalon_sink_t :=
+    new_avalon_sink(data_length => 8, ready_high_probability => 0.3);
+  constant slave_stream : stream_slave_t := as_stream(avalon_sink_stream);
+
+  signal clk   : std_logic := '0';
+  signal valid : std_logic;
+  signal ready : std_logic;
+  signal data  : std_logic_vector(data_length(avalon_source_stream)-1 downto 0);
+begin
+
+  main : process
+    variable tmp : std_logic_vector(data'range);
+  begin
+    test_runner_setup(runner, runner_cfg);
+    set_format(display_handler, verbose, true);
+    show(avalon_sink_stream.p_logger, display_handler, verbose);
+
+    wait until rising_edge(clk);
+    if run("test single push and pop") then
+      push_stream(net, master_stream, x"77");
+      pop_stream(net, slave_stream, tmp);
+      check_equal(tmp, std_logic_vector'(x"77"), "pop stream data");
+
+    elsif run("test double push and pop") then
+      push_stream(net, master_stream, x"66");
+      pop_stream(net, slave_stream, tmp);
+      check_equal(tmp, std_logic_vector'(x"66"), "pop stream first data");
+
+      push_stream(net, master_stream, x"55");
+      pop_stream(net, slave_stream, tmp);
+      check_equal(tmp, std_logic_vector'(x"55"), "pop stream second data");
+
+    elsif run("push delay pop") then
+      push_stream(net, master_stream, x"de");
+      wait until rising_edge(clk);
+      wait until rising_edge(clk);
+      wait until rising_edge(clk);
+      pop_stream(net, slave_stream, tmp);
+      check_equal(tmp, std_logic_vector'(x"de"), "pop stream data");
+
+    elsif run("block push and pop") then
+      for i in 0 to 7 loop
+        push_stream(net, master_stream, std_logic_vector(to_unsigned(i, 8)));
+        pop_stream(net, slave_stream, tmp);
+        check_equal(tmp, std_logic_vector(to_unsigned(i, 8)), "pop stream data"&natural'image(i));
+      end loop;
+
+    end if;
+    wait until rising_edge(clk);
+    test_runner_cleanup(runner);
+  end process;
+  test_runner_watchdog(runner, 10 ms);
+
+  avalon_source_vc : entity work.avalon_source
+    generic map (
+      source => avalon_source_stream)
+    port map (
+      clk   => clk,
+      valid => valid,
+      ready => ready,
+      data  => data
+    );
+
+  avalon_sink_vc : entity work.avalon_sink
+    generic map (
+      sink => avalon_sink_stream)
+    port map (
+      clk   => clk,
+      valid => valid,
+      ready => ready,
+      data  => data
+    );
+
+  clk <= not clk after 5 ns;
+end architecture;


### PR DESCRIPTION
Simple Avalon Stream VC based on the Axi Stream. 
  * added ready and valid signals randomization
  * avalon sink implementation is a bit different than axi-st slave - multiple (block) push and pop calls do not need reference queue which simplifies test bench code