### PR TITLE
Fix and test wishbone master wait for idle

### DIFF
--- a/vunit/vhdl/verification_components/src/wishbone_master.vhd
+++ b/vunit/vhdl/verification_components/src/wishbone_master.vhd
@@ -98,6 +98,9 @@ begin
         request_msg := null_msg;
 
       elsif msg_type = wait_until_idle_msg then
+        if cycle then
+          wait until not cycle;
+        end if;
         handle_wait_until_idle(net, msg_type, request_msg);
 
       else


### PR DESCRIPTION
I added the wait_for_idle functionality to the wishbone_master with #372, assuming that I can just do the same as the axi master.
However, it doesn't work that simple if you expect that idle is a really idle bus (i.e. CYC=0).

So I added a test and a wait statement. I'm still not sure if it works in all cases due to the split processes for the request and the answer. But I could not trigger further errors...