### PR TITLE
Fix bug when deleting envelopes in com_messenger.vhd

### DIFF
--- a/vunit/vhdl/com/src/com_messenger.vhd
+++ b/vunit/vhdl/com/src/com_messenger.vhd
@@ -910,8 +910,8 @@ package body com_messenger_pkg is
         mailbox.first_envelope := envelope.next_envelope;
       end if;
 
-      if mailbox.first_envelope = null then
-        mailbox.last_envelope := null;
+      if envelope.next_envelope = null then
+        mailbox.last_envelope := previous_envelope;
       end if;
 
       deallocate_envelope(envelope);


### PR DESCRIPTION
When deleting an envelope, the mailbox linked list is not updated
correctly. The last_envelope pointer is updated only if the linked
list is completely empty after deletion. However, it is not updated
if the last envelope is deleted but other envelopes still exist.
This leaves the last_envelope pointer hanging and pointing to a
deallocated envelope.

This update corrects the mistake.