### PR TITLE
ghdl_interface: get ghdl executable name from environment variable GHDL.

### DIFF
--- a/vunit/ghdl_interface.py
+++ b/vunit/ghdl_interface.py
@@ -28,6 +28,7 @@ class GHDLInterface(SimulatorInterface):
     """
 
     name = "ghdl"
+    executable = os.environ.get("GHDL", "ghdl")
     supports_gui_flag = True
     supports_colors_in_gui = True
 
@@ -72,7 +73,7 @@ class GHDLInterface(SimulatorInterface):
         """
         Find first valid ghdl toolchain prefix
         """
-        return cls.find_toolchain(["ghdl"])
+        return cls.find_toolchain([cls.executable])
 
     def __init__(self,  # pylint: disable=too-many-arguments
                  output_path, prefix, gui=False, gtkwave_fmt=None, gtkwave_args="", backend="llvm"):
@@ -90,8 +91,8 @@ class GHDLInterface(SimulatorInterface):
         self._backend = backend
         self._vhdl_standard = None
 
-    @staticmethod
-    def determine_backend(prefix):
+    @classmethod
+    def determine_backend(cls, prefix):
         """
         Determine the GHDL backend
         """
@@ -100,7 +101,7 @@ class GHDLInterface(SimulatorInterface):
             "llvm code generator": "llvm",
             "GCC back-end code generator": "gcc"
         }
-        output = subprocess.check_output([join(prefix, "ghdl"), "--version"]).decode()
+        output = subprocess.check_output([join(prefix, cls.executable), "--version"]).decode()
         for name, backend in mapping.items():
             if name in output:
                 LOGGER.debug("Detected GHDL %s", name)
@@ -169,7 +170,7 @@ class GHDLInterface(SimulatorInterface):
         """
         Returns the command to compile a vhdl file
         """
-        cmd = [join(self._prefix, 'ghdl'), '-a', '--workdir=%s' % source_file.library.directory,
+        cmd = [join(self._prefix, self.executable), '-a', '--workdir=%s' % source_file.library.directory,
                '--work=%s' % source_file.library.name,
                '--std=%s' % self._std_str(source_file.get_vhdl_standard())]
         for library in self._project.get_libraries():
@@ -182,7 +183,7 @@ class GHDLInterface(SimulatorInterface):
         """
         Return GHDL simulation command
         """
-        cmd = [join(self._prefix, 'ghdl')]
+        cmd = [join(self._prefix, self.executable)]
         cmd += ['--elab-run']
         cmd += ['--std=%s' % self._std_str(self._vhdl_standard)]
         cmd += ['--work=%s' % config.library_name]


### PR DESCRIPTION
This is for testing with various ghdl back-ends when the executable is not
the canonic one.