### PR TITLE
Add additional basic check macros for SystemVerilog VUnit

### DIFF
--- a/vunit/verilog/check/run.py
+++ b/vunit/verilog/check/run.py
@@ -1,0 +1,38 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+# Copyright (c) 2014-2018, Lars Asplund lars.anders.asplund@gmail.com
+
+from os.path import join, dirname, basename, abspath
+import sys
+from vunit.verilog import VUnit
+
+vu = VUnit.from_argv()
+
+root = dirname(__file__)
+
+lib = vu.add_library("lib")
+
+tb_list = lib.add_source_files(join(root, "test", "*.sv"))
+
+
+vu.set_sim_option("modelsim.vsim_flags.gui", ["-novopt"])
+
+#Uncomment these later when coverage reporting is added
+#vu.set_sim_option("modelsim.vsim_flags", ["-assertcover"])
+
+#lib.set_compile_option("modelsim.vcom_flags", ["+cover=bs"])
+#lib.set_compile_option("modelsim.vlog_flags", ["+cover=bs"])
+#lib.set_sim_option("enable_coverage", True)
+
+def post_run(results):
+    results.merge_coverage(
+        file_name=join(root, "vunit_out", "mlc_coverage_data.ucdb"),
+        args=["-quiet"]
+    )
+
+
+vu.main()
+#TODO: Compile coverage report
+#vu.main(post_run=post_run)

--- a/vunit/verilog/check/run.py
+++ b/vunit/verilog/check/run.py
@@ -16,23 +16,6 @@ lib = vu.add_library("lib")
 
 tb_list = lib.add_source_files(join(root, "test", "*.sv"))
 
-
 vu.set_sim_option("modelsim.vsim_flags.gui", ["-novopt"])
 
-#Uncomment these later when coverage reporting is added
-#vu.set_sim_option("modelsim.vsim_flags", ["-assertcover"])
-
-#lib.set_compile_option("modelsim.vcom_flags", ["+cover=bs"])
-#lib.set_compile_option("modelsim.vlog_flags", ["+cover=bs"])
-#lib.set_sim_option("enable_coverage", True)
-
-def post_run(results):
-    results.merge_coverage(
-        file_name=join(root, "vunit_out", "mlc_coverage_data.ucdb"),
-        args=["-quiet"]
-    )
-
-
 vu.main()
-#TODO: Compile coverage report
-#vu.main(post_run=post_run)

--- a/vunit/verilog/check/run.py
+++ b/vunit/verilog/check/run.py
@@ -2,7 +2,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this file,
 # You can obtain one at http://mozilla.org/MPL/2.0/.
 #
-# Copyright (c) 2014-2018, Lars Asplund lars.anders.asplund@gmail.com
+# Copyright (c) 2014-2019, Lars Asplund lars.anders.asplund@gmail.com
 
 from os.path import join, dirname, basename, abspath
 import sys

--- a/vunit/verilog/check/test/check_tb.sv
+++ b/vunit/verilog/check/test/check_tb.sv
@@ -10,32 +10,53 @@
 module check_tb;
 
 	class test_data;
-		randc	logic	[15:0] 	data_logic;
-		randc	integer			data_integer;
-		randc	byte			data_byte;
-		randc	shortint		data_shortint;
-		randc	longint			data_longint;
-		randc	time			data_time;
-		//randc	real			data_real;
-	endclass;
+		bit				[15:0] 	data_bit;
+		int				data_int;
+		byte			data_byte;
+		shortint		data_shortint;
+		time			data_time;
+		function void make_random;
+			data_bit = $random();
+			data_int = int'($random());
+			data_byte = byte'($random());
+			data_shortint = shortint'($random());
+			data_time = time'($random());
+		endfunction
+	endclass
 	test_data case_data1;
 	integer case_greater, case_less;
 
 	`TEST_SUITE begin
 		`TEST_SUITE_SETUP begin
 			case_data1 = new();
+			case_data1.make_random();
+			case_greater = case_data1.data_int+1;
+			case_less = case_data1.data_int-1;
 		end
 		`TEST_CASE("Check Macros Are Visible") begin
-				if(!case_data1.randomize())
-					$display("Randomization failed");
-				case_greater = case_data1.data_integer+1;
-				case_less = case_data1.data_integer-1;
-				`CHECK_EQUAL(case_data1.data_integer, case_data1.data_integer);
-				`CHECK_NOT_EQUAL(case_data1.data_integer, case_greater);
-				`CHECK_GREATER(case_greater, case_data1.data_integer);
-				`CHECK_LESS(case_less, case_data1.data_integer);
-				`CHECK_EQUAL_VARIANCE(case_less, case_data1.data_integer, 2);
-				`CHECK_EQUAL_VARIANCE(case_greater, case_data1.data_integer, 2);
+			// if(!case_data1.randomize())
+			//	$error("Randomization failed");
+			`CHECK_EQUAL(case_data1.data_int, case_data1.data_int);
+			`CHECK_NOT_EQUAL(case_data1.data_int, case_greater);
+			`CHECK_GREATER(case_greater, case_data1.data_int);
+			`CHECK_LESS(case_less, case_data1.data_int);
+			`CHECK_EQUAL_VARIANCE(case_less, case_data1.data_int, 2);
+			`CHECK_EQUAL_VARIANCE(case_greater, case_data1.data_int, 2);
 		end
+		/* `TEST_CASE("CHECK_EQUAL failure message") begin
+			`CHECK_EQUAL(case_data1.data_int, case_greater, "This test should fail.");
+		end
+		`TEST_CASE("CHECK_NOT_EQUAL failure message") begin
+			`CHECK_NOT_EQUAL(case_data1.data_int, case_data1.data_int, "This test should fail.");
+		end
+		`TEST_CASE("CHECK_GREATER failure message") begin
+			`CHECK_GREATER(case_data1.data_int, case_data1.data_int, "This test should fail.");
+		end
+		`TEST_CASE("CHECK_LESS failure message") begin
+			`CHECK_LESS(case_data1.data_int, case_data1.data_int, "This test should fail.");
+		end
+		`TEST_CASE("CHECK_EQUAL_VARIANCE failure message") begin
+			`CHECK_EQUAL_VARIANCE(case_data1.data_int, case_data1.data_int+5, 1, "This test should fail.");
+		end */
 	end
 endmodule

--- a/vunit/verilog/check/test/check_tb.sv
+++ b/vunit/verilog/check/test/check_tb.sv
@@ -30,22 +30,19 @@ module check_tb;
 	string test_output;
 	string test_expected;
 	string err_msg;
-	
 	function bit check_string_empty(string str);
-		if (str.compare("") !== 1) 
+		if (str.len() == 0)
 			return 1;
 		else
 			return 0;
 	endfunction
-	
 	function void check_macro_output(string actual, string expected);
-		assert ( actual.compare(expected) == 0) else	
+		assert ( actual.compare(expected) == 0) else
 			begin
 				$sformat(err_msg, "CHECK_EQUAL_ERROR: Failure message not as expected.\n RECV: |%f|\n  EXP: |%f|\n", actual, expected);
 				$error(err_msg);
 			end;
 	endfunction;
-
 	`TEST_SUITE begin
 		`TEST_SUITE_SETUP begin
 			case_data1 = new();
@@ -72,11 +69,10 @@ module check_tb;
 			`CHECK_EQUAL_VARIANCE(case_greater, case_data1.data_int, 2);
 			assert(check_string_empty(test_output) == 1);
 		end
-		`TEST_CASE("CHECK_EQUAL failure message") begin
+		`TEST_CASE("CHECK_EQUAL failure message integer") begin
 			// Check printouts for correct error messages
 			for (int x = 0; x < `MAX_TESTS; x++) begin
 				case_data1.make_random();
-				case_greater = case_data1.data_int+1;
 				`CHECK_EQUAL(case_data1.data_int, case_greater, "This test should fail.");
 				$sformat(test_expected, "CHECK_EQUAL failed! Got %d expected %d. This test should fail.", case_data1.data_int, case_greater);
 				check_macro_output(test_output, test_expected);
@@ -87,7 +83,8 @@ module check_tb;
 				test_output = "";
 			end
 		end
-		`TEST_CASE("CHECK_NOT_EQUAL failure message") begin
+		`TEST_CASE("CHECK_NOT_EQUAL failure message integer") begin
+			// Check printouts for correct error messages
 			for (int x = 0; x < `MAX_TESTS; x++) begin
 				case_data1.make_random();
 				case_greater = case_data1.data_int+1;
@@ -101,7 +98,8 @@ module check_tb;
 				test_output = "";
 			end
 		end
-		`TEST_CASE("CHECK_GREATER failure message") begin
+		`TEST_CASE("CHECK_GREATER failure message integer") begin
+			// Check printouts for correct error messages
 			for (int x = 0; x < `MAX_TESTS; x++) begin
 				case_data1.make_random();
 				`CHECK_GREATER(case_data1.data_int, case_data1.data_int, "This test should fail.");
@@ -114,7 +112,8 @@ module check_tb;
 				test_output = "";
 			end
 		end
-		`TEST_CASE("CHECK_LESS failure message") begin
+		`TEST_CASE("CHECK_LESS failure message integer") begin
+			// Check printouts for correct error messages
 			for (int x = 0; x < `MAX_TESTS; x++) begin
 				case_data1.make_random();
 				`CHECK_LESS(case_data1.data_int, case_data1.data_int, "This test should fail.");
@@ -127,7 +126,8 @@ module check_tb;
 				test_output = "";
 			end
 		end
-		`TEST_CASE("CHECK_EQUAL_VARIANCE failure message") begin
+		`TEST_CASE("CHECK_EQUAL_VARIANCE failure message integer") begin
+			// Check printouts for correct error messages
 			integer rand_int1, rand_int2;
 			for (int x = 0; x < `MAX_TESTS; x++) begin
 				rand_int1 = $random();
@@ -141,6 +141,6 @@ module check_tb;
 				check_macro_output(test_output, test_expected);
 				test_output = "";
 			end
-		end 
+		end
 	end
 endmodule

--- a/vunit/verilog/check/test/check_tb.sv
+++ b/vunit/verilog/check/test/check_tb.sv
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this file,
 // You can obtain one at http://mozilla.org/MPL/2.0/.
 //
-// Copyright (c) 2014-2018, Lars Asplund lars.anders.asplund@gmail.com
+// Copyright (c) 2014-2019, Lars Asplund lars.anders.asplund@gmail.com
 
 `timescale 10ns / 10ns
 `include "vunit_defines.svh"
@@ -56,8 +56,6 @@ module check_tb;
 			test_output = "";
 		end
 		`TEST_CASE("Check Macros Are Visible") begin
-			// if(!tc_data1.randomize())
-			//	$error("Randomization failed");
 			// Since $error is overriden by a macro, we need to explicitly check
 			// test output. The test_output string is only empty if the test passes.
 			`CHECK_EQUAL(tc_data1.data_int, tc_data1.data_int);
@@ -81,6 +79,11 @@ module check_tb;
 		`TEST_CASE("CREATE_MSG output wo message") begin
 			`CREATE_MSG(full_msg, "CHECK_EQUAL", tc_data1.data_int, tc_greater);
 			$sformat(test_expected, "CHECK_EQUAL failed! Got %d expected %d. ", tc_data1.data_int, tc_greater);
+			check_macro_output(full_msg, test_expected);
+		end
+		`TEST_CASE("Test that there are no extra spaces") begin
+			`CREATE_MSG(full_msg, "CHECK_EQUAL", 17, 21, "This test should fail.");
+			$sformat(test_expected, "CHECK_EQUAL failed! Got 17 expected 21. This test should fail.");
 			check_macro_output(full_msg, test_expected);
 		end
 		`TEST_CASE("CHECK_EQUAL_VARIANCE failure message integer") begin

--- a/vunit/verilog/check/test/check_tb.sv
+++ b/vunit/verilog/check/test/check_tb.sv
@@ -72,18 +72,18 @@ module check_tb;
 			assert(check_string_empty(test_output) == 1);
 		end
 		`TEST_CASE("CREATE_MSG output w message") begin
-			`CREATE_MSG(full_msg, "CHECK_EQUAL", tc_data1.data_int, tc_greater, "This test should fail.");
-			$sformat(test_expected, "CHECK_EQUAL failed! Got %0d expected %0d. This test should fail.", tc_data1.data_int, tc_greater);
+			`CREATE_MSG(full_msg, "CHECK_EQUAL", tc_data1.data_int, tc_greater, "=", "This test should fail.");
+			$sformat(test_expected, "CHECK_EQUAL failed! Got tc_data1.data_int=%0d expected =%0d. This test should fail.", tc_data1.data_int, tc_greater);
 			check_macro_output(full_msg, test_expected);
 		end
 		`TEST_CASE("CREATE_MSG output wo message") begin
-			`CREATE_MSG(full_msg, "CHECK_EQUAL", tc_data1.data_int, tc_greater);
-			$sformat(test_expected, "CHECK_EQUAL failed! Got %0d expected %0d. ", tc_data1.data_int, tc_greater);
+			`CREATE_MSG(full_msg, "CHECK_EQUAL", tc_data1.data_int, tc_greater, "=");
+			$sformat(test_expected, "CHECK_EQUAL failed! Got tc_data1.data_int=%0d expected =%0d. ", tc_data1.data_int, tc_greater);
 			check_macro_output(full_msg, test_expected);
 		end
 		`TEST_CASE("Test that there are no extra spaces") begin
-			`CREATE_MSG(full_msg, "CHECK_EQUAL", 17, 21, "This test should fail.");
-			$sformat(test_expected, "CHECK_EQUAL failed! Got 17 expected 21. This test should fail.");
+			`CREATE_MSG(full_msg, "CHECK_EQUAL", 17, 21, "=", "This test should fail.");
+			$sformat(test_expected, "CHECK_EQUAL failed! Got 17=17 expected =21. This test should fail.");
 			check_macro_output(full_msg, test_expected);
 		end
 		`TEST_CASE("CHECK_EQUAL_VARIANCE failure message integer") begin
@@ -92,11 +92,11 @@ module check_tb;
 			rand_int1 = $random();
 			rand_int2 = rand_int1 + 15;
 			`CHECK_EQUAL_VARIANCE(rand_int1, rand_int2, 5, "This test should fail.");
-			$sformat(test_expected, "CHECK_EQUAL_VARIANCE failed! Got %0d expected %0d +- %0d. This test should fail.", rand_int1, rand_int2, 5);
+			$sformat(test_expected, "CHECK_EQUAL_VARIANCE failed! Got rand_int1=%0d expected =%0d, +-%0d. This test should fail.", rand_int1, rand_int2, 5);
 			check_macro_output(test_output, test_expected);
 			test_output = "";
 			`CHECK_EQUAL_VARIANCE(rand_int1, rand_int2, 5);
-			$sformat(test_expected, "CHECK_EQUAL_VARIANCE failed! Got %0d expected %0d +- %0d. ", rand_int1, rand_int2, 5);
+			$sformat(test_expected, "CHECK_EQUAL_VARIANCE failed! Got rand_int1=%0d expected =%0d, +-%0d. ", rand_int1, rand_int2, 5);
 			check_macro_output(test_output, test_expected);
 			test_output = "";
 		end
@@ -106,10 +106,11 @@ module check_tb;
 				tc_data2.make_random();
 				`CHECK_EQUAL(tc_data1.data_int, tc_data2.data_int);
 				if (tc_data1.data_int == tc_data2.data_int) begin
+					$display("Test data is equal, checking output");
 					assert(check_string_empty(test_output) == 1);
 				end
 				else begin
-					$sformat(test_expected, "CHECK_EQUAL failed! Got %0d expected %0d. ", tc_data1.data_int, tc_data2.data_int);
+					$sformat(test_expected, "CHECK_EQUAL failed! Got tc_data1.data_int=%0d expected =%0d. ", tc_data1.data_int, tc_data2.data_int);
 					check_macro_output(test_output, test_expected);
 					test_output = "";
 				end
@@ -118,16 +119,10 @@ module check_tb;
 		`TEST_CASE("CHECK_NOT_EQUAL Int Random Tests") begin
 			for (int x = 0; x < `MAX_TESTS; x++) begin
 				tc_data1.make_random();
-				tc_data2.make_random();
-				`CHECK_NOT_EQUAL(tc_data1.data_int, tc_data2.data_int);
-				if (tc_data1.data_int !== tc_data2.data_int) begin
-					assert(check_string_empty(test_output) == 1);
-				end
-				else begin
-					$sformat(test_expected, "CHECK_NOT_EQUAL failed! Got %0d expected %0d. ", tc_data1.data_int, tc_data2.data_int);
-					check_macro_output(test_output, test_expected);
-					test_output = "";
-				end
+				`CHECK_NOT_EQUAL(tc_data1.data_int, tc_data1.data_int);
+				$sformat(test_expected, "CHECK_NOT_EQUAL failed! Got tc_data1.data_int=%0d expected !=%0d. ", tc_data1.data_int, tc_data1.data_int);
+				check_macro_output(test_output, test_expected);
+				test_output = "";
 			end
 		end
 		`TEST_CASE("CHECK_GREATER Int Random Tests") begin
@@ -136,10 +131,11 @@ module check_tb;
 				tc_data2.make_random();
 				`CHECK_GREATER(tc_data1.data_int, tc_data2.data_int);
 				if (tc_data1.data_int > tc_data2.data_int) begin
+					$display("Test data is greater, checking output");
 					assert(check_string_empty(test_output) == 1);
 				end
 				else begin
-					$sformat(test_expected, "CHECK_GREATER failed! Got %0d expected %0d. ", tc_data1.data_int, tc_data2.data_int);
+					$sformat(test_expected, "CHECK_GREATER failed! Got tc_data1.data_int=%0d expected >%0d. ", tc_data1.data_int, tc_data2.data_int);
 					check_macro_output(test_output, test_expected);
 					test_output = "";
 				end
@@ -151,10 +147,11 @@ module check_tb;
 				tc_data2.make_random();
 				`CHECK_LESS(tc_data1.data_int, tc_data2.data_int);
 				if (tc_data1.data_int < tc_data2.data_int) begin
+					$display("Test data is less, checking output");
 					assert(check_string_empty(test_output) == 1);
 				end
 				else begin
-					$sformat(test_expected, "CHECK_LESS failed! Got %0d expected %0d. ", tc_data1.data_int, tc_data2.data_int);
+					$sformat(test_expected, "CHECK_LESS failed! Got tc_data1.data_int=%0d expected <%0d. ", tc_data1.data_int, tc_data2.data_int);
 					check_macro_output(test_output, test_expected);
 					test_output = "";
 				end
@@ -166,10 +163,11 @@ module check_tb;
 				tc_data2.make_random();
 				`CHECK_EQUAL_VARIANCE(tc_data1.data_int, tc_data2.data_int, `TEST_VARIANCE);
 				if ((tc_data1.data_int > tc_data2.data_int - `TEST_VARIANCE) && (tc_data1.data_int < tc_data2.data_int + `TEST_VARIANCE)) begin
+					$display("Test data is equal, checking output");
 					assert(check_string_empty(test_output) == 1);
 				end
 				else begin
-					$sformat(test_expected, "CHECK_EQUAL_VARIANCE failed! Got %0d expected %0d +- %0d. ", tc_data1.data_int, tc_data2.data_int, `TEST_VARIANCE);
+					$sformat(test_expected, "CHECK_EQUAL_VARIANCE failed! Got tc_data1.data_int=%0d expected =%0d, +-%0d. ", tc_data1.data_int, tc_data2.data_int, `TEST_VARIANCE);
 					check_macro_output(test_output, test_expected);
 					test_output = "";
 				end
@@ -181,10 +179,11 @@ module check_tb;
 				tc_data2.make_random();
 				`CHECK_EQUAL(tc_data1.data_time, tc_data2.data_time);
 				if (tc_data1.data_time == tc_data2.data_time) begin
+					$display("Test data is equal, checking output");
 					assert(check_string_empty(test_output) == 1);
 				end
 				else begin
-					$sformat(test_expected, "CHECK_EQUAL failed! Got %0d expected %0d. ", tc_data1.data_time, tc_data2.data_time);
+					$sformat(test_expected, "CHECK_EQUAL failed! Got tc_data1.data_time=%0d expected =%0d. ", tc_data1.data_time, tc_data2.data_time);
 					check_macro_output(test_output, test_expected);
 					test_output = "";
 				end
@@ -194,15 +193,10 @@ module check_tb;
 			for (time x = 0; x < `MAX_TESTS; x++) begin
 				tc_data1.make_random();
 				tc_data2.make_random();
-				`CHECK_NOT_EQUAL(tc_data1.data_time, tc_data2.data_time);
-				if (tc_data1.data_time !== tc_data2.data_time) begin
-					assert(check_string_empty(test_output) == 1);
-				end
-				else begin
-					$sformat(test_expected, "CHECK_NOT_EQUAL failed! Got %0d expected %0d. ", tc_data1.data_time, tc_data2.data_time);
-					check_macro_output(test_output, test_expected);
-					test_output = "";
-				end
+				`CHECK_NOT_EQUAL(tc_data1.data_time, tc_data1.data_time);
+				$sformat(test_expected, "CHECK_NOT_EQUAL failed! Got tc_data1.data_time=%0d expected !=%0d. ", tc_data1.data_time, tc_data1.data_time);
+				check_macro_output(test_output, test_expected);
+				test_output = "";
 			end
 		end
 		`TEST_CASE("CHECK_GREATER Time Random Tests") begin
@@ -211,10 +205,11 @@ module check_tb;
 				tc_data2.make_random();
 				`CHECK_GREATER(tc_data1.data_time, tc_data2.data_time);
 				if (tc_data1.data_time > tc_data2.data_time) begin
+					$display("Test data is greater, checking output");
 					assert(check_string_empty(test_output) == 1);
 				end
 				else begin
-					$sformat(test_expected, "CHECK_GREATER failed! Got %0d expected %0d. ", tc_data1.data_time, tc_data2.data_time);
+					$sformat(test_expected, "CHECK_GREATER failed! Got tc_data1.data_time=%0d expected >%0d. ", tc_data1.data_time, tc_data2.data_time);
 					check_macro_output(test_output, test_expected);
 					test_output = "";
 				end
@@ -226,10 +221,11 @@ module check_tb;
 				tc_data2.make_random();
 				`CHECK_LESS(tc_data1.data_time, tc_data2.data_time);
 				if (tc_data1.data_time < tc_data2.data_time) begin
+					$display("Test data is lesser, checking output");
 					assert(check_string_empty(test_output) == 1);
 				end
 				else begin
-					$sformat(test_expected, "CHECK_LESS failed! Got %0d expected %0d. ", tc_data1.data_time, tc_data2.data_time);
+					$sformat(test_expected, "CHECK_LESS failed! Got tc_data1.data_time=%0d expected <%0d. ", tc_data1.data_time, tc_data2.data_time);
 					check_macro_output(test_output, test_expected);
 					test_output = "";
 				end
@@ -241,10 +237,11 @@ module check_tb;
 				tc_data2.make_random();
 				`CHECK_EQUAL_VARIANCE(tc_data1.data_time, tc_data2.data_time, `TEST_VARIANCE);
 				if ((tc_data1.data_time > tc_data2.data_time - `TEST_VARIANCE) && (tc_data1.data_time < tc_data2.data_time + `TEST_VARIANCE)) begin
+					$display("Test data is equal, checking output");
 					assert(check_string_empty(test_output) == 1);
 				end
 				else begin
-					$sformat(test_expected, "CHECK_EQUAL_VARIANCE failed! Got %0d expected %0d +- %0d. ", tc_data1.data_time, tc_data2.data_time, `TEST_VARIANCE);
+					$sformat(test_expected, "CHECK_EQUAL_VARIANCE failed! Got tc_data1.data_time=%0d expected =%0d, +-%0d. ", tc_data1.data_time, tc_data2.data_time, `TEST_VARIANCE);
 					check_macro_output(test_output, test_expected);
 					test_output = "";
 				end

--- a/vunit/verilog/check/test/check_tb.sv
+++ b/vunit/verilog/check/test/check_tb.sv
@@ -73,12 +73,12 @@ module check_tb;
 		end
 		`TEST_CASE("CREATE_MSG output w message") begin
 			`CREATE_MSG(full_msg, "CHECK_EQUAL", tc_data1.data_int, tc_greater, "This test should fail.");
-			$sformat(test_expected, "CHECK_EQUAL failed! Got %d expected %d. This test should fail.", tc_data1.data_int, tc_greater);
+			$sformat(test_expected, "CHECK_EQUAL failed! Got %0d expected %0d. This test should fail.", tc_data1.data_int, tc_greater);
 			check_macro_output(full_msg, test_expected);
 		end
 		`TEST_CASE("CREATE_MSG output wo message") begin
 			`CREATE_MSG(full_msg, "CHECK_EQUAL", tc_data1.data_int, tc_greater);
-			$sformat(test_expected, "CHECK_EQUAL failed! Got %d expected %d. ", tc_data1.data_int, tc_greater);
+			$sformat(test_expected, "CHECK_EQUAL failed! Got %0d expected %0d. ", tc_data1.data_int, tc_greater);
 			check_macro_output(full_msg, test_expected);
 		end
 		`TEST_CASE("Test that there are no extra spaces") begin
@@ -92,11 +92,11 @@ module check_tb;
 			rand_int1 = $random();
 			rand_int2 = rand_int1 + 15;
 			`CHECK_EQUAL_VARIANCE(rand_int1, rand_int2, 5, "This test should fail.");
-			$sformat(test_expected, "CHECK_EQUAL_VARIANCE failed! Got %d expected %d +- %d. This test should fail.", rand_int1, rand_int2, 5);
+			$sformat(test_expected, "CHECK_EQUAL_VARIANCE failed! Got %0d expected %0d +- %0d. This test should fail.", rand_int1, rand_int2, 5);
 			check_macro_output(test_output, test_expected);
 			test_output = "";
 			`CHECK_EQUAL_VARIANCE(rand_int1, rand_int2, 5);
-			$sformat(test_expected, "CHECK_EQUAL_VARIANCE failed! Got %d expected %d +- %d. ", rand_int1, rand_int2, 5);
+			$sformat(test_expected, "CHECK_EQUAL_VARIANCE failed! Got %0d expected %0d +- %0d. ", rand_int1, rand_int2, 5);
 			check_macro_output(test_output, test_expected);
 			test_output = "";
 		end
@@ -109,7 +109,7 @@ module check_tb;
 					assert(check_string_empty(test_output) == 1);
 				end
 				else begin
-					$sformat(test_expected, "CHECK_EQUAL failed! Got %d expected %d. ", tc_data1.data_int, tc_data2.data_int);
+					$sformat(test_expected, "CHECK_EQUAL failed! Got %0d expected %0d. ", tc_data1.data_int, tc_data2.data_int);
 					check_macro_output(test_output, test_expected);
 					test_output = "";
 				end
@@ -124,7 +124,7 @@ module check_tb;
 					assert(check_string_empty(test_output) == 1);
 				end
 				else begin
-					$sformat(test_expected, "CHECK_NOT_EQUAL failed! Got %d expected %d. ", tc_data1.data_int, tc_data2.data_int);
+					$sformat(test_expected, "CHECK_NOT_EQUAL failed! Got %0d expected %0d. ", tc_data1.data_int, tc_data2.data_int);
 					check_macro_output(test_output, test_expected);
 					test_output = "";
 				end
@@ -139,7 +139,7 @@ module check_tb;
 					assert(check_string_empty(test_output) == 1);
 				end
 				else begin
-					$sformat(test_expected, "CHECK_GREATER failed! Got %d expected %d. ", tc_data1.data_int, tc_data2.data_int);
+					$sformat(test_expected, "CHECK_GREATER failed! Got %0d expected %0d. ", tc_data1.data_int, tc_data2.data_int);
 					check_macro_output(test_output, test_expected);
 					test_output = "";
 				end
@@ -154,7 +154,7 @@ module check_tb;
 					assert(check_string_empty(test_output) == 1);
 				end
 				else begin
-					$sformat(test_expected, "CHECK_LESS failed! Got %d expected %d. ", tc_data1.data_int, tc_data2.data_int);
+					$sformat(test_expected, "CHECK_LESS failed! Got %0d expected %0d. ", tc_data1.data_int, tc_data2.data_int);
 					check_macro_output(test_output, test_expected);
 					test_output = "";
 				end
@@ -169,7 +169,7 @@ module check_tb;
 					assert(check_string_empty(test_output) == 1);
 				end
 				else begin
-					$sformat(test_expected, "CHECK_EQUAL_VARIANCE failed! Got %d expected %d +- %d. ", tc_data1.data_int, tc_data2.data_int, `TEST_VARIANCE);
+					$sformat(test_expected, "CHECK_EQUAL_VARIANCE failed! Got %0d expected %0d +- %0d. ", tc_data1.data_int, tc_data2.data_int, `TEST_VARIANCE);
 					check_macro_output(test_output, test_expected);
 					test_output = "";
 				end
@@ -184,7 +184,7 @@ module check_tb;
 					assert(check_string_empty(test_output) == 1);
 				end
 				else begin
-					$sformat(test_expected, "CHECK_EQUAL failed! Got %d expected %d. ", tc_data1.data_time, tc_data2.data_time);
+					$sformat(test_expected, "CHECK_EQUAL failed! Got %0d expected %0d. ", tc_data1.data_time, tc_data2.data_time);
 					check_macro_output(test_output, test_expected);
 					test_output = "";
 				end
@@ -199,7 +199,7 @@ module check_tb;
 					assert(check_string_empty(test_output) == 1);
 				end
 				else begin
-					$sformat(test_expected, "CHECK_NOT_EQUAL failed! Got %d expected %d. ", tc_data1.data_time, tc_data2.data_time);
+					$sformat(test_expected, "CHECK_NOT_EQUAL failed! Got %0d expected %0d. ", tc_data1.data_time, tc_data2.data_time);
 					check_macro_output(test_output, test_expected);
 					test_output = "";
 				end
@@ -214,7 +214,7 @@ module check_tb;
 					assert(check_string_empty(test_output) == 1);
 				end
 				else begin
-					$sformat(test_expected, "CHECK_GREATER failed! Got %d expected %d. ", tc_data1.data_time, tc_data2.data_time);
+					$sformat(test_expected, "CHECK_GREATER failed! Got %0d expected %0d. ", tc_data1.data_time, tc_data2.data_time);
 					check_macro_output(test_output, test_expected);
 					test_output = "";
 				end
@@ -229,7 +229,7 @@ module check_tb;
 					assert(check_string_empty(test_output) == 1);
 				end
 				else begin
-					$sformat(test_expected, "CHECK_LESS failed! Got %d expected %d. ", tc_data1.data_time, tc_data2.data_time);
+					$sformat(test_expected, "CHECK_LESS failed! Got %0d expected %0d. ", tc_data1.data_time, tc_data2.data_time);
 					check_macro_output(test_output, test_expected);
 					test_output = "";
 				end
@@ -244,7 +244,7 @@ module check_tb;
 					assert(check_string_empty(test_output) == 1);
 				end
 				else begin
-					$sformat(test_expected, "CHECK_EQUAL_VARIANCE failed! Got %d expected %d +- %d. ", tc_data1.data_time, tc_data2.data_time, `TEST_VARIANCE);
+					$sformat(test_expected, "CHECK_EQUAL_VARIANCE failed! Got %0d expected %0d +- %0d. ", tc_data1.data_time, tc_data2.data_time, `TEST_VARIANCE);
 					check_macro_output(test_output, test_expected);
 					test_output = "";
 				end

--- a/vunit/verilog/check/test/check_tb.sv
+++ b/vunit/verilog/check/test/check_tb.sv
@@ -1,0 +1,39 @@
+`timescale 10ns / 10ns
+`include "vunit_defines.svh"
+
+module check_tb;
+
+	class test_data;
+		randc	logic	[15:0] 	data_logic;
+		randc	integer			data_integer;
+		randc	byte			data_byte;
+		randc	shortint		data_shortint;
+		randc	longint			data_longint;
+		randc	time			data_time;
+		//randc	real			data_real;
+	endclass;
+	
+	test_data case_data1;
+	integer case_greater, case_less;
+
+	`TEST_SUITE begin
+		`TEST_SUITE_SETUP begin
+			case_data1 = new();
+		end
+		
+		`TEST_CASE("Check Macros Are Visible") begin
+				if(!case_data1.randomize()) 
+					$display("Randomization failed"); 
+				case_greater = case_data1.data_integer+1;
+				case_less = case_data1.data_integer-1;
+				`CHECK_EQUAL(case_data1.data_integer, case_data1.data_integer);
+				`CHECK_NOT_EQUAL(case_data1.data_integer, case_greater);
+				`CHECK_GREATER(case_greater, case_data1.data_integer);
+				`CHECK_LESS(case_less, case_data1.data_integer);
+				`CHECK_EQUAL_VARIANCE(case_less, case_data1.data_integer, 2);
+				`CHECK_EQUAL_VARIANCE(case_greater, case_data1.data_integer, 2);
+			
+		end
+	end
+
+endmodule 

--- a/vunit/verilog/check/test/check_tb.sv
+++ b/vunit/verilog/check/test/check_tb.sv
@@ -1,3 +1,9 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) 2015-2016, Lars Asplund lars.anders.asplund@gmail.com
+
 `timescale 10ns / 10ns
 `include "vunit_defines.svh"
 

--- a/vunit/verilog/check/test/check_tb.sv
+++ b/vunit/verilog/check/test/check_tb.sv
@@ -12,240 +12,240 @@
 
 module check_tb;
 
-	class test_data;
-		bit				[15:0] 	data_bit;
-		int				data_int;
-		byte			data_byte;
-		shortint		data_shortint;
-		time			data_time;
-		function void make_random;
-			data_bit = $random();
-			data_int = int'($random());
-			data_byte = byte'($random());
-			data_shortint = shortint'($random());
-			data_time = time'($random());
-		endfunction
-	endclass
-	test_data tc_data1;
-	test_data tc_data2;
-	integer tc_greater, tc_less;
-	string test_output;
-	string test_expected;
-	string err_msg;
-	function bit check_string_empty(string str);
-		if (str.len() == 0)
-			return 1;
-		else
-			return 0;
-	endfunction
-	function void check_macro_output(string actual, string expected);
-		assert ( actual.compare(expected) == 0) else
-			begin
-				$sformat(err_msg, "CHECK_EQUAL_ERROR: Failure message not as expected.\n RECV: |%f|\n  EXP: |%f|\n", actual, expected);
-				$error(err_msg);
-			end;
-	endfunction;
-	`TEST_SUITE begin
-		`TEST_SUITE_SETUP begin
-			string str;
-			tc_data1 = new();
-			tc_data2 = new();
-			tc_data1.make_random();
-			tc_greater = tc_data1.data_int+1;
-			tc_less = tc_data1.data_int-1;
-			test_output = "";
-		end
-		`TEST_CASE("Check Macros Are Visible") begin
-			// Since $error is overriden by a macro, we need to explicitly check
-			// test output. The test_output string is only empty if the test passes.
-			`CHECK_EQUAL(tc_data1.data_int, tc_data1.data_int);
-			assert(check_string_empty(test_output) == 1);
-			`CHECK_NOT_EQUAL(tc_data1.data_int, tc_greater);
-			assert(check_string_empty(test_output) == 1);
-			`CHECK_GREATER(tc_greater, tc_data1.data_int);
-			assert(check_string_empty(test_output) == 1);
-			`CHECK_LESS(tc_less, tc_data1.data_int);
-			assert(check_string_empty(test_output) == 1);
-			`CHECK_EQUAL_VARIANCE(tc_less, tc_data1.data_int, 2);
-			assert(check_string_empty(test_output) == 1);
-			`CHECK_EQUAL_VARIANCE(tc_greater, tc_data1.data_int, 2);
-			assert(check_string_empty(test_output) == 1);
-		end
-		`TEST_CASE("CREATE_MSG output w message") begin
-			`CREATE_MSG(full_msg, "CHECK_EQUAL", tc_data1.data_int, tc_greater, "=", "This test should fail.");
-			$sformat(test_expected, "CHECK_EQUAL failed! Got tc_data1.data_int=%0d expected =%0d. This test should fail.", tc_data1.data_int, tc_greater);
-			check_macro_output(full_msg, test_expected);
-		end
-		`TEST_CASE("CREATE_MSG output wo message") begin
-			`CREATE_MSG(full_msg, "CHECK_EQUAL", tc_data1.data_int, tc_greater, "=");
-			$sformat(test_expected, "CHECK_EQUAL failed! Got tc_data1.data_int=%0d expected =%0d. ", tc_data1.data_int, tc_greater);
-			check_macro_output(full_msg, test_expected);
-		end
-		`TEST_CASE("Test that there are no extra spaces") begin
-			`CREATE_MSG(full_msg, "CHECK_EQUAL", 17, 21, "=", "This test should fail.");
-			$sformat(test_expected, "CHECK_EQUAL failed! Got 17=17 expected =21. This test should fail.");
-			check_macro_output(full_msg, test_expected);
-		end
-		`TEST_CASE("CHECK_EQUAL_VARIANCE failure message integer") begin
-			// Check printouts for correct error messages
-			integer rand_int1, rand_int2;
-			rand_int1 = $random();
-			rand_int2 = rand_int1 + 15;
-			`CHECK_EQUAL_VARIANCE(rand_int1, rand_int2, 5, "This test should fail.");
-			$sformat(test_expected, "CHECK_EQUAL_VARIANCE failed! Got rand_int1=%0d expected =%0d, +-%0d. This test should fail.", rand_int1, rand_int2, 5);
-			check_macro_output(test_output, test_expected);
-			test_output = "";
-			`CHECK_EQUAL_VARIANCE(rand_int1, rand_int2, 5);
-			$sformat(test_expected, "CHECK_EQUAL_VARIANCE failed! Got rand_int1=%0d expected =%0d, +-%0d. ", rand_int1, rand_int2, 5);
-			check_macro_output(test_output, test_expected);
-			test_output = "";
-		end
-		`TEST_CASE("CHECK_EQUAL Int Random Tests") begin
-			for (int x = 0; x < `MAX_TESTS; x++) begin
-				tc_data1.make_random();
-				tc_data2.make_random();
-				`CHECK_EQUAL(tc_data1.data_int, tc_data2.data_int);
-				if (tc_data1.data_int == tc_data2.data_int) begin
-					$display("Test data is equal, checking output");
-					assert(check_string_empty(test_output) == 1);
-				end
-				else begin
-					$sformat(test_expected, "CHECK_EQUAL failed! Got tc_data1.data_int=%0d expected =%0d. ", tc_data1.data_int, tc_data2.data_int);
-					check_macro_output(test_output, test_expected);
-					test_output = "";
-				end
-			end
-		end
-		`TEST_CASE("CHECK_NOT_EQUAL Int Random Tests") begin
-			for (int x = 0; x < `MAX_TESTS; x++) begin
-				tc_data1.make_random();
-				`CHECK_NOT_EQUAL(tc_data1.data_int, tc_data1.data_int);
-				$sformat(test_expected, "CHECK_NOT_EQUAL failed! Got tc_data1.data_int=%0d expected !=%0d. ", tc_data1.data_int, tc_data1.data_int);
-				check_macro_output(test_output, test_expected);
-				test_output = "";
-			end
-		end
-		`TEST_CASE("CHECK_GREATER Int Random Tests") begin
-			for (int x = 0; x < `MAX_TESTS; x++) begin
-				tc_data1.make_random();
-				tc_data2.make_random();
-				`CHECK_GREATER(tc_data1.data_int, tc_data2.data_int);
-				if (tc_data1.data_int > tc_data2.data_int) begin
-					$display("Test data is greater, checking output");
-					assert(check_string_empty(test_output) == 1);
-				end
-				else begin
-					$sformat(test_expected, "CHECK_GREATER failed! Got tc_data1.data_int=%0d expected >%0d. ", tc_data1.data_int, tc_data2.data_int);
-					check_macro_output(test_output, test_expected);
-					test_output = "";
-				end
-			end
-		end
-		`TEST_CASE("CHECK_LESS Int Random Tests") begin
-			for (int x = 0; x < `MAX_TESTS; x++) begin
-				tc_data1.make_random();
-				tc_data2.make_random();
-				`CHECK_LESS(tc_data1.data_int, tc_data2.data_int);
-				if (tc_data1.data_int < tc_data2.data_int) begin
-					$display("Test data is less, checking output");
-					assert(check_string_empty(test_output) == 1);
-				end
-				else begin
-					$sformat(test_expected, "CHECK_LESS failed! Got tc_data1.data_int=%0d expected <%0d. ", tc_data1.data_int, tc_data2.data_int);
-					check_macro_output(test_output, test_expected);
-					test_output = "";
-				end
-			end
-		end
-		`TEST_CASE("CHECK_EQUAL_VARIANCE Int Random Tests") begin
-			for (int x = 0; x < `MAX_TESTS; x++) begin
-				tc_data1.make_random();
-				tc_data2.make_random();
-				`CHECK_EQUAL_VARIANCE(tc_data1.data_int, tc_data2.data_int, `TEST_VARIANCE);
-				if ((tc_data1.data_int > tc_data2.data_int - `TEST_VARIANCE) && (tc_data1.data_int < tc_data2.data_int + `TEST_VARIANCE)) begin
-					$display("Test data is equal, checking output");
-					assert(check_string_empty(test_output) == 1);
-				end
-				else begin
-					$sformat(test_expected, "CHECK_EQUAL_VARIANCE failed! Got tc_data1.data_int=%0d expected =%0d, +-%0d. ", tc_data1.data_int, tc_data2.data_int, `TEST_VARIANCE);
-					check_macro_output(test_output, test_expected);
-					test_output = "";
-				end
-			end
-		end
-		`TEST_CASE("CHECK_EQUAL Time Random Tests") begin
-			for (time x = 0; x < `MAX_TESTS; x++) begin
-				tc_data1.make_random();
-				tc_data2.make_random();
-				`CHECK_EQUAL(tc_data1.data_time, tc_data2.data_time);
-				if (tc_data1.data_time == tc_data2.data_time) begin
-					$display("Test data is equal, checking output");
-					assert(check_string_empty(test_output) == 1);
-				end
-				else begin
-					$sformat(test_expected, "CHECK_EQUAL failed! Got tc_data1.data_time=%0d expected =%0d. ", tc_data1.data_time, tc_data2.data_time);
-					check_macro_output(test_output, test_expected);
-					test_output = "";
-				end
-			end
-		end
-		`TEST_CASE("CHECK_NOT_EQUAL Time Random Tests") begin
-			for (time x = 0; x < `MAX_TESTS; x++) begin
-				tc_data1.make_random();
-				tc_data2.make_random();
-				`CHECK_NOT_EQUAL(tc_data1.data_time, tc_data1.data_time);
-				$sformat(test_expected, "CHECK_NOT_EQUAL failed! Got tc_data1.data_time=%0d expected !=%0d. ", tc_data1.data_time, tc_data1.data_time);
-				check_macro_output(test_output, test_expected);
-				test_output = "";
-			end
-		end
-		`TEST_CASE("CHECK_GREATER Time Random Tests") begin
-			for (int x = 0; x < `MAX_TESTS; x++) begin
-				tc_data1.make_random();
-				tc_data2.make_random();
-				`CHECK_GREATER(tc_data1.data_time, tc_data2.data_time);
-				if (tc_data1.data_time > tc_data2.data_time) begin
-					$display("Test data is greater, checking output");
-					assert(check_string_empty(test_output) == 1);
-				end
-				else begin
-					$sformat(test_expected, "CHECK_GREATER failed! Got tc_data1.data_time=%0d expected >%0d. ", tc_data1.data_time, tc_data2.data_time);
-					check_macro_output(test_output, test_expected);
-					test_output = "";
-				end
-			end
-		end
-		`TEST_CASE("CHECK_LESS Time Random Tests") begin
-			for (int x = 0; x < `MAX_TESTS; x++) begin
-				tc_data1.make_random();
-				tc_data2.make_random();
-				`CHECK_LESS(tc_data1.data_time, tc_data2.data_time);
-				if (tc_data1.data_time < tc_data2.data_time) begin
-					$display("Test data is lesser, checking output");
-					assert(check_string_empty(test_output) == 1);
-				end
-				else begin
-					$sformat(test_expected, "CHECK_LESS failed! Got tc_data1.data_time=%0d expected <%0d. ", tc_data1.data_time, tc_data2.data_time);
-					check_macro_output(test_output, test_expected);
-					test_output = "";
-				end
-			end
-		end
-		`TEST_CASE("CHECK_EQUAL_VARIANCE Time Random Tests") begin
-			for (int x = 0; x < `MAX_TESTS; x++) begin
-				tc_data1.make_random();
-				tc_data2.make_random();
-				`CHECK_EQUAL_VARIANCE(tc_data1.data_time, tc_data2.data_time, `TEST_VARIANCE);
-				if ((tc_data1.data_time > tc_data2.data_time - `TEST_VARIANCE) && (tc_data1.data_time < tc_data2.data_time + `TEST_VARIANCE)) begin
-					$display("Test data is equal, checking output");
-					assert(check_string_empty(test_output) == 1);
-				end
-				else begin
-					$sformat(test_expected, "CHECK_EQUAL_VARIANCE failed! Got tc_data1.data_time=%0d expected =%0d, +-%0d. ", tc_data1.data_time, tc_data2.data_time, `TEST_VARIANCE);
-					check_macro_output(test_output, test_expected);
-					test_output = "";
-				end
-			end
-		end
-	end
+   class test_data;
+      bit            [15:0]    data_bit;
+      int            data_int;
+      byte         data_byte;
+      shortint      data_shortint;
+      time         data_time;
+      function void make_random;
+         data_bit = $random();
+         data_int = int'($random());
+         data_byte = byte'($random());
+         data_shortint = shortint'($random());
+         data_time = time'($random());
+      endfunction
+   endclass
+   test_data tc_data1;
+   test_data tc_data2;
+   integer tc_greater, tc_less;
+   string test_output;
+   string test_expected;
+   string err_msg;
+   function bit check_string_empty(string str);
+      if (str.len() == 0)
+         return 1;
+      else
+         return 0;
+   endfunction
+   function void check_macro_output(string actual, string expected);
+      assert ( actual.compare(expected) == 0) else
+         begin
+            $sformat(err_msg, "CHECK_EQUAL_ERROR: Failure message not as expected.\n RECV: |%f|\n  EXP: |%f|\n", actual, expected);
+            $error(err_msg);
+         end;
+   endfunction;
+   `TEST_SUITE begin
+      `TEST_SUITE_SETUP begin
+         string str;
+         tc_data1 = new();
+         tc_data2 = new();
+         tc_data1.make_random();
+         tc_greater = tc_data1.data_int+1;
+         tc_less = tc_data1.data_int-1;
+         test_output = "";
+      end
+      `TEST_CASE("Check Macros Are Visible") begin
+         // Since $error is overriden by a macro, we need to explicitly check
+         // test output. The test_output string is only empty if the test passes.
+         `CHECK_EQUAL(tc_data1.data_int, tc_data1.data_int);
+         assert(check_string_empty(test_output) == 1);
+         `CHECK_NOT_EQUAL(tc_data1.data_int, tc_greater);
+         assert(check_string_empty(test_output) == 1);
+         `CHECK_GREATER(tc_greater, tc_data1.data_int);
+         assert(check_string_empty(test_output) == 1);
+         `CHECK_LESS(tc_less, tc_data1.data_int);
+         assert(check_string_empty(test_output) == 1);
+         `CHECK_EQUAL_VARIANCE(tc_less, tc_data1.data_int, 2);
+         assert(check_string_empty(test_output) == 1);
+         `CHECK_EQUAL_VARIANCE(tc_greater, tc_data1.data_int, 2);
+         assert(check_string_empty(test_output) == 1);
+      end
+      `TEST_CASE("CREATE_MSG output w message") begin
+         `CREATE_MSG(full_msg, "CHECK_EQUAL", tc_data1.data_int, tc_greater, "=", "This test should fail.");
+         $sformat(test_expected, "CHECK_EQUAL failed! Got tc_data1.data_int=%0d expected =%0d. This test should fail.", tc_data1.data_int, tc_greater);
+         check_macro_output(full_msg, test_expected);
+      end
+      `TEST_CASE("CREATE_MSG output wo message") begin
+         `CREATE_MSG(full_msg, "CHECK_EQUAL", tc_data1.data_int, tc_greater, "=");
+         $sformat(test_expected, "CHECK_EQUAL failed! Got tc_data1.data_int=%0d expected =%0d. ", tc_data1.data_int, tc_greater);
+         check_macro_output(full_msg, test_expected);
+      end
+      `TEST_CASE("Test that there are no extra spaces") begin
+         `CREATE_MSG(full_msg, "CHECK_EQUAL", 17, 21, "=", "This test should fail.");
+         $sformat(test_expected, "CHECK_EQUAL failed! Got 17=17 expected =21. This test should fail.");
+         check_macro_output(full_msg, test_expected);
+      end
+      `TEST_CASE("CHECK_EQUAL_VARIANCE failure message integer") begin
+         // Check printouts for correct error messages
+         integer rand_int1, rand_int2;
+         rand_int1 = $random();
+         rand_int2 = rand_int1 + 15;
+         `CHECK_EQUAL_VARIANCE(rand_int1, rand_int2, 5, "This test should fail.");
+         $sformat(test_expected, "CHECK_EQUAL_VARIANCE failed! Got rand_int1=%0d expected =%0d, +-%0d. This test should fail.", rand_int1, rand_int2, 5);
+         check_macro_output(test_output, test_expected);
+         test_output = "";
+         `CHECK_EQUAL_VARIANCE(rand_int1, rand_int2, 5);
+         $sformat(test_expected, "CHECK_EQUAL_VARIANCE failed! Got rand_int1=%0d expected =%0d, +-%0d. ", rand_int1, rand_int2, 5);
+         check_macro_output(test_output, test_expected);
+         test_output = "";
+      end
+      `TEST_CASE("CHECK_EQUAL Int Random Tests") begin
+         for (int x = 0; x < `MAX_TESTS; x++) begin
+            tc_data1.make_random();
+            tc_data2.make_random();
+            `CHECK_EQUAL(tc_data1.data_int, tc_data2.data_int);
+            if (tc_data1.data_int == tc_data2.data_int) begin
+               $display("Test data is equal, checking output");
+               assert(check_string_empty(test_output) == 1);
+            end
+            else begin
+               $sformat(test_expected, "CHECK_EQUAL failed! Got tc_data1.data_int=%0d expected =%0d. ", tc_data1.data_int, tc_data2.data_int);
+               check_macro_output(test_output, test_expected);
+               test_output = "";
+            end
+         end
+      end
+      `TEST_CASE("CHECK_NOT_EQUAL Int Random Tests") begin
+         for (int x = 0; x < `MAX_TESTS; x++) begin
+            tc_data1.make_random();
+            `CHECK_NOT_EQUAL(tc_data1.data_int, tc_data1.data_int);
+            $sformat(test_expected, "CHECK_NOT_EQUAL failed! Got tc_data1.data_int=%0d expected !=%0d. ", tc_data1.data_int, tc_data1.data_int);
+            check_macro_output(test_output, test_expected);
+            test_output = "";
+         end
+      end
+      `TEST_CASE("CHECK_GREATER Int Random Tests") begin
+         for (int x = 0; x < `MAX_TESTS; x++) begin
+            tc_data1.make_random();
+            tc_data2.make_random();
+            `CHECK_GREATER(tc_data1.data_int, tc_data2.data_int);
+            if (tc_data1.data_int > tc_data2.data_int) begin
+               $display("Test data is greater, checking output");
+               assert(check_string_empty(test_output) == 1);
+            end
+            else begin
+               $sformat(test_expected, "CHECK_GREATER failed! Got tc_data1.data_int=%0d expected >%0d. ", tc_data1.data_int, tc_data2.data_int);
+               check_macro_output(test_output, test_expected);
+               test_output = "";
+            end
+         end
+      end
+      `TEST_CASE("CHECK_LESS Int Random Tests") begin
+         for (int x = 0; x < `MAX_TESTS; x++) begin
+            tc_data1.make_random();
+            tc_data2.make_random();
+            `CHECK_LESS(tc_data1.data_int, tc_data2.data_int);
+            if (tc_data1.data_int < tc_data2.data_int) begin
+               $display("Test data is less, checking output");
+               assert(check_string_empty(test_output) == 1);
+            end
+            else begin
+               $sformat(test_expected, "CHECK_LESS failed! Got tc_data1.data_int=%0d expected <%0d. ", tc_data1.data_int, tc_data2.data_int);
+               check_macro_output(test_output, test_expected);
+               test_output = "";
+            end
+         end
+      end
+      `TEST_CASE("CHECK_EQUAL_VARIANCE Int Random Tests") begin
+         for (int x = 0; x < `MAX_TESTS; x++) begin
+            tc_data1.make_random();
+            tc_data2.make_random();
+            `CHECK_EQUAL_VARIANCE(tc_data1.data_int, tc_data2.data_int, `TEST_VARIANCE);
+            if ((tc_data1.data_int > tc_data2.data_int - `TEST_VARIANCE) && (tc_data1.data_int < tc_data2.data_int + `TEST_VARIANCE)) begin
+               $display("Test data is equal, checking output");
+               assert(check_string_empty(test_output) == 1);
+            end
+            else begin
+               $sformat(test_expected, "CHECK_EQUAL_VARIANCE failed! Got tc_data1.data_int=%0d expected =%0d, +-%0d. ", tc_data1.data_int, tc_data2.data_int, `TEST_VARIANCE);
+               check_macro_output(test_output, test_expected);
+               test_output = "";
+            end
+         end
+      end
+      `TEST_CASE("CHECK_EQUAL Time Random Tests") begin
+         for (time x = 0; x < `MAX_TESTS; x++) begin
+            tc_data1.make_random();
+            tc_data2.make_random();
+            `CHECK_EQUAL(tc_data1.data_time, tc_data2.data_time);
+            if (tc_data1.data_time == tc_data2.data_time) begin
+               $display("Test data is equal, checking output");
+               assert(check_string_empty(test_output) == 1);
+            end
+            else begin
+               $sformat(test_expected, "CHECK_EQUAL failed! Got tc_data1.data_time=%0d expected =%0d. ", tc_data1.data_time, tc_data2.data_time);
+               check_macro_output(test_output, test_expected);
+               test_output = "";
+            end
+         end
+      end
+      `TEST_CASE("CHECK_NOT_EQUAL Time Random Tests") begin
+         for (time x = 0; x < `MAX_TESTS; x++) begin
+            tc_data1.make_random();
+            tc_data2.make_random();
+            `CHECK_NOT_EQUAL(tc_data1.data_time, tc_data1.data_time);
+            $sformat(test_expected, "CHECK_NOT_EQUAL failed! Got tc_data1.data_time=%0d expected !=%0d. ", tc_data1.data_time, tc_data1.data_time);
+            check_macro_output(test_output, test_expected);
+            test_output = "";
+         end
+      end
+      `TEST_CASE("CHECK_GREATER Time Random Tests") begin
+         for (int x = 0; x < `MAX_TESTS; x++) begin
+            tc_data1.make_random();
+            tc_data2.make_random();
+            `CHECK_GREATER(tc_data1.data_time, tc_data2.data_time);
+            if (tc_data1.data_time > tc_data2.data_time) begin
+               $display("Test data is greater, checking output");
+               assert(check_string_empty(test_output) == 1);
+            end
+            else begin
+               $sformat(test_expected, "CHECK_GREATER failed! Got tc_data1.data_time=%0d expected >%0d. ", tc_data1.data_time, tc_data2.data_time);
+               check_macro_output(test_output, test_expected);
+               test_output = "";
+            end
+         end
+      end
+      `TEST_CASE("CHECK_LESS Time Random Tests") begin
+         for (int x = 0; x < `MAX_TESTS; x++) begin
+            tc_data1.make_random();
+            tc_data2.make_random();
+            `CHECK_LESS(tc_data1.data_time, tc_data2.data_time);
+            if (tc_data1.data_time < tc_data2.data_time) begin
+               $display("Test data is lesser, checking output");
+               assert(check_string_empty(test_output) == 1);
+            end
+            else begin
+               $sformat(test_expected, "CHECK_LESS failed! Got tc_data1.data_time=%0d expected <%0d. ", tc_data1.data_time, tc_data2.data_time);
+               check_macro_output(test_output, test_expected);
+               test_output = "";
+            end
+         end
+      end
+      `TEST_CASE("CHECK_EQUAL_VARIANCE Time Random Tests") begin
+         for (int x = 0; x < `MAX_TESTS; x++) begin
+            tc_data1.make_random();
+            tc_data2.make_random();
+            `CHECK_EQUAL_VARIANCE(tc_data1.data_time, tc_data2.data_time, `TEST_VARIANCE);
+            if ((tc_data1.data_time > tc_data2.data_time - `TEST_VARIANCE) && (tc_data1.data_time < tc_data2.data_time + `TEST_VARIANCE)) begin
+               $display("Test data is equal, checking output");
+               assert(check_string_empty(test_output) == 1);
+            end
+            else begin
+               $sformat(test_expected, "CHECK_EQUAL_VARIANCE failed! Got tc_data1.data_time=%0d expected =%0d, +-%0d. ", tc_data1.data_time, tc_data2.data_time, `TEST_VARIANCE);
+               check_macro_output(test_output, test_expected);
+               test_output = "";
+            end
+         end
+      end
+   end
 endmodule

--- a/vunit/verilog/check/test/check_tb.sv
+++ b/vunit/verilog/check/test/check_tb.sv
@@ -82,8 +82,8 @@ module check_tb;
          check_macro_output(full_msg, test_expected);
       end
       `TEST_CASE("Test that there are no extra spaces") begin
-         `CREATE_MSG(full_msg, "CHECK_EQUAL", 17, 21, "=", "This test should fail.");
-         $sformat(test_expected, "CHECK_EQUAL failed! Got 17=17 expected =21. This test should fail.");
+         `CREATE_MSG(full_msg, "CHECK_EQUAL", 17, 21, "", "This test should fail.");
+         $sformat(test_expected, "CHECK_EQUAL failed! Got 17=17 expected 21. This test should fail.");
          check_macro_output(full_msg, test_expected);
       end
       `TEST_CASE("CHECK_EQUAL_VARIANCE failure message integer") begin
@@ -92,11 +92,11 @@ module check_tb;
          rand_int1 = $random();
          rand_int2 = rand_int1 + 15;
          `CHECK_EQUAL_VARIANCE(rand_int1, rand_int2, 5, "This test should fail.");
-         $sformat(test_expected, "CHECK_EQUAL_VARIANCE failed! Got rand_int1=%0d expected =%0d, +-%0d. This test should fail.", rand_int1, rand_int2, 5);
+         $sformat(test_expected, "CHECK_EQUAL_VARIANCE failed! Got rand_int1=%0d expected %0d +-%0d. This test should fail.", rand_int1, rand_int2, 5);
          check_macro_output(test_output, test_expected);
          test_output = "";
          `CHECK_EQUAL_VARIANCE(rand_int1, rand_int2, 5);
-         $sformat(test_expected, "CHECK_EQUAL_VARIANCE failed! Got rand_int1=%0d expected =%0d, +-%0d. ", rand_int1, rand_int2, 5);
+         $sformat(test_expected, "CHECK_EQUAL_VARIANCE failed! Got rand_int1=%0d expected %0d +-%0d. ", rand_int1, rand_int2, 5);
          check_macro_output(test_output, test_expected);
          test_output = "";
       end
@@ -110,7 +110,7 @@ module check_tb;
                assert(check_string_empty(test_output) == 1);
             end
             else begin
-               $sformat(test_expected, "CHECK_EQUAL failed! Got tc_data1.data_int=%0d expected =%0d. ", tc_data1.data_int, tc_data2.data_int);
+               $sformat(test_expected, "CHECK_EQUAL failed! Got tc_data1.data_int=%0d expected %0d. ", tc_data1.data_int, tc_data2.data_int);
                check_macro_output(test_output, test_expected);
                test_output = "";
             end
@@ -167,7 +167,7 @@ module check_tb;
                assert(check_string_empty(test_output) == 1);
             end
             else begin
-               $sformat(test_expected, "CHECK_EQUAL_VARIANCE failed! Got tc_data1.data_int=%0d expected =%0d, +-%0d. ", tc_data1.data_int, tc_data2.data_int, `TEST_VARIANCE);
+               $sformat(test_expected, "CHECK_EQUAL_VARIANCE failed! Got tc_data1.data_int=%0d expected %0d +-%0d. ", tc_data1.data_int, tc_data2.data_int, `TEST_VARIANCE);
                check_macro_output(test_output, test_expected);
                test_output = "";
             end
@@ -183,7 +183,7 @@ module check_tb;
                assert(check_string_empty(test_output) == 1);
             end
             else begin
-               $sformat(test_expected, "CHECK_EQUAL failed! Got tc_data1.data_time=%0d expected =%0d. ", tc_data1.data_time, tc_data2.data_time);
+               $sformat(test_expected, "CHECK_EQUAL failed! Got tc_data1.data_time=%0d expected %0d. ", tc_data1.data_time, tc_data2.data_time);
                check_macro_output(test_output, test_expected);
                test_output = "";
             end
@@ -241,7 +241,7 @@ module check_tb;
                assert(check_string_empty(test_output) == 1);
             end
             else begin
-               $sformat(test_expected, "CHECK_EQUAL_VARIANCE failed! Got tc_data1.data_time=%0d expected =%0d, +-%0d. ", tc_data1.data_time, tc_data2.data_time, `TEST_VARIANCE);
+               $sformat(test_expected, "CHECK_EQUAL_VARIANCE failed! Got tc_data1.data_time=%0d expected %0d +-%0d. ", tc_data1.data_time, tc_data2.data_time, `TEST_VARIANCE);
                check_macro_output(test_output, test_expected);
                test_output = "";
             end

--- a/vunit/verilog/check/test/check_tb.sv
+++ b/vunit/verilog/check/test/check_tb.sv
@@ -18,7 +18,6 @@ module check_tb;
 		randc	time			data_time;
 		//randc	real			data_real;
 	endclass;
-	
 	test_data case_data1;
 	integer case_greater, case_less;
 
@@ -26,10 +25,9 @@ module check_tb;
 		`TEST_SUITE_SETUP begin
 			case_data1 = new();
 		end
-		
 		`TEST_CASE("Check Macros Are Visible") begin
-				if(!case_data1.randomize()) 
-					$display("Randomization failed"); 
+				if(!case_data1.randomize())
+					$display("Randomization failed");
 				case_greater = case_data1.data_integer+1;
 				case_less = case_data1.data_integer-1;
 				`CHECK_EQUAL(case_data1.data_integer, case_data1.data_integer);
@@ -38,8 +36,6 @@ module check_tb;
 				`CHECK_LESS(case_less, case_data1.data_integer);
 				`CHECK_EQUAL_VARIANCE(case_less, case_data1.data_integer, 2);
 				`CHECK_EQUAL_VARIANCE(case_greater, case_data1.data_integer, 2);
-			
 		end
 	end
-
-endmodule 
+endmodule

--- a/vunit/verilog/check/test/check_tb.sv
+++ b/vunit/verilog/check/test/check_tb.sv
@@ -8,6 +8,7 @@
 `include "vunit_defines.svh"
 `define __ERROR_FUNC(err_msg) $sformat(test_output, "%s", err_msg);
 `define MAX_TESTS 512
+`define TEST_VARIANCE 5
 
 module check_tb;
 
@@ -25,8 +26,9 @@ module check_tb;
 			data_time = time'($random());
 		endfunction
 	endclass
-	test_data case_data1;
-	integer case_greater, case_less;
+	test_data tc_data1;
+	test_data tc_data2;
+	integer tc_greater, tc_less;
 	string test_output;
 	string test_expected;
 	string err_msg;
@@ -45,101 +47,204 @@ module check_tb;
 	endfunction;
 	`TEST_SUITE begin
 		`TEST_SUITE_SETUP begin
-			case_data1 = new();
-			case_data1.make_random();
-			case_greater = case_data1.data_int+1;
-			case_less = case_data1.data_int-1;
+			string str;
+			tc_data1 = new();
+			tc_data2 = new();
+			tc_data1.make_random();
+			tc_greater = tc_data1.data_int+1;
+			tc_less = tc_data1.data_int-1;
 			test_output = "";
 		end
 		`TEST_CASE("Check Macros Are Visible") begin
-			// if(!case_data1.randomize())
+			// if(!tc_data1.randomize())
 			//	$error("Randomization failed");
 			// Since $error is overriden by a macro, we need to explicitly check
 			// test output. The test_output string is only empty if the test passes.
-			`CHECK_EQUAL(case_data1.data_int, case_data1.data_int);
+			`CHECK_EQUAL(tc_data1.data_int, tc_data1.data_int);
 			assert(check_string_empty(test_output) == 1);
-			`CHECK_NOT_EQUAL(case_data1.data_int, case_greater);
+			`CHECK_NOT_EQUAL(tc_data1.data_int, tc_greater);
 			assert(check_string_empty(test_output) == 1);
-			`CHECK_GREATER(case_greater, case_data1.data_int);
+			`CHECK_GREATER(tc_greater, tc_data1.data_int);
 			assert(check_string_empty(test_output) == 1);
-			`CHECK_LESS(case_less, case_data1.data_int);
+			`CHECK_LESS(tc_less, tc_data1.data_int);
 			assert(check_string_empty(test_output) == 1);
-			`CHECK_EQUAL_VARIANCE(case_less, case_data1.data_int, 2);
+			`CHECK_EQUAL_VARIANCE(tc_less, tc_data1.data_int, 2);
 			assert(check_string_empty(test_output) == 1);
-			`CHECK_EQUAL_VARIANCE(case_greater, case_data1.data_int, 2);
+			`CHECK_EQUAL_VARIANCE(tc_greater, tc_data1.data_int, 2);
 			assert(check_string_empty(test_output) == 1);
 		end
-		`TEST_CASE("CHECK_EQUAL failure message integer") begin
-			// Check printouts for correct error messages
-			for (int x = 0; x < `MAX_TESTS; x++) begin
-				case_data1.make_random();
-				`CHECK_EQUAL(case_data1.data_int, case_greater, "This test should fail.");
-				$sformat(test_expected, "CHECK_EQUAL failed! Got %d expected %d. This test should fail.", case_data1.data_int, case_greater);
-				check_macro_output(test_output, test_expected);
-				test_output = "";
-				`CHECK_EQUAL(case_data1.data_int, case_greater);
-				$sformat(test_expected, "CHECK_EQUAL failed! Got %d expected %d. ", case_data1.data_int, case_greater);
-				check_macro_output(test_output, test_expected);
-				test_output = "";
-			end
+		`TEST_CASE("CREATE_MSG output w message") begin
+			`CREATE_MSG(full_msg, "CHECK_EQUAL", tc_data1.data_int, tc_greater, "This test should fail.");
+			$sformat(test_expected, "CHECK_EQUAL failed! Got %d expected %d. This test should fail.", tc_data1.data_int, tc_greater);
+			check_macro_output(full_msg, test_expected);
 		end
-		`TEST_CASE("CHECK_NOT_EQUAL failure message integer") begin
-			// Check printouts for correct error messages
-			for (int x = 0; x < `MAX_TESTS; x++) begin
-				case_data1.make_random();
-				case_greater = case_data1.data_int+1;
-				`CHECK_NOT_EQUAL(case_data1.data_int, case_data1.data_int, "This test should fail.");
-				$sformat(test_expected, "CHECK_NOT_EQUAL failed! Got %d expected %d. This test should fail.", case_data1.data_int, case_data1.data_int);
-				check_macro_output(test_output, test_expected);
-				test_output = "";
-				`CHECK_NOT_EQUAL(case_data1.data_int, case_data1.data_int);
-				$sformat(test_expected, "CHECK_NOT_EQUAL failed! Got %d expected %d. ", case_data1.data_int, case_data1.data_int);
-				check_macro_output(test_output, test_expected);
-				test_output = "";
-			end
-		end
-		`TEST_CASE("CHECK_GREATER failure message integer") begin
-			// Check printouts for correct error messages
-			for (int x = 0; x < `MAX_TESTS; x++) begin
-				case_data1.make_random();
-				`CHECK_GREATER(case_data1.data_int, case_data1.data_int, "This test should fail.");
-				$sformat(test_expected, "CHECK_GREATER failed! Got %d expected %d. This test should fail.", case_data1.data_int, case_data1.data_int);
-				check_macro_output(test_output, test_expected);
-				test_output = "";
-				`CHECK_GREATER(case_data1.data_int, case_data1.data_int);
-				$sformat(test_expected, "CHECK_GREATER failed! Got %d expected %d. ", case_data1.data_int, case_data1.data_int);
-				check_macro_output(test_output, test_expected);
-				test_output = "";
-			end
-		end
-		`TEST_CASE("CHECK_LESS failure message integer") begin
-			// Check printouts for correct error messages
-			for (int x = 0; x < `MAX_TESTS; x++) begin
-				case_data1.make_random();
-				`CHECK_LESS(case_data1.data_int, case_data1.data_int, "This test should fail.");
-				$sformat(test_expected, "CHECK_LESS failed! Got %d expected %d. This test should fail.", case_data1.data_int, case_data1.data_int);
-				check_macro_output(test_output, test_expected);
-				test_output = "";
-				`CHECK_LESS(case_data1.data_int, case_data1.data_int);
-				$sformat(test_expected, "CHECK_LESS failed! Got %d expected %d. ", case_data1.data_int, case_data1.data_int);
-				check_macro_output(test_output, test_expected);
-				test_output = "";
-			end
+		`TEST_CASE("CREATE_MSG output wo message") begin
+			`CREATE_MSG(full_msg, "CHECK_EQUAL", tc_data1.data_int, tc_greater);
+			$sformat(test_expected, "CHECK_EQUAL failed! Got %d expected %d. ", tc_data1.data_int, tc_greater);
+			check_macro_output(full_msg, test_expected);
 		end
 		`TEST_CASE("CHECK_EQUAL_VARIANCE failure message integer") begin
 			// Check printouts for correct error messages
 			integer rand_int1, rand_int2;
+			rand_int1 = $random();
+			rand_int2 = rand_int1 + 15;
+			`CHECK_EQUAL_VARIANCE(rand_int1, rand_int2, 5, "This test should fail.");
+			$sformat(test_expected, "CHECK_EQUAL_VARIANCE failed! Got %d expected %d +- %d. This test should fail.", rand_int1, rand_int2, 5);
+			check_macro_output(test_output, test_expected);
+			test_output = "";
+			`CHECK_EQUAL_VARIANCE(rand_int1, rand_int2, 5);
+			$sformat(test_expected, "CHECK_EQUAL_VARIANCE failed! Got %d expected %d +- %d. ", rand_int1, rand_int2, 5);
+			check_macro_output(test_output, test_expected);
+			test_output = "";
+		end
+		`TEST_CASE("CHECK_EQUAL Int Random Tests") begin
 			for (int x = 0; x < `MAX_TESTS; x++) begin
-				rand_int1 = $random();
-				rand_int2 = rand_int1 + 15;
-				`CHECK_EQUAL_VARIANCE(rand_int1, rand_int2, 5, "This test should fail.");
-				$sformat(test_expected, "CHECK_EQUAL_VARIANCE failed! Got %d expected %d +- %d. This test should fail.", rand_int1, rand_int2, 5);
-				check_macro_output(test_output, test_expected);
-				test_output = "";
-				`CHECK_EQUAL_VARIANCE(rand_int1, rand_int2, 5);
-				$sformat(test_expected, "CHECK_EQUAL_VARIANCE failed! Got %d expected %d +- %d. ", rand_int1, rand_int2, 5);
-				check_macro_output(test_output, test_expected);
-				test_output = "";
+				tc_data1.make_random();
+				tc_data2.make_random();
+				`CHECK_EQUAL(tc_data1.data_int, tc_data2.data_int);
+				if (tc_data1.data_int == tc_data2.data_int) begin
+					assert(check_string_empty(test_output) == 1);
+				end
+				else begin
+					$sformat(test_expected, "CHECK_EQUAL failed! Got %d expected %d. ", tc_data1.data_int, tc_data2.data_int);
+					check_macro_output(test_output, test_expected);
+					test_output = "";
+				end
+			end
+		end
+		`TEST_CASE("CHECK_NOT_EQUAL Int Random Tests") begin
+			for (int x = 0; x < `MAX_TESTS; x++) begin
+				tc_data1.make_random();
+				tc_data2.make_random();
+				`CHECK_NOT_EQUAL(tc_data1.data_int, tc_data2.data_int);
+				if (tc_data1.data_int !== tc_data2.data_int) begin
+					assert(check_string_empty(test_output) == 1);
+				end
+				else begin
+					$sformat(test_expected, "CHECK_NOT_EQUAL failed! Got %d expected %d. ", tc_data1.data_int, tc_data2.data_int);
+					check_macro_output(test_output, test_expected);
+					test_output = "";
+				end
+			end
+		end
+		`TEST_CASE("CHECK_GREATER Int Random Tests") begin
+			for (int x = 0; x < `MAX_TESTS; x++) begin
+				tc_data1.make_random();
+				tc_data2.make_random();
+				`CHECK_GREATER(tc_data1.data_int, tc_data2.data_int);
+				if (tc_data1.data_int > tc_data2.data_int) begin
+					assert(check_string_empty(test_output) == 1);
+				end
+				else begin
+					$sformat(test_expected, "CHECK_GREATER failed! Got %d expected %d. ", tc_data1.data_int, tc_data2.data_int);
+					check_macro_output(test_output, test_expected);
+					test_output = "";
+				end
+			end
+		end
+		`TEST_CASE("CHECK_LESS Int Random Tests") begin
+			for (int x = 0; x < `MAX_TESTS; x++) begin
+				tc_data1.make_random();
+				tc_data2.make_random();
+				`CHECK_LESS(tc_data1.data_int, tc_data2.data_int);
+				if (tc_data1.data_int < tc_data2.data_int) begin
+					assert(check_string_empty(test_output) == 1);
+				end
+				else begin
+					$sformat(test_expected, "CHECK_LESS failed! Got %d expected %d. ", tc_data1.data_int, tc_data2.data_int);
+					check_macro_output(test_output, test_expected);
+					test_output = "";
+				end
+			end
+		end
+		`TEST_CASE("CHECK_EQUAL_VARIANCE Int Random Tests") begin
+			for (int x = 0; x < `MAX_TESTS; x++) begin
+				tc_data1.make_random();
+				tc_data2.make_random();
+				`CHECK_EQUAL_VARIANCE(tc_data1.data_int, tc_data2.data_int, `TEST_VARIANCE);
+				if ((tc_data1.data_int > tc_data2.data_int - `TEST_VARIANCE) && (tc_data1.data_int < tc_data2.data_int + `TEST_VARIANCE)) begin
+					assert(check_string_empty(test_output) == 1);
+				end
+				else begin
+					$sformat(test_expected, "CHECK_EQUAL_VARIANCE failed! Got %d expected %d +- %d. ", tc_data1.data_int, tc_data2.data_int, `TEST_VARIANCE);
+					check_macro_output(test_output, test_expected);
+					test_output = "";
+				end
+			end
+		end
+		`TEST_CASE("CHECK_EQUAL Time Random Tests") begin
+			for (time x = 0; x < `MAX_TESTS; x++) begin
+				tc_data1.make_random();
+				tc_data2.make_random();
+				`CHECK_EQUAL(tc_data1.data_time, tc_data2.data_time);
+				if (tc_data1.data_time == tc_data2.data_time) begin
+					assert(check_string_empty(test_output) == 1);
+				end
+				else begin
+					$sformat(test_expected, "CHECK_EQUAL failed! Got %d expected %d. ", tc_data1.data_time, tc_data2.data_time);
+					check_macro_output(test_output, test_expected);
+					test_output = "";
+				end
+			end
+		end
+		`TEST_CASE("CHECK_NOT_EQUAL Time Random Tests") begin
+			for (time x = 0; x < `MAX_TESTS; x++) begin
+				tc_data1.make_random();
+				tc_data2.make_random();
+				`CHECK_NOT_EQUAL(tc_data1.data_time, tc_data2.data_time);
+				if (tc_data1.data_time !== tc_data2.data_time) begin
+					assert(check_string_empty(test_output) == 1);
+				end
+				else begin
+					$sformat(test_expected, "CHECK_NOT_EQUAL failed! Got %d expected %d. ", tc_data1.data_time, tc_data2.data_time);
+					check_macro_output(test_output, test_expected);
+					test_output = "";
+				end
+			end
+		end
+		`TEST_CASE("CHECK_GREATER Time Random Tests") begin
+			for (int x = 0; x < `MAX_TESTS; x++) begin
+				tc_data1.make_random();
+				tc_data2.make_random();
+				`CHECK_GREATER(tc_data1.data_time, tc_data2.data_time);
+				if (tc_data1.data_time > tc_data2.data_time) begin
+					assert(check_string_empty(test_output) == 1);
+				end
+				else begin
+					$sformat(test_expected, "CHECK_GREATER failed! Got %d expected %d. ", tc_data1.data_time, tc_data2.data_time);
+					check_macro_output(test_output, test_expected);
+					test_output = "";
+				end
+			end
+		end
+		`TEST_CASE("CHECK_LESS Time Random Tests") begin
+			for (int x = 0; x < `MAX_TESTS; x++) begin
+				tc_data1.make_random();
+				tc_data2.make_random();
+				`CHECK_LESS(tc_data1.data_time, tc_data2.data_time);
+				if (tc_data1.data_time < tc_data2.data_time) begin
+					assert(check_string_empty(test_output) == 1);
+				end
+				else begin
+					$sformat(test_expected, "CHECK_LESS failed! Got %d expected %d. ", tc_data1.data_time, tc_data2.data_time);
+					check_macro_output(test_output, test_expected);
+					test_output = "";
+				end
+			end
+		end
+		`TEST_CASE("CHECK_EQUAL_VARIANCE Time Random Tests") begin
+			for (int x = 0; x < `MAX_TESTS; x++) begin
+				tc_data1.make_random();
+				tc_data2.make_random();
+				`CHECK_EQUAL_VARIANCE(tc_data1.data_time, tc_data2.data_time, `TEST_VARIANCE);
+				if ((tc_data1.data_time > tc_data2.data_time - `TEST_VARIANCE) && (tc_data1.data_time < tc_data2.data_time + `TEST_VARIANCE)) begin
+					assert(check_string_empty(test_output) == 1);
+				end
+				else begin
+					$sformat(test_expected, "CHECK_EQUAL_VARIANCE failed! Got %d expected %d +- %d. ", tc_data1.data_time, tc_data2.data_time, `TEST_VARIANCE);
+					check_macro_output(test_output, test_expected);
+					test_output = "";
+				end
 			end
 		end
 	end

--- a/vunit/verilog/check/test/check_tb.sv
+++ b/vunit/verilog/check/test/check_tb.sv
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this file,
 // You can obtain one at http://mozilla.org/MPL/2.0/.
 //
-// Copyright (c) 2015-2016, Lars Asplund lars.anders.asplund@gmail.com
+// Copyright (c) 2014-2018, Lars Asplund lars.anders.asplund@gmail.com
 
 `timescale 10ns / 10ns
 `include "vunit_defines.svh"

--- a/vunit/verilog/check/test/check_tb.sv
+++ b/vunit/verilog/check/test/check_tb.sv
@@ -6,6 +6,8 @@
 
 `timescale 10ns / 10ns
 `include "vunit_defines.svh"
+`define __ERROR_FUNC(err_msg) $sformat(test_output, "%s", err_msg);
+`define MAX_TESTS 512
 
 module check_tb;
 
@@ -25,6 +27,24 @@ module check_tb;
 	endclass
 	test_data case_data1;
 	integer case_greater, case_less;
+	string test_output;
+	string test_expected;
+	string err_msg;
+	
+	function bit check_string_empty(string str);
+		if (str.compare("") !== 1) 
+			return 1;
+		else
+			return 0;
+	endfunction
+	
+	function void check_macro_output(string actual, string expected);
+		assert ( actual.compare(expected) == 0) else	
+			begin
+				$sformat(err_msg, "CHECK_EQUAL_ERROR: Failure message not as expected.\n RECV: |%f|\n  EXP: |%f|\n", actual, expected);
+				$error(err_msg);
+			end;
+	endfunction;
 
 	`TEST_SUITE begin
 		`TEST_SUITE_SETUP begin
@@ -32,31 +52,95 @@ module check_tb;
 			case_data1.make_random();
 			case_greater = case_data1.data_int+1;
 			case_less = case_data1.data_int-1;
+			test_output = "";
 		end
 		`TEST_CASE("Check Macros Are Visible") begin
 			// if(!case_data1.randomize())
 			//	$error("Randomization failed");
+			// Since $error is overriden by a macro, we need to explicitly check
+			// test output. The test_output string is only empty if the test passes.
 			`CHECK_EQUAL(case_data1.data_int, case_data1.data_int);
+			assert(check_string_empty(test_output) == 1);
 			`CHECK_NOT_EQUAL(case_data1.data_int, case_greater);
+			assert(check_string_empty(test_output) == 1);
 			`CHECK_GREATER(case_greater, case_data1.data_int);
+			assert(check_string_empty(test_output) == 1);
 			`CHECK_LESS(case_less, case_data1.data_int);
+			assert(check_string_empty(test_output) == 1);
 			`CHECK_EQUAL_VARIANCE(case_less, case_data1.data_int, 2);
+			assert(check_string_empty(test_output) == 1);
 			`CHECK_EQUAL_VARIANCE(case_greater, case_data1.data_int, 2);
+			assert(check_string_empty(test_output) == 1);
 		end
-		/* `TEST_CASE("CHECK_EQUAL failure message") begin
-			`CHECK_EQUAL(case_data1.data_int, case_greater, "This test should fail.");
+		`TEST_CASE("CHECK_EQUAL failure message") begin
+			// Check printouts for correct error messages
+			for (int x = 0; x < `MAX_TESTS; x++) begin
+				case_data1.make_random();
+				case_greater = case_data1.data_int+1;
+				`CHECK_EQUAL(case_data1.data_int, case_greater, "This test should fail.");
+				$sformat(test_expected, "CHECK_EQUAL failed! Got %d expected %d. This test should fail.", case_data1.data_int, case_greater);
+				check_macro_output(test_output, test_expected);
+				test_output = "";
+				`CHECK_EQUAL(case_data1.data_int, case_greater);
+				$sformat(test_expected, "CHECK_EQUAL failed! Got %d expected %d. ", case_data1.data_int, case_greater);
+				check_macro_output(test_output, test_expected);
+				test_output = "";
+			end
 		end
 		`TEST_CASE("CHECK_NOT_EQUAL failure message") begin
-			`CHECK_NOT_EQUAL(case_data1.data_int, case_data1.data_int, "This test should fail.");
+			for (int x = 0; x < `MAX_TESTS; x++) begin
+				case_data1.make_random();
+				case_greater = case_data1.data_int+1;
+				`CHECK_NOT_EQUAL(case_data1.data_int, case_data1.data_int, "This test should fail.");
+				$sformat(test_expected, "CHECK_NOT_EQUAL failed! Got %d expected %d. This test should fail.", case_data1.data_int, case_data1.data_int);
+				check_macro_output(test_output, test_expected);
+				test_output = "";
+				`CHECK_NOT_EQUAL(case_data1.data_int, case_data1.data_int);
+				$sformat(test_expected, "CHECK_NOT_EQUAL failed! Got %d expected %d. ", case_data1.data_int, case_data1.data_int);
+				check_macro_output(test_output, test_expected);
+				test_output = "";
+			end
 		end
 		`TEST_CASE("CHECK_GREATER failure message") begin
-			`CHECK_GREATER(case_data1.data_int, case_data1.data_int, "This test should fail.");
+			for (int x = 0; x < `MAX_TESTS; x++) begin
+				case_data1.make_random();
+				`CHECK_GREATER(case_data1.data_int, case_data1.data_int, "This test should fail.");
+				$sformat(test_expected, "CHECK_GREATER failed! Got %d expected %d. This test should fail.", case_data1.data_int, case_data1.data_int);
+				check_macro_output(test_output, test_expected);
+				test_output = "";
+				`CHECK_GREATER(case_data1.data_int, case_data1.data_int);
+				$sformat(test_expected, "CHECK_GREATER failed! Got %d expected %d. ", case_data1.data_int, case_data1.data_int);
+				check_macro_output(test_output, test_expected);
+				test_output = "";
+			end
 		end
 		`TEST_CASE("CHECK_LESS failure message") begin
-			`CHECK_LESS(case_data1.data_int, case_data1.data_int, "This test should fail.");
+			for (int x = 0; x < `MAX_TESTS; x++) begin
+				case_data1.make_random();
+				`CHECK_LESS(case_data1.data_int, case_data1.data_int, "This test should fail.");
+				$sformat(test_expected, "CHECK_LESS failed! Got %d expected %d. This test should fail.", case_data1.data_int, case_data1.data_int);
+				check_macro_output(test_output, test_expected);
+				test_output = "";
+				`CHECK_LESS(case_data1.data_int, case_data1.data_int);
+				$sformat(test_expected, "CHECK_LESS failed! Got %d expected %d. ", case_data1.data_int, case_data1.data_int);
+				check_macro_output(test_output, test_expected);
+				test_output = "";
+			end
 		end
 		`TEST_CASE("CHECK_EQUAL_VARIANCE failure message") begin
-			`CHECK_EQUAL_VARIANCE(case_data1.data_int, case_data1.data_int+5, 1, "This test should fail.");
-		end */
+			integer rand_int1, rand_int2;
+			for (int x = 0; x < `MAX_TESTS; x++) begin
+				rand_int1 = $random();
+				rand_int2 = rand_int1 + 15;
+				`CHECK_EQUAL_VARIANCE(rand_int1, rand_int2, 5, "This test should fail.");
+				$sformat(test_expected, "CHECK_EQUAL_VARIANCE failed! Got %d expected %d +- %d. This test should fail.", rand_int1, rand_int2, 5);
+				check_macro_output(test_output, test_expected);
+				test_output = "";
+				`CHECK_EQUAL_VARIANCE(rand_int1, rand_int2, 5);
+				$sformat(test_expected, "CHECK_EQUAL_VARIANCE failed! Got %d expected %d +- %d. ", rand_int1, rand_int2, 5);
+				check_macro_output(test_output, test_expected);
+				test_output = "";
+			end
+		end 
 	end
 endmodule

--- a/vunit/verilog/include/vunit_defines.svh
+++ b/vunit/verilog/include/vunit_defines.svh
@@ -28,28 +28,28 @@
 `define TEST_CASE_CLEANUP if (__runner__.is_test_case_cleanup())
 `define __ERROR_FUNC(msg) $error(msg)
 `define CREATE_ARG_STRING(arg, arg_str) \
-	$swrite(arg_str, arg); \
-	for (int i=0; i<arg_str.len(); i++) begin \
-		if (arg_str[i] != " ") begin \
-			arg_str = arg_str.substr(i, arg_str.len()-1); \
-		break; \
-		end \
-	end 
+   $swrite(arg_str, arg); \
+   for (int i=0; i<arg_str.len(); i++) begin \
+      if (arg_str[i] != " ") begin \
+         arg_str = arg_str.substr(i, arg_str.len()-1); \
+      break; \
+      end \
+   end 
 `define CREATE_MSG(full_msg,func_name,got,expected,prefix,msg=__none__) \
-	string __none__; \
-	string got_str; \
-	string expected_str; \
-	string full_msg; \
-	int index; \
-	got_str = "";\
-	expected_str ="";\
-	`CREATE_ARG_STRING(got, got_str); \
-	`CREATE_ARG_STRING(expected, expected_str); \
-	full_msg = {func_name, " failed! Got ",`"got`", "=",  got_str, " expected ", prefix, expected_str, ". ", msg}; 
+   string __none__; \
+   string got_str; \
+   string expected_str; \
+   string full_msg; \
+   int index; \
+   got_str = "";\
+   expected_str ="";\
+   `CREATE_ARG_STRING(got, got_str); \
+   `CREATE_ARG_STRING(expected, expected_str); \
+   full_msg = {func_name, " failed! Got ",`"got`", "=",  got_str, " expected ", prefix, expected_str, ". ", msg}; 
 `define CHECK_EQUAL(got,expected,msg=__none__) \
         assert ((got) === (expected)) else \
           begin \
-			 `CREATE_MSG(full_msg, "CHECK_EQUAL", got, expected, "=", msg); \
+          `CREATE_MSG(full_msg, "CHECK_EQUAL", got, expected, "=", msg); \
              `__ERROR_FUNC(full_msg); \
           end
 `define CHECK_NOT_EQUAL(got,expected,msg=__none__) \
@@ -73,18 +73,18 @@
 `define CHECK_EQUAL_VARIANCE(got,expected,variance,msg=__none__) \
         assert (((got) < ((expected) + (variance))) && ((got) > ((expected) - (variance)))) else \
           begin \
-			string __none__; \
-			string got_str; \
-			string expected_str; \
-			string variance_str; \
-			string full_msg; \
-			int index; \
-			got_str = "";\
-			expected_str ="";\
-			variance_str="";\
-			`CREATE_ARG_STRING(got, got_str); \
-			`CREATE_ARG_STRING(expected, expected_str); \
-			`CREATE_ARG_STRING(variance, variance_str); \
+         string __none__; \
+         string got_str; \
+         string expected_str; \
+         string variance_str; \
+         string full_msg; \
+         int index; \
+         got_str = "";\
+         expected_str ="";\
+         variance_str="";\
+         `CREATE_ARG_STRING(got, got_str); \
+         `CREATE_ARG_STRING(expected, expected_str); \
+         `CREATE_ARG_STRING(variance, variance_str); \
              full_msg = {"CHECK_EQUAL_VARIANCE failed! Got ",`"got`", "=",  got_str, " expected =", expected_str, ", +-", variance_str, ". ", msg}; \
              `__ERROR_FUNC(full_msg); \
           end

--- a/vunit/verilog/include/vunit_defines.svh
+++ b/vunit/verilog/include/vunit_defines.svh
@@ -49,7 +49,7 @@
 `define CHECK_EQUAL(got,expected,msg=__none__) \
         assert ((got) === (expected)) else \
           begin \
-          `CREATE_MSG(full_msg, "CHECK_EQUAL", got, expected, "=", msg); \
+          `CREATE_MSG(full_msg, "CHECK_EQUAL", got, expected, "", msg); \
              `__ERROR_FUNC(full_msg); \
           end
 `define CHECK_NOT_EQUAL(got,expected,msg=__none__) \
@@ -85,6 +85,6 @@
          `CREATE_ARG_STRING(got, got_str); \
          `CREATE_ARG_STRING(expected, expected_str); \
          `CREATE_ARG_STRING(variance, variance_str); \
-             full_msg = {"CHECK_EQUAL_VARIANCE failed! Got ",`"got`", "=",  got_str, " expected =", expected_str, ", +-", variance_str, ". ", msg}; \
+             full_msg = {"CHECK_EQUAL_VARIANCE failed! Got ",`"got`", "=",  got_str, " expected ", expected_str, " +-", variance_str, ". ", msg}; \
              `__ERROR_FUNC(full_msg); \
           end

--- a/vunit/verilog/include/vunit_defines.svh
+++ b/vunit/verilog/include/vunit_defines.svh
@@ -37,10 +37,15 @@
 	end 
 `define CREATE_MSG(full_msg,func_name,got,expected,prefix,msg=__none__) \
 	string __none__; \
-	string full_msg; \
 	string got_str; \
+	string expected_str; \
+	string full_msg; \
+	int index; \
+	got_str = "";\
+	expected_str ="";\
 	`CREATE_ARG_STRING(got, got_str); \
-	$sformat(full_msg, "%s failed! Got %s%s%0d expected %s%0d. %s", func_name, got_str, prefix, got, prefix, expected, msg); 
+	`CREATE_ARG_STRING(expected, expected_str); \
+	full_msg = {func_name, " failed! Got ",`"got`", "=",  got_str, " expected ", prefix, expected_str, ". ", msg}; 
 `define CHECK_EQUAL(got,expected,msg=__none__) \
         assert ((got) === (expected)) else \
           begin \
@@ -68,10 +73,18 @@
 `define CHECK_EQUAL_VARIANCE(got,expected,variance,msg=__none__) \
         assert (((got) < ((expected) + (variance))) && ((got) > ((expected) - (variance)))) else \
           begin \
-             string __none__; \
-             string full_msg; \
-			 string got_str; \
-			 `CREATE_ARG_STRING(got, got_str); \
-             $sformat(full_msg, "CHECK_EQUAL_VARIANCE failed! Got %s=%0d expected %0d +- %0d. %s", got_str, got, expected, variance, msg); \
+			string __none__; \
+			string got_str; \
+			string expected_str; \
+			string variance_str; \
+			string full_msg; \
+			int index; \
+			got_str = "";\
+			expected_str ="";\
+			variance_str="";\
+			`CREATE_ARG_STRING(got, got_str); \
+			`CREATE_ARG_STRING(expected, expected_str); \
+			`CREATE_ARG_STRING(variance, variance_str); \
+             full_msg = {"CHECK_EQUAL_VARIANCE failed! Got ",`"got`", "=",  got_str, " expected =", expected_str, ", +-", variance_str, ". ", msg}; \
              `__ERROR_FUNC(full_msg); \
           end

--- a/vunit/verilog/include/vunit_defines.svh
+++ b/vunit/verilog/include/vunit_defines.svh
@@ -26,112 +26,51 @@
 
 `define TEST_CASE_SETUP if (__runner__.is_test_case_setup())
 `define TEST_CASE_CLEANUP if (__runner__.is_test_case_cleanup())
+`define CREATE_MSG(full_msg,func_name,got,expected,msg=__none) \
+	string __none__; \
+	string got_str; \
+	string expected_str; \
+	string full_msg; \
+	int index; \
+	got_str = "";\
+	expected_str ="";\
+	$swrite(got_str, got); \
+	$swrite(expected_str, expected); \
+	for (int i=0; i<got_str.len(); i++) begin \
+		if (got_str[i] != " ") begin \
+			got_str = got_str.substr(i, got_str.len()-1); \
+			break; \
+		end \
+	end \
+	for (int i=0; i<expected_str.len(); i++) begin \
+		if (expected_str[i] != " ") begin \
+			expected_str = expected_str.substr(i, expected_str.len()-1); \
+			break; \
+		end \
+	end \
+	full_msg = {func_name, " failed! Got ",`"got`", "=",  got_str, " expected ", expected_str, ". ", msg}; 
 `define CHECK_EQUAL(got,expected,msg=__none__) \
         assert ((got) === (expected)) else \
           begin \
-             string __none__; \
-             string got_str; \
-             string expected_str; \
-             string full_msg; \
-             int index; \
-             got_str = "";\
-             expected_str ="";\
-             $swrite(got_str, got); \
-             $swrite(expected_str, expected); \
-               for (int i=0; i<got_str.len(); i++) begin \
-                  if (got_str[i] != " ") begin \
-                     got_str = got_str.substr(i, got_str.len()-1); \
-                     break; \
-                  end \
-               end \
-               for (int i=0; i<expected_str.len(); i++) begin \
-                  if (expected_str[i] != " ") begin \
-                     expected_str = expected_str.substr(i, expected_str.len()-1); \
-                     break; \
-                  end \
-               end \
-             full_msg = {"CHECK_EQUAL failed! Got ",`"got`", "=",  got_str, " expected ", expected_str, ". ", msg}; \
+			 `CREATE_MSG(full_msg, "CHECK_EQUAL", got, expected, msg); \
              $error(full_msg); \
           end
 `define CHECK_NOT_EQUAL(got,expected,msg=__none__) \
         assert ((got) !== (expected)) else \
           begin \
-             string __none__; \
-             string got_str; \
-             string expected_str; \
-             string full_msg; \
-             int index; \
-             got_str = "";\
-             expected_str ="";\
-             $swrite(got_str, got); \
-             $swrite(expected_str, expected); \
-               for (int i=0; i<got_str.len(); i++) begin \
-                  if (got_str[i] != " ") begin \
-                     got_str = got_str.substr(i, got_str.len()-1); \
-                     break; \
-                  end \
-               end \
-               for (int i=0; i<expected_str.len(); i++) begin \
-                  if (expected_str[i] != " ") begin \
-                     expected_str = expected_str.substr(i, expected_str.len()-1); \
-                     break; \
-                  end \
-               end \
-             full_msg = {"CHECK_NOT_EQUAL failed! Got ",`"got`", "=",  got_str, " expected ", expected_str, ". ", msg}; \
+             `CREATE_MSG(full_msg, "CHECK_NOT_EQUAL", got, expected, msg); \
              $error(full_msg); \
           end
 `define CHECK_GREATER(got,expected,msg=__none__) \
         assert ((got) > (expected)) else \
           begin \
-             string __none__; \
-             string got_str; \
-             string expected_str; \
-             string full_msg; \
-             int index; \
-             got_str = "";\
-             expected_str ="";\
-             $swrite(got_str, got); \
-             $swrite(expected_str, expected); \
-               for (int i=0; i<got_str.len(); i++) begin \
-                  if (got_str[i] != " ") begin \
-                     got_str = got_str.substr(i, got_str.len()-1); \
-                     break; \
-                  end \
-               end \
-               for (int i=0; i<expected_str.len(); i++) begin \
-                  if (expected_str[i] != " ") begin \
-                     expected_str = expected_str.substr(i, expected_str.len()-1); \
-                     break; \
-                  end \
-               end \
-             full_msg = {"CHECK_GREATER failed! Got ",`"got`", "=",  got_str, " expected greater than", expected_str, ". ", msg}; \
+             `CREATE_MSG(full_msg, "CHECK_GREATER", got, expected, msg); \
              $error(full_msg); \
           end
 `define CHECK_LESS(got,expected,msg=__none__) \
         assert ((got) < (expected)) else \
           begin \
-             string __none__; \
-             string got_str; \
-             string expected_str; \
-             string full_msg; \
-             int index; \
-             got_str = "";\
-             expected_str ="";\
-             $swrite(got_str, got); \
-             $swrite(expected_str, expected); \
-               for (int i=0; i<got_str.len(); i++) begin \
-                  if (got_str[i] != " ") begin \
-                     got_str = got_str.substr(i, got_str.len()-1); \
-                     break; \
-                  end \
-               end \
-               for (int i=0; i<expected_str.len(); i++) begin \
-                  if (expected_str[i] != " ") begin \
-                     expected_str = expected_str.substr(i, expected_str.len()-1); \
-                     break; \
-                  end \
-               end \
-             full_msg = {"CHECK_LESS failed! Got ",`"got`", "=",  got_str, " expected less than ", expected_str, ". ", msg}; \
+             `CREATE_MSG(full_msg, "CHECK_LESS", got, expected, msg); \
              $error(full_msg); \
           end
 `define CHECK_EQUAL_VARIANCE(got,expected,variance,msg=__none__) \

--- a/vunit/verilog/include/vunit_defines.svh
+++ b/vunit/verilog/include/vunit_defines.svh
@@ -27,32 +27,42 @@
 `define TEST_CASE_SETUP if (__runner__.is_test_case_setup())
 `define TEST_CASE_CLEANUP if (__runner__.is_test_case_cleanup())
 `define __ERROR_FUNC(msg) $error(msg)
-`define CREATE_MSG(full_msg,func_name,got,expected,msg=__none__) \
+`define CREATE_ARG_STRING(arg, arg_str) \
+	$swrite(arg_str, arg); \
+	for (int i=0; i<arg_str.len(); i++) begin \
+		if (arg_str[i] != " ") begin \
+			arg_str = arg_str.substr(i, arg_str.len()-1); \
+		break; \
+		end \
+	end 
+`define CREATE_MSG(full_msg,func_name,got,expected,prefix,msg=__none__) \
 	string __none__; \
 	string full_msg; \
-	$sformat(full_msg, "%s failed! Got %0d expected %0d. %s", func_name, got, expected, msg); 
+	string got_str; \
+	`CREATE_ARG_STRING(got, got_str); \
+	$sformat(full_msg, "%s failed! Got %s%s%0d expected %s%0d. %s", func_name, got_str, prefix, got, prefix, expected, msg); 
 `define CHECK_EQUAL(got,expected,msg=__none__) \
         assert ((got) === (expected)) else \
           begin \
-			 `CREATE_MSG(full_msg, "CHECK_EQUAL", got, expected, msg); \
+			 `CREATE_MSG(full_msg, "CHECK_EQUAL", got, expected, "=", msg); \
              `__ERROR_FUNC(full_msg); \
           end
 `define CHECK_NOT_EQUAL(got,expected,msg=__none__) \
         assert ((got) !== (expected)) else \
           begin \
-             `CREATE_MSG(full_msg, "CHECK_NOT_EQUAL", got, expected, msg); \
+             `CREATE_MSG(full_msg, "CHECK_NOT_EQUAL", got, expected, "!=", msg); \
              `__ERROR_FUNC(full_msg); \
           end
 `define CHECK_GREATER(got,expected,msg=__none__) \
         assert ((got) > (expected)) else \
           begin \
-             `CREATE_MSG(full_msg, "CHECK_GREATER", got, expected, msg); \
+             `CREATE_MSG(full_msg, "CHECK_GREATER", got, expected, ">", msg); \
              `__ERROR_FUNC(full_msg); \
           end
 `define CHECK_LESS(got,expected,msg=__none__) \
         assert ((got) < (expected)) else \
           begin \
-             `CREATE_MSG(full_msg, "CHECK_LESS", got, expected, msg); \
+             `CREATE_MSG(full_msg, "CHECK_LESS", got, expected, "<", msg); \
              `__ERROR_FUNC(full_msg); \
           end
 `define CHECK_EQUAL_VARIANCE(got,expected,variance,msg=__none__) \
@@ -60,6 +70,8 @@
           begin \
              string __none__; \
              string full_msg; \
-             $sformat(full_msg, "CHECK_EQUAL_VARIANCE failed! Got %0d expected %0d +- %0d. %s", got, expected, variance, msg); \
+			 string got_str; \
+			 `CREATE_ARG_STRING(got, got_str); \
+             $sformat(full_msg, "CHECK_EQUAL_VARIANCE failed! Got %s=%0d expected %0d +- %0d. %s", got_str, got, expected, variance, msg); \
              `__ERROR_FUNC(full_msg); \
           end

--- a/vunit/verilog/include/vunit_defines.svh
+++ b/vunit/verilog/include/vunit_defines.svh
@@ -53,6 +53,33 @@
              full_msg = {"CHECK_EQUAL failed! Got ",`"got`", "=",  got_str, " expected ", expected_str, ". ", msg}; \
              $error(full_msg); \
           end
+`define CHECK_NOT_EQUAL(got,expected,msg=__none__) \
+        assert ((got) !== (expected)) else \
+          begin \
+             string __none__; \
+             string got_str; \
+             string expected_str; \
+             string full_msg; \
+             int index; \
+             got_str = "";\
+             expected_str ="";\
+             $swrite(got_str, got); \
+             $swrite(expected_str, expected); \
+               for (int i=0; i<got_str.len(); i++) begin \
+                  if (got_str[i] != " ") begin \
+                     got_str = got_str.substr(i, got_str.len()-1); \
+                     break; \
+                  end \
+               end \
+               for (int i=0; i<expected_str.len(); i++) begin \
+                  if (expected_str[i] != " ") begin \
+                     expected_str = expected_str.substr(i, expected_str.len()-1); \
+                     break; \
+                  end \
+               end \
+             full_msg = {"CHECK_NOT_EQUAL failed! Got ",`"got`", "=",  got_str, " expected ", expected_str, ". ", msg}; \
+             $error(full_msg); \
+          end
 `define CHECK_GREATER(got,expected,msg=__none__) \
         assert ((got) > (expected)) else \
           begin \

--- a/vunit/verilog/include/vunit_defines.svh
+++ b/vunit/verilog/include/vunit_defines.svh
@@ -53,3 +53,93 @@
              full_msg = {"CHECK_EQUAL failed! Got ",`"got`", "=",  got_str, " expected ", expected_str, ". ", msg}; \
              $error(full_msg); \
           end
+`define CHECK_GREATER(got,expected,msg=__none__) \
+        assert ((got) > (expected)) else \
+          begin \
+             string __none__; \
+             string got_str; \
+             string expected_str; \
+             string full_msg; \
+             int index; \
+             got_str = "";\
+             expected_str ="";\
+             $swrite(got_str, got); \
+             $swrite(expected_str, expected); \
+               for (int i=0; i<got_str.len(); i++) begin \
+                  if (got_str[i] != " ") begin \
+                     got_str = got_str.substr(i, got_str.len()-1); \
+                     break; \
+                  end \
+               end \
+               for (int i=0; i<expected_str.len(); i++) begin \
+                  if (expected_str[i] != " ") begin \
+                     expected_str = expected_str.substr(i, expected_str.len()-1); \
+                     break; \
+                  end \
+               end \
+             full_msg = {"CHECK_GREATER failed! Got ",`"got`", "=",  got_str, " expected greater than", expected_str, ". ", msg}; \
+             $error(full_msg); \
+          end
+`define CHECK_LESS(got,expected,msg=__none__) \
+        assert ((got) < (expected)) else \
+          begin \
+             string __none__; \
+             string got_str; \
+             string expected_str; \
+             string full_msg; \
+             int index; \
+             got_str = "";\
+             expected_str ="";\
+             $swrite(got_str, got); \
+             $swrite(expected_str, expected); \
+               for (int i=0; i<got_str.len(); i++) begin \
+                  if (got_str[i] != " ") begin \
+                     got_str = got_str.substr(i, got_str.len()-1); \
+                     break; \
+                  end \
+               end \
+               for (int i=0; i<expected_str.len(); i++) begin \
+                  if (expected_str[i] != " ") begin \
+                     expected_str = expected_str.substr(i, expected_str.len()-1); \
+                     break; \
+                  end \
+               end \
+             full_msg = {"CHECK_LESS failed! Got ",`"got`", "=",  got_str, " expected less than ", expected_str, ". ", msg}; \
+             $error(full_msg); \
+          end
+`define CHECK_EQUAL_VARIANCE(got,expected,variance,msg=__none__) \
+        assert (((got) < ((expected) + (variance))) && ((got) > ((expected) - (variance)))) else \
+          begin \
+             string __none__; \
+             string got_str; \
+             string expected_str; \
+			 string variance_str; \
+             string full_msg; \
+             int index; \
+             got_str = "";\
+			 variance_str = "";\
+             expected_str ="";\
+             $swrite(got_str, got); \
+			 $swrite(variance_str, variance); \
+             $swrite(expected_str, expected); \
+               for (int i=0; i<got_str.len(); i++) begin \
+                  if (got_str[i] != " ") begin \
+                     got_str = got_str.substr(i, got_str.len()-1); \
+                     break; \
+                  end \
+               end \
+			   for (int i=0; i<variance_str.len(); i++) begin \
+                  if (variance_str[i] != " ") begin \
+                     variance_str = variance_str.substr(i, variance_str.len()-1); \
+                     break; \
+                  end \
+               end \
+               for (int i=0; i<expected_str.len(); i++) begin \
+                  if (expected_str[i] != " ") begin \
+                     expected_str = expected_str.substr(i, expected_str.len()-1); \
+                     break; \
+                  end \
+               end \
+             full_msg = {"CHECK_EQUAL_VARIANCE failed! Got ",`"got`", "=",  got_str, " expected ", expected_str, ", +-", variance_str, ". ", msg}; \
+             $error(full_msg); \
+          end

--- a/vunit/verilog/include/vunit_defines.svh
+++ b/vunit/verilog/include/vunit_defines.svh
@@ -30,7 +30,7 @@
 `define CREATE_MSG(full_msg,func_name,got,expected,msg=__none__) \
 	string __none__; \
 	string full_msg; \
-	$sformat(full_msg, "%s failed! Got %d expected %d. %s", func_name, got, expected, msg); 
+	$sformat(full_msg, "%s failed! Got %0d expected %0d. %s", func_name, got, expected, msg); 
 `define CHECK_EQUAL(got,expected,msg=__none__) \
         assert ((got) === (expected)) else \
           begin \
@@ -60,6 +60,6 @@
           begin \
              string __none__; \
              string full_msg; \
-             $sformat(full_msg, "CHECK_EQUAL_VARIANCE failed! Got %d expected %d +- %d. %s", got, expected, variance, msg); \
+             $sformat(full_msg, "CHECK_EQUAL_VARIANCE failed! Got %0d expected %0d +- %0d. %s", got, expected, variance, msg); \
              `__ERROR_FUNC(full_msg); \
           end

--- a/vunit/verilog/include/vunit_defines.svh
+++ b/vunit/verilog/include/vunit_defines.svh
@@ -29,27 +29,8 @@
 `define __ERROR_FUNC(msg) $error(msg)
 `define CREATE_MSG(full_msg,func_name,got,expected,msg=__none) \
 	string __none__; \
-	string got_str; \
-	string expected_str; \
 	string full_msg; \
-	int index; \
-	got_str = "";\
-	expected_str ="";\
-	$swrite(got_str, got); \
-	$swrite(expected_str, expected); \
-	for (int i=0; i<got_str.len(); i++) begin \
-		if (got_str[i] != " ") begin \
-			got_str = got_str.substr(i, got_str.len()-1); \
-			break; \
-		end \
-	end \
-	for (int i=0; i<expected_str.len(); i++) begin \
-		if (expected_str[i] != " ") begin \
-			expected_str = expected_str.substr(i, expected_str.len()-1); \
-			break; \
-		end \
-	end \
-	full_msg = {func_name, " failed! Got ", got_str, " expected ", expected_str, ". ", msg}; 
+	$sformat(full_msg, "%s failed! Got %d expected %d. %s", func_name, got, expected, msg); 
 `define CHECK_EQUAL(got,expected,msg=__none__) \
         assert ((got) === (expected)) else \
           begin \
@@ -78,35 +59,7 @@
         assert (((got) < ((expected) + (variance))) && ((got) > ((expected) - (variance)))) else \
           begin \
              string __none__; \
-             string got_str; \
-             string expected_str; \
-			 string variance_str; \
              string full_msg; \
-             int index; \
-             got_str = "";\
-			 variance_str = "";\
-             expected_str ="";\
-             $swrite(got_str, got); \
-			 $swrite(variance_str, variance); \
-             $swrite(expected_str, expected); \
-               for (int i=0; i<got_str.len(); i++) begin \
-                  if (got_str[i] != " ") begin \
-                     got_str = got_str.substr(i, got_str.len()-1); \
-                     break; \
-                  end \
-               end \
-			   for (int i=0; i<variance_str.len(); i++) begin \
-                  if (variance_str[i] != " ") begin \
-                     variance_str = variance_str.substr(i, variance_str.len()-1); \
-                     break; \
-                  end \
-               end \
-               for (int i=0; i<expected_str.len(); i++) begin \
-                  if (expected_str[i] != " ") begin \
-                     expected_str = expected_str.substr(i, expected_str.len()-1); \
-                     break; \
-                  end \
-               end \
-             full_msg = {"CHECK_EQUAL_VARIANCE failed! Got ", got_str, " expected ", expected_str, ", +-", variance_str, ". ", msg}; \
+             $sformat(full_msg, "CHECK_EQUAL_VARIANCE failed! Got %d expected %d +- %d. %s", got, expected, variance, msg); \
              `__ERROR_FUNC(full_msg); \
           end

--- a/vunit/verilog/include/vunit_defines.svh
+++ b/vunit/verilog/include/vunit_defines.svh
@@ -27,7 +27,7 @@
 `define TEST_CASE_SETUP if (__runner__.is_test_case_setup())
 `define TEST_CASE_CLEANUP if (__runner__.is_test_case_cleanup())
 `define __ERROR_FUNC(msg) $error(msg)
-`define CREATE_MSG(full_msg,func_name,got,expected,msg=__none) \
+`define CREATE_MSG(full_msg,func_name,got,expected,msg=__none__) \
 	string __none__; \
 	string full_msg; \
 	$sformat(full_msg, "%s failed! Got %d expected %d. %s", func_name, got, expected, msg); 

--- a/vunit/verilog/include/vunit_defines.svh
+++ b/vunit/verilog/include/vunit_defines.svh
@@ -26,6 +26,7 @@
 
 `define TEST_CASE_SETUP if (__runner__.is_test_case_setup())
 `define TEST_CASE_CLEANUP if (__runner__.is_test_case_cleanup())
+`define __ERROR_FUNC(msg) $error(msg)
 `define CREATE_MSG(full_msg,func_name,got,expected,msg=__none) \
 	string __none__; \
 	string got_str; \
@@ -53,25 +54,25 @@
         assert ((got) === (expected)) else \
           begin \
 			 `CREATE_MSG(full_msg, "CHECK_EQUAL", got, expected, msg); \
-             $error(full_msg); \
+             `__ERROR_FUNC(full_msg); \
           end
 `define CHECK_NOT_EQUAL(got,expected,msg=__none__) \
         assert ((got) !== (expected)) else \
           begin \
              `CREATE_MSG(full_msg, "CHECK_NOT_EQUAL", got, expected, msg); \
-             $error(full_msg); \
+             `__ERROR_FUNC(full_msg); \
           end
 `define CHECK_GREATER(got,expected,msg=__none__) \
         assert ((got) > (expected)) else \
           begin \
              `CREATE_MSG(full_msg, "CHECK_GREATER", got, expected, msg); \
-             $error(full_msg); \
+             `__ERROR_FUNC(full_msg); \
           end
 `define CHECK_LESS(got,expected,msg=__none__) \
         assert ((got) < (expected)) else \
           begin \
              `CREATE_MSG(full_msg, "CHECK_LESS", got, expected, msg); \
-             $error(full_msg); \
+             `__ERROR_FUNC(full_msg); \
           end
 `define CHECK_EQUAL_VARIANCE(got,expected,variance,msg=__none__) \
         assert (((got) < ((expected) + (variance))) && ((got) > ((expected) - (variance)))) else \
@@ -107,5 +108,5 @@
                   end \
                end \
              full_msg = {"CHECK_EQUAL_VARIANCE failed! Got ",`"got`", "=",  got_str, " expected ", expected_str, ", +-", variance_str, ". ", msg}; \
-             $error(full_msg); \
+             `__ERROR_FUNC(full_msg); \
           end

--- a/vunit/verilog/include/vunit_defines.svh
+++ b/vunit/verilog/include/vunit_defines.svh
@@ -49,7 +49,7 @@
 			break; \
 		end \
 	end \
-	full_msg = {func_name, " failed! Got ",`"got`", "=",  got_str, " expected ", expected_str, ". ", msg}; 
+	full_msg = {func_name, " failed! Got ", got_str, " expected ", expected_str, ". ", msg}; 
 `define CHECK_EQUAL(got,expected,msg=__none__) \
         assert ((got) === (expected)) else \
           begin \
@@ -107,6 +107,6 @@
                      break; \
                   end \
                end \
-             full_msg = {"CHECK_EQUAL_VARIANCE failed! Got ",`"got`", "=",  got_str, " expected ", expected_str, ", +-", variance_str, ". ", msg}; \
+             full_msg = {"CHECK_EQUAL_VARIANCE failed! Got ", got_str, " expected ", expected_str, ", +-", variance_str, ". ", msg}; \
              `__ERROR_FUNC(full_msg); \
           end


### PR DESCRIPTION
Added macros:

- `CHECK_NOT_EQUAL(A, B): true is A !== B`

- `CHECK_LESS(A, B): true if A is strictly less than B`

- `CHECK_GREATER(A, B): true if A is strictly greater than B`

- `CHECK_EQUAL_VARIANCE(A, B, VAR): true if A is between B+VAR and B-VAR`

I also added a barebones testbench and testbench runner for SV check macros, under `verilog/check/test`. At the moment, all it really checks for is if the macros are currently visible.
