### PR TITLE
Support for Avalon-MM burst transfers

### DIFF
--- a/vunit/vhdl/verification_components/run.py
+++ b/vunit/vhdl/verification_components/run.py
@@ -72,7 +72,7 @@ for test in tb_avalon_master.get_tests():
     if test.name == "wr single rd single":
         gen_avalon_master_tests(test, [1], [1.0], [0.0], [1.0], [1.0])
     else:
-        gen_avalon_master_tests(test, [16], [1.0, 0.3], [0.0, 0.7], [1.0, 0.3], [1.0, 0.3])
+        gen_avalon_master_tests(test, [64], [1.0, 0.3], [0.0, 0.7], [1.0, 0.3], [1.0, 0.3])
 
 tb_wishbone_slave = lib.test_bench("tb_wishbone_slave")
 

--- a/vunit/vhdl/verification_components/src/avalon_master.vhd
+++ b/vunit/vhdl/verification_components/src/avalon_master.vhd
@@ -5,10 +5,11 @@
 -- Copyright (c) 2014-2018, Lars Asplund lars.anders.asplund@gmail.com
 -- Author Slawomir Siluk slaweksiluk@gazeta.pl
 -- Avalon Memory Mapped Master BFM
--- - support burstcount > 1
-
+-- TODO:
+-- - handle byteenable in bursts
 library ieee;
 use ieee.std_logic_1164.all;
+use ieee.numeric_std.all;
 
 use work.queue_pkg.all;
 use work.bus_master_pkg.all;
@@ -44,7 +45,10 @@ end entity;
 
 architecture a of avalon_master is
   constant av_master_read_actor : actor_t := new_actor;
+  constant avmm_burst_rd_actor : actor_t := new_actor;
   constant acknowledge_queue : queue_t := new_queue;
+  constant burst_acknowledge_queue : queue_t := new_queue;
+  constant burstlen_queue : queue_t := new_queue;
 begin
 
   main : process
@@ -52,10 +56,12 @@ begin
     variable msg_type : msg_type_t;
     variable rnd : RandomPType;
     variable msgs : natural;
+    variable burst : positive;
   begin
     rnd.InitSeed(rnd'instance_name);
     write <= '0';
     read  <= '0';
+    burstcount <= std_logic_vector(to_unsigned(1, burstcount'length));
     wait until rising_edge(clk);
     loop
       request_msg := null_msg;
@@ -74,16 +80,50 @@ begin
           read <= '0';
           push(acknowledge_queue, request_msg);
 
+        elsif msg_type = bus_burst_read_msg then
+          while rnd.Uniform(0.0, 1.0) > read_high_probability loop
+            wait until rising_edge(clk);
+          end loop;
+          address <= pop_std_ulogic_vector(request_msg);
+          burstcount <= std_logic_vector(to_unsigned(1, burstcount'length));
+          burst := pop_integer(request_msg);
+          burstcount <= std_logic_vector(to_unsigned(burst, burstcount'length));
+          byteenable(byteenable'range) <= (others => '1');
+          read <= '1';
+          wait until rising_edge(clk) and waitrequest = '0';
+          read <= '0';
+          push(burst_acknowledge_queue, request_msg);
+          push(burstlen_queue, burst);
+
         elsif msg_type = bus_write_msg then
           while rnd.Uniform(0.0, 1.0) > write_high_probability loop
             wait until rising_edge(clk);
           end loop;
           address <= pop_std_ulogic_vector(request_msg);
+          burstcount <= std_logic_vector(to_unsigned(1, burstcount'length));
           writedata <= pop_std_ulogic_vector(request_msg);
           byteenable <= pop_std_ulogic_vector(request_msg);
           write <= '1';
           wait until rising_edge(clk) and waitrequest = '0';
           write <= '0';
+
+        elsif msg_type = bus_burst_write_msg then
+          address <= pop_std_ulogic_vector(request_msg);
+          burst := pop_integer(request_msg);
+          burstcount <= std_logic_vector(to_unsigned(burst, burstcount'length));
+          for i in 0 to burst-1 loop
+            while rnd.Uniform(0.0, 1.0) > write_high_probability loop
+              wait until rising_edge(clk);
+            end loop;
+            writedata <= pop_std_ulogic_vector(request_msg);
+            -- TODO handle byteenable
+            byteenable(byteenable'range) <= (others => '1');
+            write <= '1';
+            wait until rising_edge(clk) and waitrequest = '0';
+            write <= '0';
+            address(address'range) <= (others => 'U');
+            burstcount(burstcount'range) <= (others => 'U');
+          end loop;
 
         else
           unexpected_msg_type(msg_type);
@@ -98,7 +138,7 @@ begin
     variable request_msg, reply_msg : msg_t;
   begin
     if use_readdatavalid then
-        wait until readdatavalid = '1' and rising_edge(clk);
+        wait until readdatavalid = '1' and not is_empty(acknowledge_queue) and rising_edge(clk);
     else
         -- Non-pipelined case: waits for slave to de-assert waitrequest and sample data after fixed_read_latency cycles.
         wait until rising_edge(clk) and waitrequest = '0' and read = '1';
@@ -115,5 +155,23 @@ begin
     delete(request_msg);
   end process;
 
-  burstcount <= "1";
+  burst_read_capture : process
+    variable request_msg, reply_msg : msg_t;
+    variable burst : positive;
+  begin
+    wait until readdatavalid = '1' and not is_empty(burst_acknowledge_queue) and rising_edge(clk);
+    request_msg := pop(burst_acknowledge_queue);
+    burst := pop(burstlen_queue);
+    reply_msg := new_msg(sender => avmm_burst_rd_actor);
+    push_integer(reply_msg, burst);
+    push_std_ulogic_vector(reply_msg, readdata);
+    for i in 1 to burst-1 loop
+      wait until readdatavalid = '1' and rising_edge(clk) for 1 us;
+      check_true(readdatavalid = '1', "avalon master burst readdatavalid timeout");
+      push_std_ulogic_vector(reply_msg, readdata);
+    end loop;
+    reply(net, request_msg, reply_msg);
+    delete(request_msg);
+  end process;
+
 end architecture;

--- a/vunit/vhdl/verification_components/src/avalon_pkg.vhd
+++ b/vunit/vhdl/verification_components/src/avalon_pkg.vhd
@@ -45,7 +45,7 @@ package body avalon_pkg is
     return avalon_slave_t is
   begin
     return (p_actor => new_actor(name),
-            p_ack_actor => new_actor(name&"_ack"),
+            p_ack_actor => new_actor(name&" read-ack"),
             p_memory => to_vc_interface(memory, logger),
             p_logger => logger,
             readdatavalid_high_probability => readdatavalid_high_probability,

--- a/vunit/vhdl/verification_components/src/avalon_slave.vhd
+++ b/vunit/vhdl/verification_components/src/avalon_slave.vhd
@@ -6,8 +6,7 @@
 -- Author Slawomir Siluk slaweksiluk@gazeta.pl
 --
 -- Avalon memory mapped slave wrapper for Vunit memory VC
--- TODO:
--- - support burstcount > 1
+
 library ieee;
 use ieee.std_logic_1164.all;
 use ieee.numeric_std.all;
@@ -40,58 +39,64 @@ end entity;
 
 architecture a of avalon_slave is
 
-  constant slave_write_msg  : msg_type_t := new_msg_type("avmm slave write");
   constant slave_read_msg   : msg_type_t := new_msg_type("avmm slave read");
 
 begin
 
-  request : process
-    variable wr_request_msg : msg_t;
-    variable rd_request_msg : msg_t;
+  write_handler : process
+    variable pending_writes : positive := 1;
+    variable addr : natural;
   begin
-    wait until (write or read) = '1' and waitrequest = '0' and rising_edge(clk);
-	check_false(write = '1' and read = '1');
-    if write = '1' then
-      wr_request_msg := new_msg(slave_write_msg, avalon_slave.p_actor);
-      -- For write, address and data are passed to ack proc
-      push_integer(wr_request_msg, to_integer(unsigned(address)));
-      push_std_ulogic_vector(wr_request_msg, writedata);
-      send(net, avalon_slave.p_ack_actor, wr_request_msg);
-    elsif read = '1' then
-      rd_request_msg := new_msg(slave_read_msg, avalon_slave.p_actor);
-      -- For read, only address is passed to ack proc
-      push_integer(rd_request_msg, to_integer(unsigned(address)));
-      send(net, avalon_slave.p_ack_actor, rd_request_msg);
-    end if;
+    loop
+      wait until write = '1' and waitrequest = '0' and rising_edge(clk);
+      -- Burst write in progress
+      if pending_writes > 1 then
+        addr := addr + byteenable'length;
+        pending_writes := pending_writes -1;
+        write_word(avalon_slave.p_memory, addr, writedata);
+      -- Burst start or single burst
+      else
+        addr := to_integer(unsigned(address));
+        pending_writes := to_integer(unsigned(burstcount));
+        write_word(avalon_slave.p_memory, addr, writedata);
+      end if;
+    end loop;
   end process;
 
-  acknowledge : process
+  read_request : process
+    variable rd_request_msg : msg_t;
+  begin
+    wait until read = '1' and waitrequest = '0' and rising_edge(clk);
+    rd_request_msg := new_msg(slave_read_msg, avalon_slave.p_actor);
+    -- For read, only address is passed to ack proc
+    push_integer(rd_request_msg, to_integer(unsigned(burstcount)));
+    push_integer(rd_request_msg, to_integer(unsigned(address)));
+    send(net, avalon_slave.p_ack_actor, rd_request_msg);
+  end process;
+
+  read_handler : process
     variable request_msg : msg_t;
     variable msg_type : msg_type_t;
-    variable data : std_logic_vector(writedata'range);
-    variable addr : natural;
+    variable baseaddr : natural;
+    variable burst : positive;
     variable rnd : RandomPType;
   begin
     readdatavalid <= '0';
     receive(net, avalon_slave.p_ack_actor, request_msg);
     msg_type := message_type(request_msg);
 
-    if msg_type = slave_write_msg then
-      addr := pop_integer(request_msg);
-      data := pop_std_ulogic_vector(request_msg);
-      write_word(avalon_slave.p_memory, addr, data);
-
-    elsif msg_type = slave_read_msg then
-      data := (others => '0');
-      addr := pop_integer(request_msg);
-      data := read_word(avalon_slave.p_memory, addr, byteenable'length);
-      while rnd.Uniform(0.0, 1.0) > avalon_slave.readdatavalid_high_probability loop
+    if msg_type = slave_read_msg then
+      burst := pop_integer(request_msg);
+      baseaddr := pop_integer(request_msg);
+      for i in 0 to burst-1 loop
+        while rnd.Uniform(0.0, 1.0) > avalon_slave.readdatavalid_high_probability loop
+          wait until rising_edge(clk);
+        end loop;
+        readdata <= read_word(avalon_slave.p_memory, baseaddr + byteenable'length*i, byteenable'length);
+        readdatavalid <= '1';
         wait until rising_edge(clk);
+        readdatavalid <= '0';
       end loop;
-      readdata <= data;
-      readdatavalid <= '1';
-      wait until rising_edge(clk);
-      readdatavalid <= '0';
 
     else
       unexpected_msg_type(msg_type);

--- a/vunit/vhdl/verification_components/src/bus_master_pkg-body.vhd
+++ b/vunit/vhdl/verification_components/src/bus_master_pkg-body.vhd
@@ -98,11 +98,11 @@ package body bus_master_pkg is
     write_bus(net, bus_handle, to_address(bus_handle, address), data, byte_enable);
   end;
 
-  procedure write_bus(signal net : inout network_t;
+  procedure burst_write_bus(signal net : inout network_t;
                       constant bus_handle : bus_master_t;
                       constant address : std_logic_vector;
                       constant burst_length : positive;
-                      constant burstdata : queue_t) is
+                      constant data : queue_t) is
     variable request_msg : msg_t := new_msg(bus_burst_write_msg);
     variable full_address : std_logic_vector(bus_handle.p_address_length-1 downto 0) := (others => '0');
     variable full_data : std_logic_vector(bus_handle.p_data_length-1 downto 0) := (others => '0');
@@ -111,19 +111,19 @@ package body bus_master_pkg is
     push_std_ulogic_vector(request_msg, full_address);
     push_integer(request_msg, burst_length);
     for i in 0 to burst_length-1 loop
-      full_data(bus_handle.p_data_length-1 downto 0) := pop(burstdata);
+      full_data(bus_handle.p_data_length-1 downto 0) := pop(data);
       push_std_ulogic_vector(request_msg, full_data);
     end loop;
     send(net, bus_handle.p_actor, request_msg);
   end procedure;
 
-  procedure write_bus(signal net : inout network_t;
+  procedure burst_write_bus(signal net : inout network_t;
                       constant bus_handle : bus_master_t;
                       constant address : natural;
                       constant burst_length : positive;
-                      constant burstdata : queue_t) is
+                      constant data : queue_t) is
   begin
-    write_bus(net, bus_handle, to_address(bus_handle, address), burst_length, burstdata);
+    burst_write_bus(net, bus_handle, to_address(bus_handle, address), burst_length, data);
   end procedure;
 
   procedure check_bus(signal net : inout network_t;
@@ -188,7 +188,7 @@ package body bus_master_pkg is
     read_bus(net, bus_handle, to_address(bus_handle, address), reference);
   end;
 
-  procedure read_bus(signal net : inout network_t;
+  procedure burst_read_bus(signal net : inout network_t;
                       constant bus_handle : bus_master_t;
                       constant address : std_logic_vector;
                       constant burst_length : positive;
@@ -203,13 +203,13 @@ package body bus_master_pkg is
     send(net, bus_handle.p_actor, request_msg);
   end procedure;
 
-  procedure read_bus(signal net : inout network_t;
+  procedure burst_read_bus(signal net : inout network_t;
                       constant bus_handle : bus_master_t;
                       constant address : natural;
                       constant burst_length : positive;
                       variable reference : inout bus_reference_t) is
   begin
-    read_bus(net, bus_handle, to_address(bus_handle, address), burst_length, reference);
+    burst_read_bus(net, bus_handle, to_address(bus_handle, address), burst_length, reference);
   end procedure;
 
   -- Await read bus reply
@@ -225,20 +225,20 @@ package body bus_master_pkg is
     delete(reply_msg);
   end procedure;
 
-  procedure await_read_bus_reply(signal net : inout network_t;
+  procedure await_burst_read_bus_reply(signal net : inout network_t;
                                  constant bus_handle : bus_master_t;
-                                 constant burstdata : queue_t;
+                                 constant data : queue_t;
                                  variable reference : inout bus_reference_t) is
     variable reply_msg : msg_t;
     alias request_msg : msg_t is reference;
-    variable data : std_logic_vector(bus_handle.p_data_length-1 downto 0);
+    variable d : std_logic_vector(bus_handle.p_data_length-1 downto 0);
     variable burst_length : positive;
   begin
     receive_reply(net, request_msg, reply_msg);
     burst_length := pop_integer(reply_msg);
     for i in 0 to burst_length-1 loop
-      data := pop_std_ulogic_vector(reply_msg)(data'range);
-      push(burstdata, data);
+      d := pop_std_ulogic_vector(reply_msg)(d'range);
+      push(data, d);
     end loop;
     delete(request_msg);
     delete(reply_msg);
@@ -264,24 +264,24 @@ package body bus_master_pkg is
     read_bus(net, bus_handle, to_address(bus_handle, address), data);
   end;
 
-  procedure read_bus(signal net : inout network_t;
+  procedure burst_read_bus(signal net : inout network_t;
                       constant bus_handle : bus_master_t;
                       constant address : std_logic_vector;
                       constant burst_length : positive;
-                      constant burstdata : queue_t) is
+                      constant data : queue_t) is
     variable reference : bus_reference_t;
   begin
-    read_bus(net, bus_handle, address, burst_length, reference);
-    await_read_bus_reply(net, bus_handle, burstdata, reference);
+    burst_read_bus(net, bus_handle, address, burst_length, reference);
+    await_burst_read_bus_reply(net, bus_handle, data, reference);
   end procedure;
 
-  procedure read_bus(signal net : inout network_t;
+  procedure burst_read_bus(signal net : inout network_t;
                       constant bus_handle : bus_master_t;
                       constant address : natural;
                       constant burst_length : positive;
-                      constant burstdata : queue_t) is
+                      constant data : queue_t) is
   begin
-    read_bus(net, bus_handle, to_address(bus_handle, address), burst_length, burstdata);
+    burst_read_bus(net, bus_handle, to_address(bus_handle, address), burst_length, data);
   end procedure;
 
   procedure wait_until_read_equals(

--- a/vunit/vhdl/verification_components/src/bus_master_pkg-body.vhd
+++ b/vunit/vhdl/verification_components/src/bus_master_pkg-body.vhd
@@ -10,6 +10,8 @@ use ieee.numeric_std.all;
 
 use work.queue_pkg.all;
 use work.sync_pkg.all;
+use work.queue_pkg.all;
+use work.check_pkg.all;
 
 package body bus_master_pkg is
 
@@ -96,6 +98,34 @@ package body bus_master_pkg is
     write_bus(net, bus_handle, to_address(bus_handle, address), data, byte_enable);
   end;
 
+  procedure write_bus(signal net : inout network_t;
+                      constant bus_handle : bus_master_t;
+                      constant address : std_logic_vector;
+                      constant burstsize : positive;
+                      constant burstdata : queue_t) is
+    variable request_msg : msg_t := new_msg(bus_burst_write_msg);
+    variable full_address : std_logic_vector(bus_handle.p_address_length-1 downto 0) := (others => '0');
+    variable full_data : std_logic_vector(bus_handle.p_data_length-1 downto 0) := (others => '0');
+  begin
+    full_address(address'length-1 downto 0) := address;
+    push_std_ulogic_vector(request_msg, full_address);
+    push_integer(request_msg, burstsize);
+    for i in 0 to burstsize-1 loop
+      full_data(bus_handle.p_data_length-1 downto 0) := pop(burstdata);
+      push_std_ulogic_vector(request_msg, full_data);
+    end loop;
+    send(net, bus_handle.p_actor, request_msg);
+  end procedure;
+
+  procedure write_bus(signal net : inout network_t;
+                      constant bus_handle : bus_master_t;
+                      constant address : natural;
+                      constant burstsize : positive;
+                      constant burstdata : queue_t) is
+  begin
+    write_bus(net, bus_handle, to_address(bus_handle, address), burstsize, burstdata);
+  end procedure;
+
   procedure check_bus(signal net : inout network_t;
                       constant bus_handle : bus_master_t;
                       constant address : std_logic_vector;
@@ -158,6 +188,30 @@ package body bus_master_pkg is
     read_bus(net, bus_handle, to_address(bus_handle, address), reference);
   end;
 
+  procedure read_bus(signal net : inout network_t;
+                      constant bus_handle : bus_master_t;
+                      constant address : std_logic_vector;
+                      constant burstsize : positive;
+                      variable reference : inout bus_reference_t) is
+    variable full_address : std_logic_vector(bus_handle.p_address_length-1 downto 0) := (others => '0');
+    alias request_msg : msg_t is reference;
+  begin
+    request_msg := new_msg(bus_burst_read_msg);
+    full_address(address'length-1 downto 0) := address;
+    push_std_ulogic_vector(request_msg, full_address);
+    push_integer(request_msg, burstsize);
+    send(net, bus_handle.p_actor, request_msg);
+  end procedure;
+
+  procedure read_bus(signal net : inout network_t;
+                      constant bus_handle : bus_master_t;
+                      constant address : natural;
+                      constant burstsize : positive;
+                      variable reference : inout bus_reference_t) is
+  begin
+    read_bus(net, bus_handle, to_address(bus_handle, address), burstsize, reference);
+  end procedure;
+
   -- Await read bus reply
   procedure await_read_bus_reply(signal net : inout network_t;
                                  variable reference : inout bus_reference_t;
@@ -167,6 +221,25 @@ package body bus_master_pkg is
   begin
     receive_reply(net, request_msg, reply_msg);
     data := pop_std_ulogic_vector(reply_msg)(data'range);
+    delete(request_msg);
+    delete(reply_msg);
+  end procedure;
+
+  procedure await_read_bus_reply(signal net : inout network_t;
+                                 constant bus_handle : bus_master_t;
+                                 constant burstdata : queue_t;
+                                 variable reference : inout bus_reference_t) is
+    variable reply_msg : msg_t;
+    alias request_msg : msg_t is reference;
+    variable data : std_logic_vector(bus_handle.p_data_length-1 downto 0);
+    variable burstsize : positive;
+  begin
+    receive_reply(net, request_msg, reply_msg);
+    burstsize := pop_integer(reply_msg);
+    for i in 0 to burstsize-1 loop
+      data := pop_std_ulogic_vector(reply_msg)(data'range);
+      push(burstdata, data);
+    end loop;
     delete(request_msg);
     delete(reply_msg);
   end procedure;
@@ -190,6 +263,26 @@ package body bus_master_pkg is
   begin
     read_bus(net, bus_handle, to_address(bus_handle, address), data);
   end;
+
+  procedure read_bus(signal net : inout network_t;
+                      constant bus_handle : bus_master_t;
+                      constant address : std_logic_vector;
+                      constant burstsize : positive;
+                      constant burstdata : queue_t) is
+    variable reference : bus_reference_t;
+  begin
+    read_bus(net, bus_handle, address, burstsize, reference);
+    await_read_bus_reply(net, bus_handle, burstdata, reference);
+  end procedure;
+
+  procedure read_bus(signal net : inout network_t;
+                      constant bus_handle : bus_master_t;
+                      constant address : natural;
+                      constant burstsize : positive;
+                      constant burstdata : queue_t) is
+  begin
+    read_bus(net, bus_handle, to_address(bus_handle, address), burstsize, burstdata);
+  end procedure;
 
   procedure wait_until_read_equals(
     signal net : inout network_t;

--- a/vunit/vhdl/verification_components/src/bus_master_pkg-body.vhd
+++ b/vunit/vhdl/verification_components/src/bus_master_pkg-body.vhd
@@ -101,7 +101,7 @@ package body bus_master_pkg is
   procedure write_bus(signal net : inout network_t;
                       constant bus_handle : bus_master_t;
                       constant address : std_logic_vector;
-                      constant burstsize : positive;
+                      constant burst_length : positive;
                       constant burstdata : queue_t) is
     variable request_msg : msg_t := new_msg(bus_burst_write_msg);
     variable full_address : std_logic_vector(bus_handle.p_address_length-1 downto 0) := (others => '0');
@@ -109,8 +109,8 @@ package body bus_master_pkg is
   begin
     full_address(address'length-1 downto 0) := address;
     push_std_ulogic_vector(request_msg, full_address);
-    push_integer(request_msg, burstsize);
-    for i in 0 to burstsize-1 loop
+    push_integer(request_msg, burst_length);
+    for i in 0 to burst_length-1 loop
       full_data(bus_handle.p_data_length-1 downto 0) := pop(burstdata);
       push_std_ulogic_vector(request_msg, full_data);
     end loop;
@@ -120,10 +120,10 @@ package body bus_master_pkg is
   procedure write_bus(signal net : inout network_t;
                       constant bus_handle : bus_master_t;
                       constant address : natural;
-                      constant burstsize : positive;
+                      constant burst_length : positive;
                       constant burstdata : queue_t) is
   begin
-    write_bus(net, bus_handle, to_address(bus_handle, address), burstsize, burstdata);
+    write_bus(net, bus_handle, to_address(bus_handle, address), burst_length, burstdata);
   end procedure;
 
   procedure check_bus(signal net : inout network_t;
@@ -191,7 +191,7 @@ package body bus_master_pkg is
   procedure read_bus(signal net : inout network_t;
                       constant bus_handle : bus_master_t;
                       constant address : std_logic_vector;
-                      constant burstsize : positive;
+                      constant burst_length : positive;
                       variable reference : inout bus_reference_t) is
     variable full_address : std_logic_vector(bus_handle.p_address_length-1 downto 0) := (others => '0');
     alias request_msg : msg_t is reference;
@@ -199,17 +199,17 @@ package body bus_master_pkg is
     request_msg := new_msg(bus_burst_read_msg);
     full_address(address'length-1 downto 0) := address;
     push_std_ulogic_vector(request_msg, full_address);
-    push_integer(request_msg, burstsize);
+    push_integer(request_msg, burst_length);
     send(net, bus_handle.p_actor, request_msg);
   end procedure;
 
   procedure read_bus(signal net : inout network_t;
                       constant bus_handle : bus_master_t;
                       constant address : natural;
-                      constant burstsize : positive;
+                      constant burst_length : positive;
                       variable reference : inout bus_reference_t) is
   begin
-    read_bus(net, bus_handle, to_address(bus_handle, address), burstsize, reference);
+    read_bus(net, bus_handle, to_address(bus_handle, address), burst_length, reference);
   end procedure;
 
   -- Await read bus reply
@@ -232,11 +232,11 @@ package body bus_master_pkg is
     variable reply_msg : msg_t;
     alias request_msg : msg_t is reference;
     variable data : std_logic_vector(bus_handle.p_data_length-1 downto 0);
-    variable burstsize : positive;
+    variable burst_length : positive;
   begin
     receive_reply(net, request_msg, reply_msg);
-    burstsize := pop_integer(reply_msg);
-    for i in 0 to burstsize-1 loop
+    burst_length := pop_integer(reply_msg);
+    for i in 0 to burst_length-1 loop
       data := pop_std_ulogic_vector(reply_msg)(data'range);
       push(burstdata, data);
     end loop;
@@ -267,21 +267,21 @@ package body bus_master_pkg is
   procedure read_bus(signal net : inout network_t;
                       constant bus_handle : bus_master_t;
                       constant address : std_logic_vector;
-                      constant burstsize : positive;
+                      constant burst_length : positive;
                       constant burstdata : queue_t) is
     variable reference : bus_reference_t;
   begin
-    read_bus(net, bus_handle, address, burstsize, reference);
+    read_bus(net, bus_handle, address, burst_length, reference);
     await_read_bus_reply(net, bus_handle, burstdata, reference);
   end procedure;
 
   procedure read_bus(signal net : inout network_t;
                       constant bus_handle : bus_master_t;
                       constant address : natural;
-                      constant burstsize : positive;
+                      constant burst_length : positive;
                       constant burstdata : queue_t) is
   begin
-    read_bus(net, bus_handle, to_address(bus_handle, address), burstsize, burstdata);
+    read_bus(net, bus_handle, to_address(bus_handle, address), burst_length, burstdata);
   end procedure;
 
   procedure wait_until_read_equals(

--- a/vunit/vhdl/verification_components/src/bus_master_pkg.vhd
+++ b/vunit/vhdl/verification_components/src/bus_master_pkg.vhd
@@ -71,6 +71,10 @@ package bus_master_pkg is
                       constant data : std_logic_vector;
                       -- default byte enable is all bytes
                       constant byte_enable : std_logic_vector := "");
+  -- Procedures for burst bus write: Caller is responsible for allocation and
+  -- deallocation of burstdata queue. Procedure cunsumes burst_length data words
+  -- from burstdata queue. If burstdata queue has less data words, all data
+  -- words are consumed and pop from empty queue error is raised.
   procedure write_bus(signal net : inout network_t;
                       constant bus_handle : bus_master_t;
                       constant address : std_logic_vector;
@@ -106,6 +110,9 @@ package bus_master_pkg is
   procedure await_read_bus_reply(signal net : inout network_t;
                                  variable reference : inout bus_reference_t;
                                  variable data : inout std_logic_vector);
+  -- Procedure for burst read reply: Caller is responsible for allocation and
+  -- deallocation of burstdata queue. Procedure pushes burst_length data words
+  -- into burstdata queue.
   procedure await_read_bus_reply(signal net : inout network_t;
                                  constant bus_handle : bus_master_t;
                                  constant burstdata : queue_t;
@@ -132,6 +139,9 @@ package bus_master_pkg is
                      constant bus_handle : bus_master_t;
                      constant address : natural;
                      variable data : inout std_logic_vector);
+  -- Procedure for burst bus read: Caller is responsible for allocation and
+  -- deallocation of burstdata queue. Procedure pushes burst_length data words
+  -- into burstdata queue.
   procedure read_bus(signal net : inout network_t;
                       constant bus_handle : bus_master_t;
                       constant address : std_logic_vector;

--- a/vunit/vhdl/verification_components/src/bus_master_pkg.vhd
+++ b/vunit/vhdl/verification_components/src/bus_master_pkg.vhd
@@ -74,12 +74,12 @@ package bus_master_pkg is
   procedure write_bus(signal net : inout network_t;
                       constant bus_handle : bus_master_t;
                       constant address : std_logic_vector;
-                      constant burstsize : positive;
+                      constant burst_length : positive;
                       constant burstdata : queue_t);
   procedure write_bus(signal net : inout network_t;
                       constant bus_handle : bus_master_t;
                       constant address : natural;
-                      constant burstsize : positive;
+                      constant burst_length : positive;
                       constant burstdata : queue_t);
 
   -- Non blocking: Read the bus returning a reference to the future reply
@@ -94,12 +94,12 @@ package bus_master_pkg is
   procedure read_bus(signal net : inout network_t;
                       constant bus_handle : bus_master_t;
                       constant address : std_logic_vector;
-                      constant burstsize : positive;
+                      constant burst_length : positive;
                       variable reference : inout bus_reference_t);
   procedure read_bus(signal net : inout network_t;
                       constant bus_handle : bus_master_t;
                       constant address : natural;
-                      constant burstsize : positive;
+                      constant burst_length : positive;
                       variable reference : inout bus_reference_t);
 
   -- Blocking: Await read bus reply data
@@ -135,12 +135,12 @@ package bus_master_pkg is
   procedure read_bus(signal net : inout network_t;
                       constant bus_handle : bus_master_t;
                       constant address : std_logic_vector;
-                      constant burstsize : positive;
+                      constant burst_length : positive;
                       constant burstdata : queue_t);
   procedure read_bus(signal net : inout network_t;
                       constant bus_handle : bus_master_t;
                       constant address : natural;
-                      constant burstsize : positive;
+                      constant burst_length : positive;
                       constant burstdata : queue_t);
 
   -- Blocking: Wait until a read from address equals the value using

--- a/vunit/vhdl/verification_components/src/bus_master_pkg.vhd
+++ b/vunit/vhdl/verification_components/src/bus_master_pkg.vhd
@@ -72,19 +72,19 @@ package bus_master_pkg is
                       -- default byte enable is all bytes
                       constant byte_enable : std_logic_vector := "");
   -- Procedures for burst bus write: Caller is responsible for allocation and
-  -- deallocation of burstdata queue. Procedure cunsumes burst_length data words
-  -- from burstdata queue. If burstdata queue has less data words, all data
+  -- deallocation of data queue. Procedure cunsumes burst_length data words
+  -- from data queue. If data queue has less data words, all data
   -- words are consumed and pop from empty queue error is raised.
-  procedure write_bus(signal net : inout network_t;
+  procedure burst_write_bus(signal net : inout network_t;
                       constant bus_handle : bus_master_t;
                       constant address : std_logic_vector;
                       constant burst_length : positive;
-                      constant burstdata : queue_t);
-  procedure write_bus(signal net : inout network_t;
+                      constant data : queue_t);
+  procedure burst_write_bus(signal net : inout network_t;
                       constant bus_handle : bus_master_t;
                       constant address : natural;
                       constant burst_length : positive;
-                      constant burstdata : queue_t);
+                      constant data : queue_t);
 
   -- Non blocking: Read the bus returning a reference to the future reply
   procedure read_bus(signal net : inout network_t;
@@ -95,12 +95,12 @@ package bus_master_pkg is
                      constant bus_handle : bus_master_t;
                      constant address : natural;
                      variable reference : inout bus_reference_t);
-  procedure read_bus(signal net : inout network_t;
+  procedure burst_read_bus(signal net : inout network_t;
                       constant bus_handle : bus_master_t;
                       constant address : std_logic_vector;
                       constant burst_length : positive;
                       variable reference : inout bus_reference_t);
-  procedure read_bus(signal net : inout network_t;
+  procedure burst_read_bus(signal net : inout network_t;
                       constant bus_handle : bus_master_t;
                       constant address : natural;
                       constant burst_length : positive;
@@ -111,11 +111,11 @@ package bus_master_pkg is
                                  variable reference : inout bus_reference_t;
                                  variable data : inout std_logic_vector);
   -- Procedure for burst read reply: Caller is responsible for allocation and
-  -- deallocation of burstdata queue. Procedure pushes burst_length data words
-  -- into burstdata queue.
-  procedure await_read_bus_reply(signal net : inout network_t;
+  -- deallocation of data queue. Procedure pushes burst_length data words
+  -- into data queue.
+  procedure await_burst_read_bus_reply(signal net : inout network_t;
                                  constant bus_handle : bus_master_t;
-                                 constant burstdata : queue_t;
+                                 constant data : queue_t;
                                  variable reference : inout bus_reference_t);
 
   -- Blocking: Read bus and check result against expected data
@@ -140,18 +140,18 @@ package bus_master_pkg is
                      constant address : natural;
                      variable data : inout std_logic_vector);
   -- Procedure for burst bus read: Caller is responsible for allocation and
-  -- deallocation of burstdata queue. Procedure pushes burst_length data words
-  -- into burstdata queue.
-  procedure read_bus(signal net : inout network_t;
+  -- deallocation of data queue. Procedure pushes burst_length data words
+  -- into data queue.
+  procedure burst_read_bus(signal net : inout network_t;
                       constant bus_handle : bus_master_t;
                       constant address : std_logic_vector;
                       constant burst_length : positive;
-                      constant burstdata : queue_t);
-  procedure read_bus(signal net : inout network_t;
+                      constant data : queue_t);
+  procedure burst_read_bus(signal net : inout network_t;
                       constant bus_handle : bus_master_t;
                       constant address : natural;
                       constant burst_length : positive;
-                      constant burstdata : queue_t);
+                      constant data : queue_t);
 
   -- Blocking: Wait until a read from address equals the value using
   -- std_match If timeout is reached error with msg

--- a/vunit/vhdl/verification_components/src/bus_master_pkg.vhd
+++ b/vunit/vhdl/verification_components/src/bus_master_pkg.vhd
@@ -12,6 +12,7 @@ use ieee.std_logic_1164.all;
 use work.logger_pkg.all;
 context work.com_context;
 use work.sync_pkg.all;
+use work.queue_pkg.all;
 
 package bus_master_pkg is
 
@@ -70,6 +71,16 @@ package bus_master_pkg is
                       constant data : std_logic_vector;
                       -- default byte enable is all bytes
                       constant byte_enable : std_logic_vector := "");
+  procedure write_bus(signal net : inout network_t;
+                      constant bus_handle : bus_master_t;
+                      constant address : std_logic_vector;
+                      constant burstsize : positive;
+                      constant burstdata : queue_t);
+  procedure write_bus(signal net : inout network_t;
+                      constant bus_handle : bus_master_t;
+                      constant address : natural;
+                      constant burstsize : positive;
+                      constant burstdata : queue_t);
 
   -- Non blocking: Read the bus returning a reference to the future reply
   procedure read_bus(signal net : inout network_t;
@@ -80,11 +91,25 @@ package bus_master_pkg is
                      constant bus_handle : bus_master_t;
                      constant address : natural;
                      variable reference : inout bus_reference_t);
+  procedure read_bus(signal net : inout network_t;
+                      constant bus_handle : bus_master_t;
+                      constant address : std_logic_vector;
+                      constant burstsize : positive;
+                      variable reference : inout bus_reference_t);
+  procedure read_bus(signal net : inout network_t;
+                      constant bus_handle : bus_master_t;
+                      constant address : natural;
+                      constant burstsize : positive;
+                      variable reference : inout bus_reference_t);
 
   -- Blocking: Await read bus reply data
   procedure await_read_bus_reply(signal net : inout network_t;
                                  variable reference : inout bus_reference_t;
                                  variable data : inout std_logic_vector);
+  procedure await_read_bus_reply(signal net : inout network_t;
+                                 constant bus_handle : bus_master_t;
+                                 constant burstdata : queue_t;
+                                 variable reference : inout bus_reference_t);
 
   -- Blocking: Read bus and check result against expected data
   procedure check_bus(signal net : inout network_t;
@@ -107,6 +132,16 @@ package bus_master_pkg is
                      constant bus_handle : bus_master_t;
                      constant address : natural;
                      variable data : inout std_logic_vector);
+  procedure read_bus(signal net : inout network_t;
+                      constant bus_handle : bus_master_t;
+                      constant address : std_logic_vector;
+                      constant burstsize : positive;
+                      constant burstdata : queue_t);
+  procedure read_bus(signal net : inout network_t;
+                      constant bus_handle : bus_master_t;
+                      constant address : natural;
+                      constant burstsize : positive;
+                      constant burstdata : queue_t);
 
   -- Blocking: Wait until a read from address equals the value using
   -- std_match If timeout is reached error with msg
@@ -139,4 +174,6 @@ package bus_master_pkg is
   -- Message type definitions, used by VC-instances
   constant bus_write_msg : msg_type_t := new_msg_type("write bus");
   constant bus_read_msg : msg_type_t := new_msg_type("read bus");
+  constant bus_burst_write_msg : msg_type_t := new_msg_type("burst write bus");
+  constant bus_burst_read_msg : msg_type_t := new_msg_type("burst read bus");
 end package;

--- a/vunit/vhdl/verification_components/test/tb_avalon_master.gtkw
+++ b/vunit/vhdl/verification_components/test/tb_avalon_master.gtkw
@@ -1,21 +1,21 @@
 [*]
 [*] GTKWave Analyzer v3.3.89 (w)1999-2018 BSI
-[*] Mon Jul 23 15:44:35 2018
+[*] Wed Aug  1 10:47:45 2018
 [*]
-[dumpfile] "/home/slawek/git/github/vunit/vunit/vhdl/verification_components/vunit_out/test_output/vunit_lib.tb_avalon_master.waitrequest_prob_0.0,transfers_2,readdatavalid_prob_1.0,write_prob_1.0,read_prob_1.0.wr_block_rd_block_0aeaff7c74e89eadfef59cd1551c2184bfbe8cae/ghdl/wave.ghw"
-[dumpfile_mtime] "Mon Jul 23 15:44:17 2018"
-[dumpfile_size] 3111
+[dumpfile] "/home/slawek/git/github/vunit/vunit/vhdl/verification_components/vunit_out/test_output/vunit_lib.tb_avalon_master.waitrequest_prob_0.0,transfers_16,readdatavalid_prob_1.0,write_prob_1.0,read_prob_1.0.random_burstcount_264398a89671e8a3153a653d88de6afc2f73ba13/ghdl/wave.ghw"
+[dumpfile_mtime] "Wed Aug  1 10:45:42 2018"
+[dumpfile_size] 5698
 [savefile] "/home/slawek/git/github/vunit/vunit/vhdl/verification_components/test/tb_avalon_master.gtkw"
-[timestart] 0
-[size] 1684 600
+[timestart] 59500000
+[size] 1731 670
 [pos] -1 -1
-*-25.000000 140000000 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1
+*-25.000000 224000000 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1
 [treeopen] top.
 [treeopen] top.tb_avalon_master.
 [sst_width] 229
 [signals_width] 366
 [sst_expanded] 1
-[sst_vpaned_height] 285
+[sst_vpaned_height] 337
 @800200
 -master
 @28
@@ -23,12 +23,12 @@ top.tb_avalon_master.dut.clk
 @22
 #{top.tb_avalon_master.dut.address[31:0]} top.tb_avalon_master.dut.address[31] top.tb_avalon_master.dut.address[30] top.tb_avalon_master.dut.address[29] top.tb_avalon_master.dut.address[28] top.tb_avalon_master.dut.address[27] top.tb_avalon_master.dut.address[26] top.tb_avalon_master.dut.address[25] top.tb_avalon_master.dut.address[24] top.tb_avalon_master.dut.address[23] top.tb_avalon_master.dut.address[22] top.tb_avalon_master.dut.address[21] top.tb_avalon_master.dut.address[20] top.tb_avalon_master.dut.address[19] top.tb_avalon_master.dut.address[18] top.tb_avalon_master.dut.address[17] top.tb_avalon_master.dut.address[16] top.tb_avalon_master.dut.address[15] top.tb_avalon_master.dut.address[14] top.tb_avalon_master.dut.address[13] top.tb_avalon_master.dut.address[12] top.tb_avalon_master.dut.address[11] top.tb_avalon_master.dut.address[10] top.tb_avalon_master.dut.address[9] top.tb_avalon_master.dut.address[8] top.tb_avalon_master.dut.address[7] top.tb_avalon_master.dut.address[6] top.tb_avalon_master.dut.address[5] top.tb_avalon_master.dut.address[4] top.tb_avalon_master.dut.address[3] top.tb_avalon_master.dut.address[2] top.tb_avalon_master.dut.address[1] top.tb_avalon_master.dut.address[0]
 @24
-top.tb_avalon_master.dut.burstcount[0]
+#{top.tb_avalon_master.burstcount[7:0]} top.tb_avalon_master.burstcount[7] top.tb_avalon_master.burstcount[6] top.tb_avalon_master.burstcount[5] top.tb_avalon_master.burstcount[4] top.tb_avalon_master.burstcount[3] top.tb_avalon_master.burstcount[2] top.tb_avalon_master.burstcount[1] top.tb_avalon_master.burstcount[0]
 @22
 #{top.tb_avalon_master.dut.byteenable[3:0]} top.tb_avalon_master.dut.byteenable[3] top.tb_avalon_master.dut.byteenable[2] top.tb_avalon_master.dut.byteenable[1] top.tb_avalon_master.dut.byteenable[0]
-@28
-top.tb_avalon_master.dut.waitrequest
 @29
+top.tb_avalon_master.dut.waitrequest
+@28
 top.tb_avalon_master.dut.write
 @22
 #{top.tb_avalon_master.dut.writedata[31:0]} top.tb_avalon_master.dut.writedata[31] top.tb_avalon_master.dut.writedata[30] top.tb_avalon_master.dut.writedata[29] top.tb_avalon_master.dut.writedata[28] top.tb_avalon_master.dut.writedata[27] top.tb_avalon_master.dut.writedata[26] top.tb_avalon_master.dut.writedata[25] top.tb_avalon_master.dut.writedata[24] top.tb_avalon_master.dut.writedata[23] top.tb_avalon_master.dut.writedata[22] top.tb_avalon_master.dut.writedata[21] top.tb_avalon_master.dut.writedata[20] top.tb_avalon_master.dut.writedata[19] top.tb_avalon_master.dut.writedata[18] top.tb_avalon_master.dut.writedata[17] top.tb_avalon_master.dut.writedata[16] top.tb_avalon_master.dut.writedata[15] top.tb_avalon_master.dut.writedata[14] top.tb_avalon_master.dut.writedata[13] top.tb_avalon_master.dut.writedata[12] top.tb_avalon_master.dut.writedata[11] top.tb_avalon_master.dut.writedata[10] top.tb_avalon_master.dut.writedata[9] top.tb_avalon_master.dut.writedata[8] top.tb_avalon_master.dut.writedata[7] top.tb_avalon_master.dut.writedata[6] top.tb_avalon_master.dut.writedata[5] top.tb_avalon_master.dut.writedata[4] top.tb_avalon_master.dut.writedata[3] top.tb_avalon_master.dut.writedata[2] top.tb_avalon_master.dut.writedata[1] top.tb_avalon_master.dut.writedata[0]

--- a/vunit/vhdl/verification_components/test/tb_avalon_master.vhd
+++ b/vunit/vhdl/verification_components/test/tb_avalon_master.vhd
@@ -172,13 +172,13 @@ begin
       for i in 0 to tb_cfg.transfers -1 loop
         push(data_queue, std_logic_vector(to_unsigned(i, writedata'length)));
       end loop;
-      write_bus(net, bus_handle, 0, tb_cfg.transfers, data_queue);
+      burst_write_bus(net, bus_handle, 0, tb_cfg.transfers, data_queue);
       check_true(is_empty(data_queue), "wr queue not flushed by master");
 
       info(tb_logger, "Reading...");
-      read_bus(net, bus_handle, 0, tb_cfg.transfers, burst_rd_ref);
+      burst_read_bus(net, bus_handle, 0, tb_cfg.transfers, burst_rd_ref);
       info(tb_logger, "Get reads by references...");
-      await_read_bus_reply(net, bus_handle, data_queue, burst_rd_ref);
+      await_burst_read_bus_reply(net, bus_handle, data_queue, burst_rd_ref);
 
       info(tb_logger, "Compare...");
       for i in 0 to tb_cfg.transfers-1 loop
@@ -193,11 +193,11 @@ begin
       for i in 0 to tb_cfg.transfers -1 loop
         push(data_queue, std_logic_vector(to_unsigned(i, writedata'length)));
       end loop;
-      write_bus(net, bus_handle, 0, tb_cfg.transfers, data_queue);
+      burst_write_bus(net, bus_handle, 0, tb_cfg.transfers, data_queue);
       check_true(is_empty(data_queue), "wr queue not flushed by master");
 
       info(tb_logger, "Reading...");
-      read_bus(net, bus_handle, 0, tb_cfg.transfers, data_queue);
+      burst_read_bus(net, bus_handle, 0, tb_cfg.transfers, data_queue);
 
       info(tb_logger, "Compare...");
       for i in 0 to tb_cfg.transfers-1 loop
@@ -217,7 +217,7 @@ begin
       addr := 0;
       while transfers > 0 loop
         gen_rndburst(rnd, rndburst, transfers);
-        write_bus(net, bus_handle, addr, rndburst, data_queue);
+        burst_write_bus(net, bus_handle, addr, rndburst, data_queue);
         addr := addr + rndburst * byteenable'length;
       end loop;
       check_true(is_empty(data_queue), "wr queue not flushed by master");
@@ -227,7 +227,7 @@ begin
       addr := 0;
       while transfers > 0 loop
         gen_rndburst(rnd, rndburst, transfers);
-        read_bus(net, bus_handle, addr, rndburst, burst_rd_ref);
+        burst_read_bus(net, bus_handle, addr, rndburst, burst_rd_ref);
         push(rd_ref_queue, burst_rd_ref);
         addr := addr + rndburst * byteenable'length;
       end loop;
@@ -235,7 +235,7 @@ begin
       info(tb_logger, "Get reads by references and compre...");
       while not is_empty(rd_ref_queue) loop
         burst_rd_ref := pop(rd_ref_queue);
-        await_read_bus_reply(net, bus_handle, data_queue, burst_rd_ref);
+        await_burst_read_bus_reply(net, bus_handle, data_queue, burst_rd_ref);
         while not is_empty(data_queue) loop
           tmp := pop(data_queue);
           check_equal(tmp, std_logic_vector(to_unsigned(i, readdata'length)), "read data");
@@ -262,21 +262,21 @@ begin
       for i in 1 to tb_cfg.transfers loop
         push(data_queue, std_logic_vector(to_unsigned(i, writedata'length)));
       end loop;
-      write_bus(net, bus_handle, 0, tb_cfg.transfers, data_queue);
+      burst_write_bus(net, bus_handle, 0, tb_cfg.transfers, data_queue);
       wait_until_idle(net, bus_handle);
       wait until rising_edge(clk);
       check_equal(write, '0', "unexpected write after wail till idle");
 
-      read_bus(net, bus_handle, 0, tb_cfg.transfers, data_queue);
+      burst_read_bus(net, bus_handle, 0, tb_cfg.transfers, data_queue);
       wait_until_idle(net, bus_handle);
       wait until rising_edge(clk);
       check_equal(readdatavalid, '0', "unexpected readdatavalid after wail till idle");
 
-      read_bus(net, bus_handle, 0, tb_cfg.transfers, burst_rd_ref);
+      burst_read_bus(net, bus_handle, 0, tb_cfg.transfers, burst_rd_ref);
       wait_until_idle(net, bus_handle);
       wait until rising_edge(clk);
       check_equal(readdatavalid, '0', "unexpected readdatavalid after wail till idle");
-      await_read_bus_reply(net, bus_handle, data_queue, burst_rd_ref);
+      await_burst_read_bus_reply(net, bus_handle, data_queue, burst_rd_ref);
       wait_until_idle(net, bus_handle);
 
     end if;

--- a/vunit/vhdl/verification_components/test/tb_avalon_master.vhd
+++ b/vunit/vhdl/verification_components/test/tb_avalon_master.vhd
@@ -30,19 +30,21 @@ architecture a of tb_avalon_master is
   type tb_cfg_t is record
     data_width : positive;
     addr_width : positive;
-    burstcount : std_logic_vector(0 downto 0);
+    burst_width : positive;
     write_prob : real;
     read_prob : real;
     waitrequest_prob : real;
     readdatavalid_prob : real;
     transfers : positive;
+    rndburst_max : positive;
   end record tb_cfg_t;
 
   impure function decode(encoded_tb_cfg : string) return tb_cfg_t is
   begin
     return (data_width => 32,
             addr_width => 32,
-            burstcount => "1",
+            burst_width => 8,
+            rndburst_max => 3,
             write_prob => real'value(get(encoded_tb_cfg, "write_prob")),
             read_prob => real'value(get(encoded_tb_cfg, "read_prob")),
             waitrequest_prob => real'value(get(encoded_tb_cfg, "waitrequest_prob")),
@@ -58,7 +60,7 @@ architecture a of tb_avalon_master is
   signal writedata  : std_logic_vector(tb_cfg.data_width-1 downto 0);
   signal readdata  : std_logic_vector(tb_cfg.data_width-1 downto 0);
   signal byteenable   : std_logic_vector(tb_cfg.data_width/8 -1 downto 0);
-  signal burstcount : std_logic_vector(tb_cfg.burstcount'range);
+  signal burstcount : std_logic_vector(tb_cfg.burst_width -1 downto 0);
   signal write   : std_logic := '0';
   signal read   : std_logic := '0';
   signal readdatavalid : std_logic := '0';
@@ -66,27 +68,52 @@ architecture a of tb_avalon_master is
 
   constant master_logger : logger_t := get_logger("master");
   constant tb_logger : logger_t := get_logger("tb");
+  constant master_actor : actor_t := new_actor("Avalon-MM Master");
   constant bus_handle : bus_master_t := new_bus(data_length => tb_cfg.data_width,
-      address_length => tb_cfg.addr_width, logger => master_logger);
+      address_length => tb_cfg.addr_width, logger => master_logger,
+      actor => master_actor);
 
   constant memory : memory_t := new_memory;
   constant buf : buffer_t := allocate(memory, tb_cfg.transfers * byteenable'length);
   constant avalon_slave : avalon_slave_t := new_avalon_slave(
     memory => memory,
     readdatavalid_high_probability => tb_cfg.readdatavalid_prob,
-    waitrequest_high_probability => tb_cfg.waitrequest_prob
+    waitrequest_high_probability => tb_cfg.waitrequest_prob,
+    name => "Avalon-MM Slave"
   );
+
+  procedure gen_rndburst(
+    variable rnd : inout RandomPType;
+    variable rndburst : inout positive;
+    variable transfers : inout natural
+  ) is
+  begin
+    rndburst := rnd.RandInt(1, tb_cfg.rndburst_max);
+    if transfers >= rndburst then
+      transfers := transfers - rndburst;
+    else
+      rndburst := transfers;
+      transfers := 0;
+    end if;
+  end procedure;
 
 begin
 
   main_stim : process
     variable tmp : std_logic_vector(writedata'range);
     variable value : std_logic_vector(writedata'range) := (others => '1');
-    variable bus_rd_ref1 : bus_reference_t;
-    variable bus_rd_ref2 : bus_reference_t;
+    variable burst_rd_ref : bus_reference_t;
     type bus_reference_arr_t is array (0 to tb_cfg.transfers-1) of bus_reference_t;
     variable rd_ref : bus_reference_arr_t;
+    constant data_queue : queue_t := new_queue;
+    constant rd_ref_queue : queue_t := new_queue;
+    variable rnd : RandomPType;
+    variable transfers : natural;
+    variable rndburst : positive;
+    variable i : natural;
+    variable addr : natural range 0 to tb_cfg.transfers*byteenable'length;
   begin
+    rnd.InitSeed(rnd'instance_name);
     test_runner_setup(runner, runner_cfg);
     set_format(display_handler, verbose, true);
     show(tb_logger, display_handler, verbose);
@@ -136,6 +163,84 @@ begin
         await_read_bus_reply(net, rd_ref(i), tmp);
         check_equal(tmp, std_logic_vector(to_unsigned(i, readdata'length)), "read data");
       end loop;
+
+
+    elsif run("burst wr and burst rd non-blocking") then
+      info(tb_logger, "Writing...");
+      for i in 0 to tb_cfg.transfers -1 loop
+        push(data_queue, std_logic_vector(to_unsigned(i, writedata'length)));
+      end loop;
+      write_bus(net, bus_handle, 0, tb_cfg.transfers, data_queue);
+      check_true(is_empty(data_queue), "wr queue not flushed by master");
+
+      info(tb_logger, "Reading...");
+      read_bus(net, bus_handle, 0, tb_cfg.transfers, burst_rd_ref);
+      info(tb_logger, "Get reads by references...");
+      await_read_bus_reply(net, bus_handle, data_queue, burst_rd_ref);
+
+      info(tb_logger, "Compare...");
+      for i in 0 to tb_cfg.transfers-1 loop
+        tmp := pop(data_queue);
+        check_equal(tmp, std_logic_vector(to_unsigned(i, readdata'length)), "read data");
+      end loop;
+      check_true(is_empty(data_queue), "rd queue not flushed by master");
+
+
+    elsif run("burst wr and burst rd blocking") then
+      info(tb_logger, "Writing...");
+      for i in 0 to tb_cfg.transfers -1 loop
+        push(data_queue, std_logic_vector(to_unsigned(i, writedata'length)));
+      end loop;
+      write_bus(net, bus_handle, 0, tb_cfg.transfers, data_queue);
+      check_true(is_empty(data_queue), "wr queue not flushed by master");
+
+      info(tb_logger, "Reading...");
+      read_bus(net, bus_handle, 0, tb_cfg.transfers, data_queue);
+
+      info(tb_logger, "Compare...");
+      for i in 0 to tb_cfg.transfers-1 loop
+        tmp := pop(data_queue);
+        check_equal(tmp, std_logic_vector(to_unsigned(i, readdata'length)), "read data");
+      end loop;
+      check_true(is_empty(data_queue), "rd queue not flushed by master");
+
+
+    elsif run("random burstcount") then
+      for i in 0 to tb_cfg.transfers -1 loop
+        push(data_queue, std_logic_vector(to_unsigned(i, writedata'length)));
+      end loop;
+
+      info(tb_logger, "Writing...");
+      transfers := tb_cfg.transfers;
+      addr := 0;
+      while transfers > 0 loop
+        gen_rndburst(rnd, rndburst, transfers);
+        write_bus(net, bus_handle, addr, rndburst, data_queue);
+        addr := addr + rndburst * byteenable'length;
+      end loop;
+      check_true(is_empty(data_queue), "wr queue not flushed by master");
+
+      info(tb_logger, "Reading...");
+      transfers := tb_cfg.transfers;
+      addr := 0;
+      while transfers > 0 loop
+        gen_rndburst(rnd, rndburst, transfers);
+        read_bus(net, bus_handle, addr, rndburst, burst_rd_ref);
+        push(rd_ref_queue, burst_rd_ref);
+        addr := addr + rndburst * byteenable'length;
+      end loop;
+
+      info(tb_logger, "Get reads by references and compre...");
+      while not is_empty(rd_ref_queue) loop
+        burst_rd_ref := pop(rd_ref_queue);
+        await_read_bus_reply(net, bus_handle, data_queue, burst_rd_ref);
+        while not is_empty(data_queue) loop
+          tmp := pop(data_queue);
+          check_equal(tmp, std_logic_vector(to_unsigned(i, readdata'length)), "read data");
+          i := i + 1;
+        end loop;
+      end loop;
+
 
     end if;
 

--- a/vunit/vhdl/verification_components/test/tb_avalon_slave.gtkw
+++ b/vunit/vhdl/verification_components/test/tb_avalon_slave.gtkw
@@ -1,31 +1,30 @@
 [*]
 [*] GTKWave Analyzer v3.3.89 (w)1999-2018 BSI
-[*] Wed Jun 20 12:06:31 2018
+[*] Tue Jul 31 12:25:32 2018
 [*]
-[dumpfile] "/home/slawek/git/github/vunit/vunit/vhdl/verification_components/vunit_out/test_output/vunit_lib.tb_avalon_slave.num_cycles_2,waitrequest_prob_0.0,readdatavalid_prob_1.0,data_width_32.wr_block_rd_block_914b35695f27cc08a5c7b3cc2fedcf9bff3c816f/ghdl/wave.ghw"
-[dumpfile_mtime] "Wed Jun 20 12:06:21 2018"
-[dumpfile_size] 2467
+[dumpfile] "/home/slawek/git/github/vunit/vunit/vhdl/verification_components/vunit_out/test_output/vunit_lib.tb_avalon_slave.num_cycles_2,waitrequest_prob_0.4,readdatavalid_prob_1.0,data_width_32.burst_wr_block_rd_block_65f77a631932f84558fdd96efbd954f322029e05/ghdl/wave.ghw"
+[dumpfile_mtime] "Tue Jul 31 12:22:54 2018"
+[dumpfile_size] 2770
 [savefile] "/home/slawek/git/github/vunit/vunit/vhdl/verification_components/test/tb_avalon_slave.gtkw"
 [timestart] 0
-[size] 1000 600
-[pos] -1 -1
-*-26.000000 100900000 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1
+[size] 1544 794
+[pos] 325 97
+*-26.000000 180000000 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1
 [treeopen] top.
 [treeopen] top.tb_avalon_slave.
 [sst_width] 229
 [signals_width] 269
 [sst_expanded] 1
-[sst_vpaned_height] 285
+[sst_vpaned_height] 425
 @28
 top.tb_avalon_slave.dut_slave.clk
 @22
 #{top.tb_avalon_slave.dut_slave.address[31:0]} top.tb_avalon_slave.dut_slave.address[31] top.tb_avalon_slave.dut_slave.address[30] top.tb_avalon_slave.dut_slave.address[29] top.tb_avalon_slave.dut_slave.address[28] top.tb_avalon_slave.dut_slave.address[27] top.tb_avalon_slave.dut_slave.address[26] top.tb_avalon_slave.dut_slave.address[25] top.tb_avalon_slave.dut_slave.address[24] top.tb_avalon_slave.dut_slave.address[23] top.tb_avalon_slave.dut_slave.address[22] top.tb_avalon_slave.dut_slave.address[21] top.tb_avalon_slave.dut_slave.address[20] top.tb_avalon_slave.dut_slave.address[19] top.tb_avalon_slave.dut_slave.address[18] top.tb_avalon_slave.dut_slave.address[17] top.tb_avalon_slave.dut_slave.address[16] top.tb_avalon_slave.dut_slave.address[15] top.tb_avalon_slave.dut_slave.address[14] top.tb_avalon_slave.dut_slave.address[13] top.tb_avalon_slave.dut_slave.address[12] top.tb_avalon_slave.dut_slave.address[11] top.tb_avalon_slave.dut_slave.address[10] top.tb_avalon_slave.dut_slave.address[9] top.tb_avalon_slave.dut_slave.address[8] top.tb_avalon_slave.dut_slave.address[7] top.tb_avalon_slave.dut_slave.address[6] top.tb_avalon_slave.dut_slave.address[5] top.tb_avalon_slave.dut_slave.address[4] top.tb_avalon_slave.dut_slave.address[3] top.tb_avalon_slave.dut_slave.address[2] top.tb_avalon_slave.dut_slave.address[1] top.tb_avalon_slave.dut_slave.address[0]
 #{top.tb_avalon_slave.dut_slave.byteenable[3:0]} top.tb_avalon_slave.dut_slave.byteenable[3] top.tb_avalon_slave.dut_slave.byteenable[2] top.tb_avalon_slave.dut_slave.byteenable[1] top.tb_avalon_slave.dut_slave.byteenable[0]
+@23
+#{top.tb_avalon_slave.burstcount[7:0]} top.tb_avalon_slave.burstcount[7] top.tb_avalon_slave.burstcount[6] top.tb_avalon_slave.burstcount[5] top.tb_avalon_slave.burstcount[4] top.tb_avalon_slave.burstcount[3] top.tb_avalon_slave.burstcount[2] top.tb_avalon_slave.burstcount[1] top.tb_avalon_slave.burstcount[0]
 @28
-top.tb_avalon_slave.dut_slave.burstcount[0]
-@29
 top.tb_avalon_slave.dut_slave.waitrequest
-@28
 top.tb_avalon_slave.dut_slave.write
 @22
 #{top.tb_avalon_slave.dut_slave.writedata[31:0]} top.tb_avalon_slave.dut_slave.writedata[31] top.tb_avalon_slave.dut_slave.writedata[30] top.tb_avalon_slave.dut_slave.writedata[29] top.tb_avalon_slave.dut_slave.writedata[28] top.tb_avalon_slave.dut_slave.writedata[27] top.tb_avalon_slave.dut_slave.writedata[26] top.tb_avalon_slave.dut_slave.writedata[25] top.tb_avalon_slave.dut_slave.writedata[24] top.tb_avalon_slave.dut_slave.writedata[23] top.tb_avalon_slave.dut_slave.writedata[22] top.tb_avalon_slave.dut_slave.writedata[21] top.tb_avalon_slave.dut_slave.writedata[20] top.tb_avalon_slave.dut_slave.writedata[19] top.tb_avalon_slave.dut_slave.writedata[18] top.tb_avalon_slave.dut_slave.writedata[17] top.tb_avalon_slave.dut_slave.writedata[16] top.tb_avalon_slave.dut_slave.writedata[15] top.tb_avalon_slave.dut_slave.writedata[14] top.tb_avalon_slave.dut_slave.writedata[13] top.tb_avalon_slave.dut_slave.writedata[12] top.tb_avalon_slave.dut_slave.writedata[11] top.tb_avalon_slave.dut_slave.writedata[10] top.tb_avalon_slave.dut_slave.writedata[9] top.tb_avalon_slave.dut_slave.writedata[8] top.tb_avalon_slave.dut_slave.writedata[7] top.tb_avalon_slave.dut_slave.writedata[6] top.tb_avalon_slave.dut_slave.writedata[5] top.tb_avalon_slave.dut_slave.writedata[4] top.tb_avalon_slave.dut_slave.writedata[3] top.tb_avalon_slave.dut_slave.writedata[2] top.tb_avalon_slave.dut_slave.writedata[1] top.tb_avalon_slave.dut_slave.writedata[0]


### PR DESCRIPTION
### Master
For support for burst transfers current bus_master had to be extended and some way of passing multiple data words had to be chosen. I decided to use VUnit queues as it seems the most natural for me. Please comment if somebody see the better options. Currently data words from queue are pushed to bus burst msg, however it is also possible to push queue reference instead of single data chunks.

In bursts transactions byteenable signals is always high - probably need to extend it.

### Slave
Avalon Slave was rewritten - write and read handling is separated.  New implementation does not prevent simultaneous write and read .The another event which should be forbidden is mixed write/read bursts. In general bus monitor should be added to capture and report  such a invalid transactions.