### PR TITLE
Fix issue with rivierapro not waiting for license before running sim

### DIFF
--- a/vunit/rivierapro_interface.py
+++ b/vunit/rivierapro_interface.py
@@ -257,6 +257,9 @@ proc vunit_load {{}} {{
     # Make the variable 'aldec' visible; otherwise, the Matlab interface
     # is broken because vsim does not find the library aldec_matlab_cosim.
     global aldec
+    # Make the variable 'LICENSE_QUEUE' visible (if set); otherwise vsim
+    # will not wait for simulation licenses.
+    global LICENSE_QUEUE
 
     set vsim_failed [catch {{
         eval vsim {{{vsim_flags}}}


### PR DESCRIPTION
This enables riviera to wait for simulation licenses (such as RIVIERA_VHDL_SIMULATION_LV and RIVIERA_CODECOVERAGE_SUPPORT) between simulations by making the LICENSE_QUEUE variable available to the vunit_load proc.

I've tested and there's no change in behavior if the (tcl variable) LICENSE_QUEUE is not set.

Worth noting is that the LICENSE_QUEUE variable specifies the seconds to wait before asking for a new license, and nothing else, so LICENCE_QUEUE should preferably be set to something like 30 seconds.