### PR TITLE
Add support for configuration attributes

### DIFF
--- a/docs/python_interface.rst
+++ b/docs/python_interface.rst
@@ -13,11 +13,15 @@ The Python interface of VUnit is exposed through the :class:`VUnit
 
 Attributes
 ----------
-The user may set custom attributes on test cases via comments. The
-attributes can for example be used to achieve requirements
-trace-ability. The attributes are exported in the :ref:`JSON Export
-<json_export>`. All user defined attributes must start with a dot
-(``.``) as non-dot attributes are reserved for built-in attributes.
+The user may set custom attributes on test cases via comments or via the
+``set_attribute`` method. The attributes can for example be used to achieve
+requirements trace-ability. The attributes are exported in the
+:ref:`JSON Export <json_export>`. All user defined attributes must start
+with a dot (``.``) as non-dot attributes are reserved for built-in
+attributes.
+
+Attributes set via the python interface will effectively overwrite the value
+of a user attribute set via code comments.
 
 Example
 <<<<<<<
@@ -38,10 +42,19 @@ Example
         end
     end
 
+
+.. code-block:: python
+   :caption: Python Example
+
+   my_test.set_attribute(".requirement-117", None)
+
+
 .. code-block:: json
    :caption: JSON Export has attributes attached to each test. The
-             attributes all have null value to be forward compatible
-             in a future where user attributes can have values.
+             attributes added via comments all have null value to be
+             forward compatible in a future where user attributes can
+             have values. Attributes set via python can have basic type
+             values.
 
     {
        "attributes": {

--- a/vunit/test/unit/test_configuration.py
+++ b/vunit/test/unit/test_configuration.py
@@ -14,7 +14,8 @@ Tests the test test_bench module
 import unittest
 import contextlib
 from os.path import join
-from vunit.configuration import Configuration
+from vunit.configuration import (Configuration,
+                                 AttributeException)
 from vunit.test.mock_2or3 import mock
 from vunit.test.common import (with_tempdir,
                                create_tempdir)
@@ -66,6 +67,18 @@ class TestConfiguration(unittest.TestCase):
         design_unit_tb_path.generic_names = ["runner_cfg", "tb_path"]
         config_tb_path = Configuration('name', design_unit_tb_path)
         self.assertEqual(config_tb_path.generics["tb_path"], (tb_path + "/").replace("\\", "/"))
+
+    def test_constructor_adds_no_attributes(self):
+        with _create_config() as config:
+            self.assertEqual({}, config.attributes)
+
+    def test_constructor_adds_supplied_attributes(self):
+        with _create_config(attributes={"foo": "bar"}) as config:
+            self.assertEqual({"foo": "bar"}, config.attributes)
+
+    def test_set_attribute_must_start_with_dot(self):
+        with _create_config() as config:
+            self.assertRaises(AttributeException, config.set_attribute, "foo", "bar")
 
     def test_call_post_check_none(self):
         self.assertEqual(self._call_post_check(None, output_path="output_path", read_output=None), True)

--- a/vunit/test/unit/test_test_bench.py
+++ b/vunit/test/unit/test_test_bench.py
@@ -25,6 +25,7 @@ from vunit.test_bench import (TestBench,
                               FileLocation,
                               Attribute,
                               LegacyAttribute)
+from vunit.configuration import AttributeException
 from vunit.ostools import write_file
 from vunit.test.mock_2or3 import mock
 from vunit.test.common import (with_tempdir,
@@ -288,7 +289,11 @@ if run("Test_2")
                               generics=dict(value=1,
                                             global_value="local value"))
         test_bench.add_config(name="value=2",
-                              generics=dict(value=2))
+                              generics=dict(value=2),
+                              attributes={".foo": "bar"})
+
+        self.assertRaises(AttributeException, test_bench.add_config, name="c3",
+                          attributes={"foo", "bar"})
 
         tests = self.create_tests(test_bench)
         self.assert_has_tests(tests, ["lib.tb_entity.value=1",
@@ -296,8 +301,12 @@ if run("Test_2")
 
         self.assertEqual(get_config_of(tests, "lib.tb_entity.value=1").generics,
                          {"value": 1, "global_value": "local value"})
+        self.assertEqual(get_config_of(tests, "lib.tb_entity.value=1").attributes,
+                         {})
         self.assertEqual(get_config_of(tests, "lib.tb_entity.value=2").generics,
                          {"value": 2, "global_value": "global value"})
+        self.assertEqual(get_config_of(tests, "lib.tb_entity.value=2").attributes,
+                         {".foo": "bar"})
 
     @with_tempdir
     def test_test_case_add_config(self, tempdir):
@@ -318,7 +327,11 @@ if run("test 2")
                                            global_value="local value"))
         test_case.add_config(name="c2",
                              generics=dict(value=2),
-                             sim_options=dict(disable_ieee_warnings=False))
+                             sim_options=dict(disable_ieee_warnings=False),
+                             attributes={".foo": "bar"})
+
+        self.assertRaises(AttributeException, test_case.add_config, name="c3",
+                          attributes={"foo", "bar"})
 
         tests = self.create_tests(test_bench)
         self.assert_has_tests(tests, ["lib.tb_entity.test 1",
@@ -330,8 +343,12 @@ if run("test 2")
         config_c2_test2 = get_config_of(tests, "lib.tb_entity.c2.test 2")
         self.assertEqual(config_test1.generics,
                          {"global_value": "global value"})
+        self.assertEqual(config_c1_test2.attributes,
+                         {})
         self.assertEqual(config_c1_test2.generics,
                          {"value": 1, "global_value": "local value"})
+        self.assertEqual(config_c2_test2.attributes,
+                         {".foo": "bar"})
         self.assertEqual(config_c2_test2.generics,
                          {"value": 2, "global_value": "global value"})
 

--- a/vunit/test/unit/test_ui.py
+++ b/vunit/test/unit/test_ui.py
@@ -415,13 +415,15 @@ Listed 2 files""".splitlines()))
             lib = ui.add_library("lib")
             file_name = join(tempdir, "tb_filter.vhd")
             create_vhdl_test_bench_file("tb_filter", file_name,
-                                        tests=["Test 1", "Test 2", "Test 3"],
+                                        tests=["Test 1", "Test 2", "Test 3", "Test 4"],
                                         test_attributes={
                                             "Test 1": [".attr0"],
                                             "Test 2": [".attr0", ".attr1"],
-                                            "Test 3": [".attr1"]
+                                            "Test 3": [".attr1"],
+                                            "Test 4": []
                                         })
             lib.add_source_file(file_name)
+            lib.test_bench("tb_filter").test("Test 4").set_attribute(".attr2", None)
 
         def check_stdout(ui, expected):
             " Check that stdout matches expected "
@@ -443,7 +445,8 @@ Listed 2 files""".splitlines()))
                      "lib.tb_filter.Test 1\n"
                      "lib.tb_filter.Test 2\n"
                      "lib.tb_filter.Test 3\n"
-                     "Listed 3 tests")
+                     "lib.tb_filter.Test 4\n"
+                     "Listed 4 tests")
 
         ui = self._create_ui("--list", "*2*")
         setup(ui)
@@ -458,6 +461,12 @@ Listed 2 files""".splitlines()))
                      "lib.tb_filter.Test 2\n"
                      "Listed 2 tests")
 
+        ui = self._create_ui("--list", "--with-attribute=.attr2")
+        setup(ui)
+        check_stdout(ui,
+                     "lib.tb_filter.Test 4\n"
+                     "Listed 1 tests")
+
         ui = self._create_ui("--list", "--with-attributes", ".attr0", "--with-attributes", ".attr1")
         setup(ui)
         check_stdout(ui,
@@ -468,12 +477,14 @@ Listed 2 files""".splitlines()))
         setup(ui)
         check_stdout(ui,
                      "lib.tb_filter.Test 3\n"
-                     "Listed 1 tests")
+                     "lib.tb_filter.Test 4\n"
+                     "Listed 2 tests")
 
         ui = self._create_ui("--list", "--without-attributes", ".attr0", "--without-attributes", ".attr1")
         setup(ui)
         check_stdout(ui,
-                     "Listed 0 tests")
+                     "lib.tb_filter.Test 4\n"
+                     "Listed 1 tests")
 
         ui = self._create_ui("--list",
                              "--with-attributes", ".attr0",
@@ -500,6 +511,7 @@ Listed 2 files""".splitlines()))
                                     tests=["Test one", "Test two"],
                                     test_attributes={"Test one": [".attr0"]})
         lib2.add_source_file(file_name2)
+        lib2.test_bench("tb_bar").set_attribute(".attr1", "bar")
 
         self._run_main(ui)
 
@@ -529,9 +541,9 @@ Listed 2 files""".splitlines()))
                          {"lib1.tb_foo.all": ({"file_name": file_name1, "offset": 180, "length": 18},
                                               {}),
                           "lib2.tb_bar.Test one": ({"file_name": file_name2, "offset": 235, "length": 8},
-                                                   {".attr0": None}),
+                                                   {".attr0": None, ".attr1": "bar"}),
                           "lib2.tb_bar.Test two": ({"file_name": file_name2, "offset": 283, "length": 8},
-                                                   {})})
+                                                   {".attr1": "bar"})})
 
     def test_library_attributes(self):
         ui = self._create_ui()

--- a/vunit/test_list.py
+++ b/vunit/test_list.py
@@ -81,12 +81,18 @@ class TestSuiteWrapper(object):
         return self._test_case.name
 
     @property
+    def test_configuration(self):
+        return {self.name: self._test_case.test_configuration}
+
+    @property
     def test_information(self):
         return {self.name: self._test_case.test_information}
 
     def keep_matches(self, test_filter):
+        attributes = self._test_case.attribute_names.copy()
+        attributes.update(set(self._test_case.test_configuration.attributes.keys()))
         return test_filter(name=self._test_case.name,
-                           attribute_names=self._test_case.attribute_names)
+                           attribute_names=attributes)
 
     def run(self, *args, **kwargs):
         """

--- a/vunit/test_suites.py
+++ b/vunit/test_suites.py
@@ -30,6 +30,8 @@ class IndependentSimTestCase(object):
             # JUnit XML test reports wants three dotted name hierarchies
             self._name += ".all"
 
+        self._configuration = config
+
         self._test = test
 
         self._run = TestRun(simulator_if=simulator_if,
@@ -45,6 +47,10 @@ class IndependentSimTestCase(object):
     @property
     def attribute_names(self):
         return self._test.attribute_names
+
+    @property
+    def test_configuration(self):
+        return self._configuration
 
     @property
     def test_information(self):
@@ -71,6 +77,8 @@ class SameSimTestSuite(object):
 
         if not config.is_default:
             self._name += "." + config.name
+
+        self._configuration = config
 
         self._tests = tests
         self._run = TestRun(simulator_if=simulator_if,
@@ -100,9 +108,15 @@ class SameSimTestSuite(object):
         """
         Keep tests which pattern return False if no remaining tests
         """
+        def _merge_attributes(attribute_names, attributes):
+            merged_attributes = attribute_names.copy()
+            merged_attributes.update(set(attributes.keys()))
+            return merged_attributes
+
         self._tests = [test for test in self._tests
                        if test_filter(name=_full_name(self.name, test.name),
-                                      attribute_names=test.attribute_names)]
+                                      attribute_names=_merge_attributes(test.attribute_names,
+                                                                        self._configuration.attributes))]
         self._run.set_test_cases([test.name for test in self._tests])
         return len(self._tests) > 0
 


### PR DESCRIPTION
Adds the ability to attach an attribute dictionary to a test or
testbench configuration.
These attributes are exported to json when --export-json is supplied to
the python runner.