### PR TITLE
Make axi_stream_master drive X if invalid

### DIFF
--- a/vunit/vhdl/verification_components/src/axi_stream_master.vhd
+++ b/vunit/vhdl/verification_components/src/axi_stream_master.vhd
@@ -16,7 +16,11 @@ use work.sync_pkg.all;
 
 entity axi_stream_master is
   generic (
-    master : axi_stream_master_t);
+    master : axi_stream_master_t;
+    drive_invalid          : boolean   := true;
+    drive_invalid_val      : std_logic := 'X';
+    drive_invalid_val_user : std_logic := '0'
+  );
   port (
     aclk   : in std_logic;
     tvalid : out std_logic                                          := '0';
@@ -28,7 +32,7 @@ entity axi_stream_master is
     tid    : out std_logic_vector(id_length(master)-1 downto 0)     := (others => '0');
     tdest  : out std_logic_vector(dest_length(master)-1 downto 0)   := (others => '0');
     tuser  : out std_logic_vector(user_length(master)-1 downto 0)   := (others => '0')
-    );
+  );
 end entity;
 
 architecture a of axi_stream_master is
@@ -37,6 +41,15 @@ begin
     variable msg : msg_t;
     variable msg_type : msg_type_t;
   begin
+    if drive_invalid then
+      tdata <= (others => drive_invalid_val);
+      tkeep <= (others => drive_invalid_val);
+      tstrb <= (others => drive_invalid_val);
+      tid   <= (others => drive_invalid_val);
+      tdest <= (others => drive_invalid_val);
+      tuser <= (others => drive_invalid_val_user);
+    end if;
+
     receive(net, master.p_actor, msg);
     msg_type := message_type(msg);
 

--- a/vunit/vhdl/verification_components/test/tb_axi_stream.vhd
+++ b/vunit/vhdl/verification_components/test/tb_axi_stream.vhd
@@ -62,6 +62,14 @@ architecture a of tb_axi_stream is
   signal tid      : std_logic_vector(id_length(slave_axi_stream)-1 downto 0);
   signal tdest    : std_logic_vector(dest_length(slave_axi_stream)-1 downto 0);
   signal tuser    : std_logic_vector(user_length(slave_axi_stream)-1 downto 0);
+
+  signal not_valid      : std_logic;
+  signal not_valid_data : std_logic;
+  signal not_valid_keep : std_logic;
+  signal not_valid_strb : std_logic;
+  signal not_valid_id   : std_logic;
+  signal not_valid_dest : std_logic;
+  signal not_valid_user : std_logic;
 begin
 
   main : process
@@ -281,6 +289,21 @@ begin
       tid    => tid,
       tuser  => tuser,
       tdest  => tdest);
+
+ not_valid <= not tvalid;
+
+ not_valid_data <= '1' when tdata = std_logic_vector'("XXXXXXXX") else '0';
+ check_true(aclk, not_valid, not_valid_data, "Invalid data not X");
+ not_valid_keep <= '1' when tkeep = std_logic_vector'("X") else '0';
+ check_true(aclk, not_valid, not_valid_keep, "Invalid keep not X");
+ not_valid_strb <= '1' when tstrb = std_logic_vector'("X") else '0';
+ check_true(aclk, not_valid, not_valid_strb, "Invalid strb not X");
+ not_valid_id   <= '1' when tid   = std_logic_vector'("XXXXXXXX") else '0';
+ check_true(aclk, not_valid, not_valid_id,   "Invalid id not X");
+ not_valid_dest <= '1' when tdest = std_logic_vector'("XXXXXXXX") else '0';
+ check_true(aclk, not_valid, not_valid_dest, "Invalid dest not X");
+ not_valid_user <= '1' when tuser = std_logic_vector'("00000000") else '0';
+ check_true(aclk, not_valid, not_valid_user, "Invalid user not 0");
 
   axi_stream_slave_inst : entity work.axi_stream_slave
     generic map(


### PR DESCRIPTION
This is a somewhat radical change: It makes the axi_stream_master drive X (or as configured by generic) on most signals (tuser is different by ARM spec).

Reasoning: We had a discussion recently among the HDL people in the company about this. It was triggered by a bug, where a streaming block was tested correctly - but it was actually broken. The cause was that the stream source did not drive 100% duty cycle but applied the output value already after the last value was consumed.
The block did not correctly delay the valid signal (not long enough), but due to the early data value, the output was already correct.
The same happens the other way round, what would apply for the axi_stream_master: If the data value is kept after the transaction, a TVALID that is delayed too much would not be detected.

The people here agreed that a test driver must be conservative and actually cancel the data signals on a deactivated valid.
I just implemented this now. Maybe you have a different opinion? Or is there a better solution to this topic?