### PR TITLE
Always use the most up-to-date version of modelsim.ini

### DIFF
--- a/vunit/modelsim_interface.py
+++ b/vunit/modelsim_interface.py
@@ -100,11 +100,8 @@ class ModelSimInterface(VsimSimulatorMixin, SimulatorInterface):  # pylint: disa
 
     def _create_modelsim_ini(self):
         """
-        Create the modelsim.ini file if it does not exist
+        Create the modelsim.ini file
         """
-        if file_exists(self._sim_cfg_file_name):
-            return
-
         parent = dirname(self._sim_cfg_file_name)
         if not file_exists(parent):
             os.makedirs(parent)

--- a/vunit/test/unit/test_modelsim_interface.py
+++ b/vunit/test/unit/test_modelsim_interface.py
@@ -28,11 +28,7 @@ class TestModelSimInterface(unittest.TestCase):
     @mock.patch("vunit.simulator_interface.check_output", autospec=True, return_value="")
     @mock.patch("vunit.modelsim_interface.Process", autospec=True)
     def test_compile_project_vhdl_2008(self, process, check_output):
-        write_file("modelsim.ini", """
-[Library]
-                   """)
-        modelsim_ini = join(self.output_path, "modelsim.ini")
-        simif = ModelSimInterface(prefix="prefix",
+        simif = ModelSimInterface(prefix=self.prefix_path,
                                   output_path=self.output_path,
                                   persistent=False)
         project = Project()
@@ -40,25 +36,17 @@ class TestModelSimInterface(unittest.TestCase):
         write_file("file.vhd", "")
         project.add_source_file("file.vhd", "lib", file_type="vhdl", vhdl_standard="2008")
         simif.compile_project(project)
-        process.assert_called_once_with([join("prefix", "vlib"), "-unix", "lib_path"], env=simif.get_env())
-        check_output.assert_called_once_with(
-            [join('prefix', 'vcom'),
-             '-quiet',
-             '-modelsimini',
-             modelsim_ini,
-             '-2008',
-             '-work',
-             'lib',
-             'file.vhd'], env=simif.get_env())
+        process_args = [join(self.prefix_path, "vlib"), "-unix", "lib_path"]
+        process.assert_called_once_with(process_args, env=simif.get_env())
+        check_args = [join(self.prefix_path, 'vcom'), '-quiet', '-modelsimini',
+                      join(self.output_path, "modelsim.ini"), '-2008',
+                      '-work', 'lib', 'file.vhd']
+        check_output.assert_called_once_with(check_args, env=simif.get_env())
 
     @mock.patch("vunit.simulator_interface.check_output", autospec=True, return_value="")
     @mock.patch("vunit.modelsim_interface.Process", autospec=True)
     def test_compile_project_vhdl_2002(self, process, check_output):
-        write_file("modelsim.ini", """
-[Library]
-                   """)
-        modelsim_ini = join(self.output_path, "modelsim.ini")
-        simif = ModelSimInterface(prefix="prefix",
+        simif = ModelSimInterface(prefix=self.prefix_path,
                                   output_path=self.output_path,
                                   persistent=False)
         project = Project()
@@ -66,25 +54,17 @@ class TestModelSimInterface(unittest.TestCase):
         write_file("file.vhd", "")
         project.add_source_file("file.vhd", "lib", file_type="vhdl", vhdl_standard="2002")
         simif.compile_project(project)
-        process.assert_called_once_with([join("prefix", "vlib"), "-unix", "lib_path"], env=simif.get_env())
-        check_output.assert_called_once_with(
-            [join('prefix', 'vcom'),
-             '-quiet',
-             '-modelsimini',
-             modelsim_ini,
-             '-2002',
-             '-work',
-             'lib',
-             'file.vhd'], env=simif.get_env())
+        process_args = [join(self.prefix_path, "vlib"), "-unix", "lib_path"]
+        process.assert_called_once_with(process_args, env=simif.get_env())
+        check_args = [join(self.prefix_path, 'vcom'), '-quiet', '-modelsimini',
+                      join(self.output_path, "modelsim.ini"), '-2002',
+                      '-work', 'lib', 'file.vhd']
+        check_output.assert_called_once_with(check_args, env=simif.get_env())
 
     @mock.patch("vunit.simulator_interface.check_output", autospec=True, return_value="")
     @mock.patch("vunit.modelsim_interface.Process", autospec=True)
     def test_compile_project_vhdl_93(self, process, check_output):
-        write_file("modelsim.ini", """
-[Library]
-                   """)
-        modelsim_ini = join(self.output_path, "modelsim.ini")
-        simif = ModelSimInterface(prefix="prefix",
+        simif = ModelSimInterface(prefix=self.prefix_path,
                                   output_path=self.output_path,
                                   persistent=False)
         project = Project()
@@ -92,25 +72,17 @@ class TestModelSimInterface(unittest.TestCase):
         write_file("file.vhd", "")
         project.add_source_file("file.vhd", "lib", file_type="vhdl", vhdl_standard="93")
         simif.compile_project(project)
-        process.assert_called_once_with([join("prefix", "vlib"), "-unix", "lib_path"], env=simif.get_env())
-        check_output.assert_called_once_with(
-            [join('prefix', 'vcom'),
-             '-quiet',
-             '-modelsimini',
-             modelsim_ini,
-             '-93',
-             '-work',
-             'lib',
-             'file.vhd'], env=simif.get_env())
+        process_args = [join(self.prefix_path, "vlib"), "-unix", "lib_path"]
+        process.assert_called_once_with(process_args, env=simif.get_env())
+        check_args = [join(self.prefix_path, 'vcom'), '-quiet', '-modelsimini',
+                      join(self.output_path, "modelsim.ini"), '-93',
+                      '-work', 'lib', 'file.vhd']
+        check_output.assert_called_once_with(check_args, env=simif.get_env())
 
     @mock.patch("vunit.simulator_interface.check_output", autospec=True, return_value="")
     @mock.patch("vunit.modelsim_interface.Process", autospec=True)
     def test_compile_project_vhdl_extra_flags(self, process, check_output):
-        write_file("modelsim.ini", """
-[Library]
-                   """)
-        modelsim_ini = join(self.output_path, "modelsim.ini")
-        simif = ModelSimInterface(prefix="prefix",
+        simif = ModelSimInterface(prefix=self.prefix_path,
                                   output_path=self.output_path,
                                   persistent=False)
         project = Project()
@@ -119,17 +91,12 @@ class TestModelSimInterface(unittest.TestCase):
         source_file = project.add_source_file("file.vhd", "lib", file_type="vhdl")
         source_file.set_compile_option("modelsim.vcom_flags", ["custom", "flags"])
         simif.compile_project(project)
-        process.assert_called_once_with([join("prefix", "vlib"), "-unix", "lib_path"], env=simif.get_env())
-        check_output.assert_called_once_with([join('prefix', 'vcom'),
-                                              '-quiet',
-                                              '-modelsimini',
-                                              modelsim_ini,
-                                              'custom',
-                                              'flags',
-                                              '-2008',
-                                              '-work',
-                                              'lib',
-                                              'file.vhd'], env=simif.get_env())
+        process_args = [join(self.prefix_path, "vlib"), "-unix", "lib_path"]
+        process.assert_called_once_with(process_args, env=simif.get_env())
+        check_args = [join(self.prefix_path, 'vcom'), '-quiet', '-modelsimini',
+                      join(self.output_path, "modelsim.ini"), 'custom',
+                      'flags', '-2008', '-work', 'lib', 'file.vhd']
+        check_output.assert_called_once_with(check_args, env=simif.get_env())
 
     @mock.patch("vunit.simulator_interface.check_output", autospec=True, return_value="")
     @mock.patch("vunit.modelsim_interface.Process", autospec=True)
@@ -137,11 +104,7 @@ class TestModelSimInterface(unittest.TestCase):
         for coverage_off in [False, True]:
             check_output.reset_mock()
 
-            write_file("modelsim.ini", """
-[Library]
-                   """)
-            modelsim_ini = join(self.output_path, "modelsim.ini")
-            simif = ModelSimInterface(prefix="prefix",
+            simif = ModelSimInterface(prefix=self.prefix_path,
                                       output_path=self.output_path,
                                       coverage="best",
                                       persistent=False)
@@ -157,24 +120,18 @@ class TestModelSimInterface(unittest.TestCase):
                 covargs = ['+cover=best']
 
             simif.compile_project(project)
-            process.assert_called_once_with([join("prefix", "vlib"), "-unix", "lib_path"], env=simif.get_env())
-            check_output.assert_called_once_with([join('prefix', 'vcom'),
-                                                  '-quiet',
-                                                  '-modelsimini',
-                                                  modelsim_ini] + covargs + [
-                                                      '-2008',
-                                                      '-work',
-                                                      'lib',
-                                                      'file.vhd'], env=simif.get_env())
+            process_args = [join(self.prefix_path, "vlib"), "-unix", "lib_path"]
+            process.assert_called_once_with(process_args, env=simif.get_env())
+            check_args = ([join(self.prefix_path, 'vcom'), '-quiet', '-modelsimini',
+                           join(self.output_path, "modelsim.ini")]
+                          + covargs
+                          + ['-2008', '-work', 'lib', 'file.vhd'])
+            check_output.assert_called_once_with(check_args, env=simif.get_env())
 
     @mock.patch("vunit.simulator_interface.check_output", autospec=True, return_value="")
     @mock.patch("vunit.modelsim_interface.Process", autospec=True)
     def test_compile_project_verilog(self, process, check_output):
-        write_file("modelsim.ini", """
-[Library]
-                   """)
-        modelsim_ini = join(self.output_path, "modelsim.ini")
-        simif = ModelSimInterface(prefix="prefix",
+        simif = ModelSimInterface(prefix=self.prefix_path,
                                   output_path=self.output_path,
                                   persistent=False)
         project = Project()
@@ -182,24 +139,17 @@ class TestModelSimInterface(unittest.TestCase):
         write_file("file.v", "")
         project.add_source_file("file.v", "lib", file_type="verilog")
         simif.compile_project(project)
-        process.assert_called_once_with([join("prefix", "vlib"), "-unix", "lib_path"], env=simif.get_env())
-        check_output.assert_called_once_with([join('prefix', 'vlog'),
-                                              '-quiet',
-                                              '-modelsimini',
-                                              modelsim_ini,
-                                              '-work',
-                                              'lib',
-                                              'file.v',
-                                              '-L', 'lib'], env=simif.get_env())
+        process_args = [join(self.prefix_path, "vlib"), "-unix", "lib_path"]
+        process.assert_called_once_with(process_args, env=simif.get_env())
+        check_args = [join(self.prefix_path, 'vlog'), '-quiet', '-modelsimini',
+                      join(self.output_path, "modelsim.ini"), '-work', 'lib',
+                      'file.v', '-L', 'lib']
+        check_output.assert_called_once_with(check_args, env=simif.get_env())
 
     @mock.patch("vunit.simulator_interface.check_output", autospec=True, return_value="")
     @mock.patch("vunit.modelsim_interface.Process", autospec=True)
     def test_compile_project_system_verilog(self, process, check_output):
-        write_file("modelsim.ini", """
-[Library]
-                   """)
-        modelsim_ini = join(self.output_path, "modelsim.ini")
-        simif = ModelSimInterface(prefix="prefix",
+        simif = ModelSimInterface(prefix=self.prefix_path,
                                   output_path=self.output_path,
                                   persistent=False)
         project = Project()
@@ -207,25 +157,17 @@ class TestModelSimInterface(unittest.TestCase):
         write_file("file.sv", "")
         project.add_source_file("file.sv", "lib", file_type="systemverilog")
         simif.compile_project(project)
-        process.assert_called_once_with([join("prefix", "vlib"), "-unix", "lib_path"], env=simif.get_env())
-        check_output.assert_called_once_with([join('prefix', 'vlog'),
-                                              '-quiet',
-                                              '-modelsimini',
-                                              modelsim_ini,
-                                              '-sv',
-                                              '-work',
-                                              'lib',
-                                              'file.sv',
-                                              '-L', 'lib'], env=simif.get_env())
+        process_args = [join(self.prefix_path, "vlib"), "-unix", "lib_path"]
+        process.assert_called_once_with(process_args, env=simif.get_env())
+        check_args = [join(self.prefix_path, 'vlog'), '-quiet', '-modelsimini',
+                      join(self.output_path, "modelsim.ini"), '-sv',
+                      '-work', 'lib', 'file.sv', '-L', 'lib']
+        check_output.assert_called_once_with(check_args, env=simif.get_env())
 
     @mock.patch("vunit.simulator_interface.check_output", autospec=True, return_value="")
     @mock.patch("vunit.modelsim_interface.Process", autospec=True)
     def test_compile_project_verilog_extra_flags(self, process, check_output):
-        write_file("modelsim.ini", """
-[Library]
-                   """)
-        modelsim_ini = join(self.output_path, "modelsim.ini")
-        simif = ModelSimInterface(prefix="prefix",
+        simif = ModelSimInterface(prefix=self.prefix_path,
                                   output_path=self.output_path,
                                   persistent=False)
         project = Project()
@@ -234,26 +176,17 @@ class TestModelSimInterface(unittest.TestCase):
         source_file = project.add_source_file("file.v", "lib", file_type="verilog")
         source_file.set_compile_option("modelsim.vlog_flags", ["custom", "flags"])
         simif.compile_project(project)
-        process.assert_called_once_with([join("prefix", "vlib"), "-unix", "lib_path"], env=simif.get_env())
-        check_output.assert_called_once_with([join('prefix', 'vlog'),
-                                              '-quiet',
-                                              '-modelsimini',
-                                              modelsim_ini,
-                                              'custom',
-                                              'flags',
-                                              '-work',
-                                              'lib',
-                                              'file.v',
-                                              '-L', 'lib'], env=simif.get_env())
+        process_args = [join(self.prefix_path, "vlib"), "-unix", "lib_path"]
+        process.assert_called_once_with(process_args, env=simif.get_env())
+        check_args = [join(self.prefix_path, 'vlog'), '-quiet', '-modelsimini',
+                      join(self.output_path, "modelsim.ini"), 'custom', 'flags',
+                      '-work', 'lib', 'file.v', '-L', 'lib']
+        check_output.assert_called_once_with(check_args, env=simif.get_env())
 
     @mock.patch("vunit.simulator_interface.check_output", autospec=True, return_value="")
     @mock.patch("vunit.modelsim_interface.Process", autospec=True)
     def test_compile_project_verilog_coverage(self, process, check_output):
-        write_file("modelsim.ini", """
-[Library]
-                   """)
-        modelsim_ini = join(self.output_path, "modelsim.ini")
-        simif = ModelSimInterface(prefix="prefix",
+        simif = ModelSimInterface(prefix=self.prefix_path,
                                   output_path=self.output_path,
                                   coverage="best",
                                   persistent=False)
@@ -262,25 +195,17 @@ class TestModelSimInterface(unittest.TestCase):
         write_file("file.v", "")
         project.add_source_file("file.v", "lib", file_type="verilog")
         simif.compile_project(project)
-        process.assert_called_once_with([join("prefix", "vlib"), "-unix", "lib_path"], env=simif.get_env())
-        check_output.assert_called_once_with([join('prefix', 'vlog'),
-                                              '-quiet',
-                                              '-modelsimini',
-                                              modelsim_ini,
-                                              '+cover=best',
-                                              '-work',
-                                              'lib',
-                                              'file.v',
-                                              '-L', 'lib'], env=simif.get_env())
+        process_args = [join(self.prefix_path, "vlib"), "-unix", "lib_path"]
+        process.assert_called_once_with(process_args, env=simif.get_env())
+        check_args = [join(self.prefix_path, 'vlog'), '-quiet', '-modelsimini',
+                      join(self.output_path, "modelsim.ini"), '+cover=best',
+                      '-work', 'lib', 'file.v', '-L', 'lib']
+        check_output.assert_called_once_with(check_args, env=simif.get_env())
 
     @mock.patch("vunit.simulator_interface.check_output", autospec=True, return_value="")
     @mock.patch("vunit.modelsim_interface.Process", autospec=True)
     def test_compile_project_verilog_include(self, process, check_output):
-        write_file("modelsim.ini", """
-[Library]
-                   """)
-        modelsim_ini = join(self.output_path, "modelsim.ini")
-        simif = ModelSimInterface(prefix="prefix",
+        simif = ModelSimInterface(prefix=self.prefix_path,
                                   output_path=self.output_path,
                                   persistent=False)
         project = Project()
@@ -288,25 +213,17 @@ class TestModelSimInterface(unittest.TestCase):
         write_file("file.v", "")
         project.add_source_file("file.v", "lib", file_type="verilog", include_dirs=["include"])
         simif.compile_project(project)
-        process.assert_called_once_with([join("prefix", "vlib"), "-unix", "lib_path"], env=simif.get_env())
-        check_output.assert_called_once_with([join('prefix', 'vlog'),
-                                              '-quiet',
-                                              '-modelsimini',
-                                              modelsim_ini,
-                                              '-work',
-                                              'lib',
-                                              'file.v',
-                                              '-L', 'lib',
-                                              '+incdir+include'], env=simif.get_env())
+        process_args = [join(self.prefix_path, "vlib"), "-unix", "lib_path"]
+        process.assert_called_once_with(process_args, env=simif.get_env())
+        check_args = [join(self.prefix_path, 'vlog'), '-quiet', '-modelsimini',
+                      join(self.output_path, "modelsim.ini"), '-work', 'lib',
+                      'file.v', '-L', 'lib', '+incdir+include']
+        check_output.assert_called_once_with(check_args, env=simif.get_env())
 
     @mock.patch("vunit.simulator_interface.check_output", autospec=True, return_value="")
     @mock.patch("vunit.modelsim_interface.Process", autospec=True)
     def test_compile_project_verilog_define(self, process, check_output):
-        write_file("modelsim.ini", """
-[Library]
-                   """)
-        modelsim_ini = join(self.output_path, "modelsim.ini")
-        simif = ModelSimInterface(prefix="prefix",
+        simif = ModelSimInterface(prefix=self.prefix_path,
                                   output_path=self.output_path,
                                   persistent=False)
         project = Project()
@@ -314,23 +231,17 @@ class TestModelSimInterface(unittest.TestCase):
         write_file("file.v", "")
         project.add_source_file("file.v", "lib", file_type="verilog", defines={"defname": "defval"})
         simif.compile_project(project)
-        process.assert_called_once_with([join("prefix", "vlib"), "-unix", "lib_path"], env=simif.get_env())
-        check_output.assert_called_once_with([join('prefix', 'vlog'),
-                                              '-quiet',
-                                              '-modelsimini',
-                                              modelsim_ini,
-                                              '-work',
-                                              'lib',
-                                              'file.v',
-                                              '-L', 'lib',
-                                              '+define+defname=defval'], env=simif.get_env())
+        process_args = [join(self.prefix_path, "vlib"), "-unix", "lib_path"]
+        process.assert_called_once_with(process_args, env=simif.get_env())
+        process_args = [join(self.prefix_path, 'vlog'), '-quiet', '-modelsimini',
+                        join(self.output_path, "modelsim.ini"), '-work', 'lib',
+                        'file.v', '-L', 'lib', '+define+defname=defval']
+        check_output.assert_called_once_with(process_args, env=simif.get_env())
 
     def test_copies_modelsim_ini_file_from_install(self):
-        installed_path = join(self.output_path, "prefix")
-        modelsim_ini = join(self.output_path, "modelsim", "modelsim.ini")
-        installed_modelsim_ini = join(self.output_path, "modelsim.ini")
-        user_modelsim_ini = join(self.output_path, "my_modelsim.ini")
-        renew_path(installed_path)
+        modelsim_ini = join(self.output_path, "modelsim.ini")
+        installed_modelsim_ini = join(self.prefix_path, "../modelsim.ini")
+        user_modelsim_ini = join(self.test_path, "my_modelsim.ini")
 
         with open(installed_modelsim_ini, "w") as fptr:
             fptr.write("installed")
@@ -338,18 +249,16 @@ class TestModelSimInterface(unittest.TestCase):
         with open(user_modelsim_ini, "w") as fptr:
             fptr.write("user")
 
-        ModelSimInterface(prefix=join(self.output_path, "prefix"),
-                          output_path=join(self.output_path, "modelsim"),
+        ModelSimInterface(prefix=self.prefix_path,
+                          output_path=self.output_path,
                           persistent=False)
         with open(modelsim_ini, "r") as fptr:
             self.assertEqual(fptr.read(), "installed")
 
     def test_copies_modelsim_ini_file_from_user(self):
-        installed_path = join(self.output_path, "prefix")
-        modelsim_ini = join(self.output_path, "modelsim", "modelsim.ini")
-        installed_modelsim_ini = join(self.output_path, "modelsim.ini")
-        user_modelsim_ini = join(self.output_path, "my_modelsim.ini")
-        renew_path(installed_path)
+        modelsim_ini = join(self.output_path, "modelsim.ini")
+        installed_modelsim_ini = join(self.prefix_path, "../modelsim.ini")
+        user_modelsim_ini = join(self.test_path, "my_modelsim.ini")
 
         with open(installed_modelsim_ini, "w") as fptr:
             fptr.write("installed")
@@ -358,21 +267,69 @@ class TestModelSimInterface(unittest.TestCase):
             fptr.write("user")
 
         with set_env(VUNIT_MODELSIM_INI=user_modelsim_ini):
-            ModelSimInterface(prefix=join(self.output_path, "prefix"),
-                              output_path=join(self.output_path, "modelsim"),
+            ModelSimInterface(prefix=self.prefix_path,
+                              output_path=self.output_path,
+                              persistent=False)
+
+        with open(modelsim_ini, "r") as fptr:
+            self.assertEqual(fptr.read(), "user")
+
+    def test_overwrites_modelsim_ini_file_from_install(self):
+        modelsim_ini = join(self.output_path, "modelsim.ini")
+        installed_modelsim_ini = join(self.prefix_path, "../modelsim.ini")
+        user_modelsim_ini = join(self.test_path, "my_modelsim.ini")
+
+        with open(modelsim_ini, "w") as fptr:
+            fptr.write("existing")
+
+        with open(installed_modelsim_ini, "w") as fptr:
+            fptr.write("installed")
+
+        with open(user_modelsim_ini, "w") as fptr:
+            fptr.write("user")
+
+        ModelSimInterface(prefix=self.prefix_path,
+                          output_path=self.output_path,
+                          persistent=False)
+        with open(modelsim_ini, "r") as fptr:
+            self.assertEqual(fptr.read(), "installed")
+
+    def test_overwrites_modelsim_ini_file_from_user(self):
+        modelsim_ini = join(self.output_path, "modelsim.ini")
+        installed_modelsim_ini = join(self.prefix_path, "../modelsim.ini")
+        user_modelsim_ini = join(self.test_path, "my_modelsim.ini")
+
+        with open(modelsim_ini, "w") as fptr:
+            fptr.write("existing")
+
+        with open(installed_modelsim_ini, "w") as fptr:
+            fptr.write("installed")
+
+        with open(user_modelsim_ini, "w") as fptr:
+            fptr.write("user")
+
+        with set_env(VUNIT_MODELSIM_INI=user_modelsim_ini):
+            ModelSimInterface(prefix=self.prefix_path,
+                              output_path=self.output_path,
                               persistent=False)
 
         with open(modelsim_ini, "r") as fptr:
             self.assertEqual(fptr.read(), "user")
 
     def setUp(self):
-        self.output_path = join(dirname(__file__), "test_modelsim_out")
+        self.test_path = join(dirname(__file__), "test_modelsim_out")
+        self.output_path = join(self.test_path, "modelsim")
+        self.prefix_path = join(self.test_path, "prefix/bin")
+        renew_path(self.test_path)
         renew_path(self.output_path)
+        renew_path(self.prefix_path)
+        installed_modelsim_ini = join(self.prefix_path, "../modelsim.ini")
+        write_file(installed_modelsim_ini, "[Library]")
         self.project = Project()
         self.cwd = os.getcwd()
-        os.chdir(self.output_path)
+        os.chdir(self.test_path)
 
     def tearDown(self):
         os.chdir(self.cwd)
-        if exists(self.output_path):
-            rmtree(self.output_path)
+        if exists(self.test_path):
+            rmtree(self.test_path)


### PR DESCRIPTION
The local copy of modelsim.ini is now re-created on each invocation
of VUnit, to capture any potential updates to VUNIT_MODELSIM_INI.
The unit tests for ModelSimInterface have been updated to eliminate
the expectation that a local modelsim.ini file exits. Instead,
setUp includes the creation of a simulated modelsim environment.
Upon initialization, ModelSimInterface will pull the modelsim.ini
file from this environment, as it would in the real case.

Closes #388 