### PR TITLE
Fix linting error in pylint test

### DIFF
--- a/vunit/test/lint/test_pylint.py
+++ b/vunit/test/lint/test_pylint.py
@@ -24,4 +24,4 @@ class TestPylint(unittest.TestCase):
     def test_pylint():
         check_call([sys.executable, "-m", "pylint",
                     "--rcfile=" + join(dirname(__file__), "pylintrc")]
-                   + get_files_and_folders())
+                    + get_files_and_folders())


### PR DESCRIPTION
Missing space for vertical alignment.