### PR TITLE
Handle sync messages in axi_stream_slave

### DIFF
--- a/vunit/vhdl/verification_components/src/axi_stream_pkg.vhd
+++ b/vunit/vhdl/verification_components/src/axi_stream_pkg.vhd
@@ -127,6 +127,7 @@ package axi_stream_pkg is
   impure function as_stream(master : axi_stream_master_t) return stream_master_t;
   impure function as_stream(slave : axi_stream_slave_t) return stream_slave_t;
   impure function as_sync(master : axi_stream_master_t) return sync_handle_t;
+  impure function as_sync(slave : axi_stream_slave_t) return sync_handle_t;
 
   constant push_axi_stream_msg        : msg_type_t := new_msg_type("push axi stream");
   constant axi_stream_transaction_msg : msg_type_t := new_msg_type("axi stream transaction");
@@ -309,6 +310,11 @@ package body axi_stream_pkg is
   impure function as_sync(master : axi_stream_master_t) return sync_handle_t is
   begin
     return master.p_actor;
+  end;
+
+  impure function as_sync(slave : axi_stream_slave_t) return sync_handle_t is
+  begin
+    return slave.p_actor;
   end;
 
   procedure push_axi_stream(signal net : inout network_t;

--- a/vunit/vhdl/verification_components/src/axi_stream_slave.vhd
+++ b/vunit/vhdl/verification_components/src/axi_stream_slave.vhd
@@ -34,6 +34,8 @@ begin
     receive(net, slave.p_actor, msg);
     msg_type := message_type(msg);
 
+    handle_sync_message(net, msg_type, msg);
+
     if msg_type = stream_pop_msg then
       tready <= '1';
       wait until (tvalid and tready) = '1' and rising_edge(aclk);


### PR DESCRIPTION
Most of these changes are similar to current features in the axi_stream_master.

Added checks that wait_for_time behaves correctly for both master and slave (wasn't currently checked for master).