### PR TITLE
reset for axi_stream_master

### DIFF
--- a/vunit/vhdl/verification_components/src/axi_stream_master.vhd
+++ b/vunit/vhdl/verification_components/src/axi_stream_master.vhd
@@ -16,28 +16,34 @@ use work.sync_pkg.all;
 
 entity axi_stream_master is
   generic (
-    master : axi_stream_master_t;
+    master                 : axi_stream_master_t;
     drive_invalid          : boolean   := true;
     drive_invalid_val      : std_logic := 'X';
     drive_invalid_val_user : std_logic := '0'
   );
   port (
-    aclk   : in std_logic;
-    tvalid : out std_logic                                          := '0';
-    tready : in std_logic                                           := '1';
-    tdata  : out std_logic_vector(data_length(master)-1 downto 0)   := (others => '0');
-    tlast  : out std_logic                                          := '0';
-    tkeep  : out std_logic_vector(data_length(master)/8-1 downto 0) := (others => '0');
-    tstrb  : out std_logic_vector(data_length(master)/8-1 downto 0) := (others => '0');
-    tid    : out std_logic_vector(id_length(master)-1 downto 0)     := (others => '0');
-    tdest  : out std_logic_vector(dest_length(master)-1 downto 0)   := (others => '0');
-    tuser  : out std_logic_vector(user_length(master)-1 downto 0)   := (others => '0')
+    aclk         : in  std_logic;
+    areset_in_n  : in  std_logic                                          := '1';
+    areset_out_n : out std_logic                                          := '1';
+    tvalid       : out std_logic                                          := '0';
+    tready       : in  std_logic                                          := '1';
+    tdata        : out std_logic_vector(data_length(master)-1 downto 0)   := (others => '0');
+    tlast        : out std_logic                                          := '0';
+    tkeep        : out std_logic_vector(data_length(master)/8-1 downto 0) := (others => '0');
+    tstrb        : out std_logic_vector(data_length(master)/8-1 downto 0) := (others => '0');
+    tid          : out std_logic_vector(id_length(master)-1 downto 0)     := (others => '0');
+    tdest        : out std_logic_vector(dest_length(master)-1 downto 0)   := (others => '0');
+    tuser        : out std_logic_vector(user_length(master)-1 downto 0)   := (others => '0')
   );
 end entity;
 
 architecture a of axi_stream_master is
-   constant message_queue : queue_t := new_queue;
+
+   signal notify_bus_process_done : std_logic := '0';
+   constant message_queue         : queue_t   := new_queue;
+
 begin
+
   main : process
     variable request_msg : msg_t;
     variable msg_type    : msg_type_t;
@@ -47,10 +53,12 @@ begin
 
     if msg_type = stream_push_msg or msg_type = push_axi_stream_msg then
       push(message_queue, request_msg);
+    elsif msg_type = axi_stream_reset_msg then
+      push(message_queue, request_msg);
     elsif msg_type = wait_for_time_msg then
       push(message_queue, request_msg);
     elsif msg_type = wait_until_idle_msg then
-      wait until tvalid = '0' and is_empty(message_queue) and rising_edge(aclk);
+      wait on notify_bus_process_done until is_empty(message_queue);
       handle_wait_until_idle(net, msg_type, request_msg);
     else
       unexpected_msg_type(msg_type);
@@ -60,6 +68,7 @@ begin
   bus_process : process
     variable msg : msg_t;
     variable msg_type : msg_type_t;
+    variable reset_cycles : positive := 1;
   begin
     if drive_invalid then
       tdata <= (others => drive_invalid_val);
@@ -71,49 +80,64 @@ begin
     end if;
 
     -- Wait for messages to arrive on the queue, posted by the process above
-    wait until rising_edge(aclk) and not is_empty(message_queue);
+    wait until rising_edge(aclk) and (not is_empty(message_queue) or areset_in_n = '0');
 
-    while not is_empty(message_queue) loop
+    if (areset_in_n = '0') then
+      tvalid <= '0';
+    else
+      while not is_empty(message_queue) loop
+        msg := pop(message_queue);
+        msg_type := message_type(msg);
 
-      msg := pop(message_queue);
-      msg_type := message_type(msg);
+        if msg_type = wait_for_time_msg then
+          handle_sync_message(net, msg_type, msg);
+          -- Re-align with the clock when a wait for time message was handled, because this breaks edge alignment.
+          wait until rising_edge(aclk);
+        elsif msg_type = axi_stream_reset_msg then
+          reset_cycles := pop(msg);
+          areset_out_n <= '0';
+          tvalid       <= '0';
+          for I in 0 to reset_cycles - 1 loop
+            wait until rising_edge(aclk);
+          end loop;
+          areset_out_n <= '1';
 
-      if msg_type = wait_for_time_msg then
-        handle_sync_message(net, msg_type, msg);
-        -- Re-align with the clock when a wait for time message was handled, because this breaks edge alignment.
-        wait until rising_edge(aclk);
-      elsif msg_type = stream_push_msg or msg_type = push_axi_stream_msg then
-        tvalid <= '1';
-        tdata <= pop_std_ulogic_vector(msg);
-        if msg_type = push_axi_stream_msg then
-          tlast <= pop_std_ulogic(msg);
-          tkeep <= pop_std_ulogic_vector(msg);
-          tstrb <= pop_std_ulogic_vector(msg);
-          tid <= pop_std_ulogic_vector(msg);
-          tdest <= pop_std_ulogic_vector(msg);
-          tuser <= pop_std_ulogic_vector(msg);
-        else
-          if pop_boolean(msg) then
-            tlast <= '1';
+        elsif msg_type = stream_push_msg or msg_type = push_axi_stream_msg then
+          tvalid <= '1';
+          tdata <= pop_std_ulogic_vector(msg);
+          if msg_type = push_axi_stream_msg then
+            tlast <= pop_std_ulogic(msg);
+            tkeep <= pop_std_ulogic_vector(msg);
+            tstrb <= pop_std_ulogic_vector(msg);
+            tid <= pop_std_ulogic_vector(msg);
+            tdest <= pop_std_ulogic_vector(msg);
+            tuser <= pop_std_ulogic_vector(msg);
           else
-            tlast <= '0';
+            if pop_boolean(msg) then
+              tlast <= '1';
+            else
+              tlast <= '0';
+            end if;
+            tkeep <= (others => '1');
+            tstrb <= (others => '1');
+            tid   <= (others => '0');
+            tdest <= (others => '0');
+            tuser <= (others => '0');
           end if;
-          tkeep <= (others => '1');
-          tstrb <= (others => '1');
-          tid   <= (others => '0');
-          tdest <= (others => '0');
-          tuser <= (others => '0');
+          wait until ((tvalid and tready) = '1' or areset_in_n = '0') and rising_edge(aclk);
+          tvalid <= '0';
+          tlast <= '0';
+        else
+          unexpected_msg_type(msg_type);
         end if;
-        wait until (tvalid and tready) = '1' and rising_edge(aclk);
-        tvalid <= '0';
-        tlast <= '0';
-      else
-        unexpected_msg_type(msg_type);
-      end if;
 
-      delete(msg);
-    end loop;
+        delete(msg);
+      end loop;
 
+      notify_bus_process_done <= '1';
+      wait until notify_bus_process_done = '1';
+      notify_bus_process_done <= '0';
+    end if;
   end process;
 
   axi_stream_monitor_generate : if master.p_monitor /= null_axi_stream_monitor generate
@@ -141,7 +165,7 @@ begin
         protocol_checker => master.p_protocol_checker)
       port map (
         aclk     => aclk,
-        areset_n => open,
+        areset_n => areset_in_n,
         tvalid   => tvalid,
         tready   => tready,
         tdata    => tdata,

--- a/vunit/vhdl/verification_components/src/axi_stream_pkg.vhd
+++ b/vunit/vhdl/verification_components/src/axi_stream_pkg.vhd
@@ -184,6 +184,7 @@ package axi_stream_pkg is
   constant push_axi_stream_msg : msg_type_t := new_msg_type("push axi stream");
   constant pop_axi_stream_msg : msg_type_t := new_msg_type("pop axi stream");
   constant axi_stream_transaction_msg : msg_type_t := new_msg_type("axi stream transaction");
+  constant axi_stream_reset_msg : msg_type_t := new_msg_type("axi stream reset");
 
   alias axi_stream_reference_t is msg_t;
 
@@ -282,6 +283,12 @@ package axi_stream_pkg is
     variable msg_type        : inout msg_type_t;
     variable msg             : inout msg_t;
     variable axi_transaction : out axi_stream_transaction_t);
+
+  procedure axi_stream_reset(
+    signal net       : inout network_t;
+    axi_stream       : axi_stream_master_t;
+    number_of_cycles : positive := 1
+  );
 
 end package;
 
@@ -742,6 +749,16 @@ package body axi_stream_pkg is
 
       pop_axi_stream_transaction(msg, axi_transaction);
     end if;
+  end;
+
+  procedure axi_stream_reset(
+    signal net       : inout network_t;
+    axi_stream       : axi_stream_master_t;
+    number_of_cycles : positive := 1        ) is
+    variable msg : msg_t := new_msg(axi_stream_reset_msg);
+  begin
+    push(msg, number_of_cycles);
+    send(net, axi_stream.p_actor, msg);
   end;
 
 end package body;

--- a/vunit/vhdl/verification_components/src/axi_stream_pkg.vhd
+++ b/vunit/vhdl/verification_components/src/axi_stream_pkg.vhd
@@ -184,7 +184,6 @@ package axi_stream_pkg is
   constant push_axi_stream_msg : msg_type_t := new_msg_type("push axi stream");
   constant pop_axi_stream_msg : msg_type_t := new_msg_type("pop axi stream");
   constant axi_stream_transaction_msg : msg_type_t := new_msg_type("axi stream transaction");
-  constant axi_stream_reset_msg : msg_type_t := new_msg_type("axi stream reset");
 
   alias axi_stream_reference_t is msg_t;
 
@@ -283,12 +282,6 @@ package axi_stream_pkg is
     variable msg_type        : inout msg_type_t;
     variable msg             : inout msg_t;
     variable axi_transaction : out axi_stream_transaction_t);
-
-  procedure axi_stream_reset(
-    signal net       : inout network_t;
-    axi_stream       : axi_stream_master_t;
-    number_of_cycles : positive := 1
-  );
 
 end package;
 
@@ -749,16 +742,6 @@ package body axi_stream_pkg is
 
       pop_axi_stream_transaction(msg, axi_transaction);
     end if;
-  end;
-
-  procedure axi_stream_reset(
-    signal net       : inout network_t;
-    axi_stream       : axi_stream_master_t;
-    number_of_cycles : positive := 1        ) is
-    variable msg : msg_t := new_msg(axi_stream_reset_msg);
-  begin
-    push(msg, number_of_cycles);
-    send(net, axi_stream.p_actor, msg);
   end;
 
 end package body;

--- a/vunit/vhdl/verification_components/src/axi_stream_slave.vhd
+++ b/vunit/vhdl/verification_components/src/axi_stream_slave.vhd
@@ -17,16 +17,17 @@ entity axi_stream_slave is
   generic (
     slave : axi_stream_slave_t);
   port (
-    aclk   : in std_logic;
-    tvalid : in std_logic;
-    tready : out std_logic := '0';
-    tdata  : in std_logic_vector(data_length(slave)-1 downto 0);
-    tlast  : in std_logic                                         := '1';
-    tkeep  : in std_logic_vector(data_length(slave)/8-1 downto 0) := (others => '0');
-    tstrb  : in std_logic_vector(data_length(slave)/8-1 downto 0) := (others => '0');
-    tid    : in std_logic_vector(id_length(slave)-1 downto 0)     := (others => '0');
-    tdest  : in std_logic_vector(dest_length(slave)-1 downto 0)   := (others => '0');
-    tuser  : in std_logic_vector(user_length(slave)-1 downto 0)   := (others => '0')
+    aclk     : in std_logic;
+    areset_n : in std_logic  := '1';
+    tvalid   : in std_logic;
+    tready   : out std_logic := '0';
+    tdata    : in std_logic_vector(data_length(slave)-1 downto 0);
+    tlast    : in std_logic                                         := '1';
+    tkeep    : in std_logic_vector(data_length(slave)/8-1 downto 0) := (others => '0');
+    tstrb    : in std_logic_vector(data_length(slave)/8-1 downto 0) := (others => '0');
+    tid      : in std_logic_vector(id_length(slave)-1 downto 0)     := (others => '0');
+    tdest    : in std_logic_vector(dest_length(slave)-1 downto 0)   := (others => '0');
+    tuser    : in std_logic_vector(user_length(slave)-1 downto 0)   := (others => '0')
  );
 end entity;
 
@@ -98,7 +99,7 @@ begin
         protocol_checker => slave.p_protocol_checker)
       port map (
         aclk     => aclk,
-        areset_n => open,
+        areset_n => areset_n,
         tvalid   => tvalid,
         tready   => tready,
         tdata    => tdata,

--- a/vunit/vhdl/verification_components/test/tb_axi_stream.vhd
+++ b/vunit/vhdl/verification_components/test/tb_axi_stream.vhd
@@ -51,20 +51,17 @@ architecture a of tb_axi_stream is
 
   constant n_monitors : natural := 3;
 
-  signal aclk          : std_logic := '0';
-  signal areset_n      : std_logic := '1';
-  signal areset_out_n  : std_logic := '1';
-  signal areset_sel    : std_logic := '0';
-  signal areset_ext_n  : std_logic := '1';
-  signal tvalid        : std_logic;
-  signal tready        : std_logic;
-  signal tdata         : std_logic_vector(data_length(slave_axi_stream)-1 downto 0);
-  signal tlast         : std_logic;
-  signal tkeep         : std_logic_vector(data_length(slave_axi_stream)/8-1 downto 0);
-  signal tstrb         : std_logic_vector(data_length(slave_axi_stream)/8-1 downto 0);
-  signal tid           : std_logic_vector(id_length(slave_axi_stream)-1 downto 0);
-  signal tdest         : std_logic_vector(dest_length(slave_axi_stream)-1 downto 0);
-  signal tuser         : std_logic_vector(user_length(slave_axi_stream)-1 downto 0);
+  signal aclk     : std_logic := '0';
+  signal areset_n : std_logic := '1';
+  signal tvalid   : std_logic;
+  signal tready   : std_logic;
+  signal tdata    : std_logic_vector(data_length(slave_axi_stream)-1 downto 0);
+  signal tlast    : std_logic;
+  signal tkeep    : std_logic_vector(data_length(slave_axi_stream)/8-1 downto 0);
+  signal tstrb    : std_logic_vector(data_length(slave_axi_stream)/8-1 downto 0);
+  signal tid      : std_logic_vector(id_length(slave_axi_stream)-1 downto 0);
+  signal tdest    : std_logic_vector(dest_length(slave_axi_stream)-1 downto 0);
+  signal tuser    : std_logic_vector(user_length(slave_axi_stream)-1 downto 0);
 
   signal not_valid      : std_logic;
   signal not_valid_data : std_logic;
@@ -137,23 +134,13 @@ begin
         );
         check_true(axi_stream_transaction.tlast, result("for axi_stream_transaction.tlast"));
       end loop;
-    elsif run("test resets") then
-      areset_sel   <= '0';
+    elsif run("test reset") then
       wait until rising_edge(aclk);
-      areset_ext_n <= '0';
+      areset_n <= '0';
       wait until rising_edge(aclk);
-      check_equal(tvalid, '0', result("for valid check while in reset"));
-      areset_ext_n <= '1';
+      check_equal(tvalid, '0', result("for valid low check while in reset"));
+      areset_n <= '1';
       wait until rising_edge(aclk);
-      areset_sel   <= '1';
-      wait until rising_edge(aclk);
-      areset_ext_n <= '0';
-      wait until rising_edge(aclk);
-      axi_stream_reset(net, master_axi_stream, 3);
-      timestamp := now;
-      wait_until_idle(net, master_sync);
-      check_equal(now - 10 ns, timestamp + 30 ns, result("for reset time"));
-      check_equal(tvalid, '0', result("for valid check while in reset"));
 
     elsif run("test single push and pop with tlast") then
       push_stream(net, master_stream, x"88", true);
@@ -327,35 +314,32 @@ begin
     generic map(
       master => master_axi_stream)
     port map(
-      aclk         => aclk,
-      areset_in_n  => areset_n,
-      areset_out_n => areset_out_n,
-      tvalid       => tvalid,
-      tready       => tready,
-      tdata        => tdata,
-      tlast        => tlast,
-      tkeep        => tkeep,
-      tstrb        => tstrb,
-      tid          => tid,
-      tuser        => tuser,
-      tdest        => tdest);
+      aclk     => aclk,
+      areset_n => areset_n,
+      tvalid   => tvalid,
+      tready   => tready,
+      tdata    => tdata,
+      tlast    => tlast,
+      tkeep    => tkeep,
+      tstrb    => tstrb,
+      tid      => tid,
+      tuser    => tuser,
+      tdest    => tdest);
 
-  areset_n  <= areset_out_n when areset_sel = '1' else areset_ext_n;
+ not_valid <= not tvalid;
 
-  not_valid <= not tvalid;
-
-  not_valid_data <= '1' when tdata = std_logic_vector'("XXXXXXXX") else '0';
-  check_true(aclk, not_valid, not_valid_data, "Invalid data not X");
-  not_valid_keep <= '1' when tkeep = std_logic_vector'("X") else '0';
-  check_true(aclk, not_valid, not_valid_keep, "Invalid keep not X");
-  not_valid_strb <= '1' when tstrb = std_logic_vector'("X") else '0';
-  check_true(aclk, not_valid, not_valid_strb, "Invalid strb not X");
-  not_valid_id   <= '1' when tid   = std_logic_vector'("XXXXXXXX") else '0';
-  check_true(aclk, not_valid, not_valid_id,   "Invalid id not X");
-  not_valid_dest <= '1' when tdest = std_logic_vector'("XXXXXXXX") else '0';
-  check_true(aclk, not_valid, not_valid_dest, "Invalid dest not X");
-  not_valid_user <= '1' when tuser = std_logic_vector'("00000000") else '0';
-  check_true(aclk, not_valid, not_valid_user, "Invalid user not 0");
+ not_valid_data <= '1' when tdata = std_logic_vector'("XXXXXXXX") else '0';
+ check_true(aclk, not_valid, not_valid_data, "Invalid data not X");
+ not_valid_keep <= '1' when tkeep = std_logic_vector'("X") else '0';
+ check_true(aclk, not_valid, not_valid_keep, "Invalid keep not X");
+ not_valid_strb <= '1' when tstrb = std_logic_vector'("X") else '0';
+ check_true(aclk, not_valid, not_valid_strb, "Invalid strb not X");
+ not_valid_id   <= '1' when tid   = std_logic_vector'("XXXXXXXX") else '0';
+ check_true(aclk, not_valid, not_valid_id,   "Invalid id not X");
+ not_valid_dest <= '1' when tdest = std_logic_vector'("XXXXXXXX") else '0';
+ check_true(aclk, not_valid, not_valid_dest, "Invalid dest not X");
+ not_valid_user <= '1' when tuser = std_logic_vector'("00000000") else '0';
+ check_true(aclk, not_valid, not_valid_user, "Invalid user not 0");
 
   axi_stream_slave_inst : entity work.axi_stream_slave
     generic map(


### PR DESCRIPTION
added reset output to use when the axi_stream_master is generating the reset.
changed wait until idle construction to use a notify from the bus process so that we are sure all transactions (including the reset) have been handled.
added checking of reset input on places where it is required so that a reset is handled properly in the master.
added axi_stream_reset to vci.
added reset input to axi_stream_slave.vhd.
added basic test for reset functionality.