### PR TITLE
Add option to not dependency scan xil_defaultlib

### DIFF
--- a/vunit/vivado/vivado.py
+++ b/vunit/vivado/vivado.py
@@ -86,7 +86,7 @@ def _read_compile_order(file_name):
     with open(file_name, "r") as ifile:
 
         for line in ifile.readlines():
-            library_name, file_type, file_name = line.strip().split(",", maxsplit=2)
+            library_name, file_type, file_name = line.strip().split(",", 2)
             assert file_type in ("Verilog", "VHDL", "Verilog Header")
             libraries.add(library_name)
 

--- a/vunit/vivado/vivado.py
+++ b/vunit/vivado/vivado.py
@@ -14,7 +14,7 @@ from os import makedirs
 from os.path import abspath, join, dirname, exists, basename
 
 
-def add_from_compile_order_file(vunit_obj, compile_order_file):
+def add_from_compile_order_file(vunit_obj, compile_order_file, dependency_scan_defaultlib=True):
     """
     Add Vivado IP:s from a compile order file
     """
@@ -32,8 +32,9 @@ def add_from_compile_order_file(vunit_obj, compile_order_file):
     for library_name, file_name in compile_order:
         is_verilog = file_name.endswith(".v") or file_name.endswith(".vp")
 
-        # Use VUnit dependency scanning for everything in xil_defaultlib
-        scan_dependencies = library_name == "xil_defaultlib"
+        # Optionally use VUnit dependency scanning for everything in xil_defaultlib, which
+        # typically contains unencrypted top levels that instantiate encrypted implementations.
+        scan_dependencies = dependency_scan_defaultlib and library_name == "xil_defaultlib"
         source_file = vunit_obj.library(library_name).add_source_file(
             file_name,
             no_parse=not scan_dependencies,


### PR DESCRIPTION
In my current project we have some IP cores that add all their (encrypted) files to xil_defaultlib. Unlike cores from Xilinx that add their unencrypted top levels to xil_defaultlib and implementations to specific libraries e.g. `lib_fifo_v1_0_10`, which makes it possible to do some rudimentary dependency scan.

Without this PR, the files in xil_defaultlib are not compiled in the correct order in my case, which breaks the compilation. With this change I can disable the dependency scan and instead use a linear dependency chain for all of the IP files, which makes them compile in the correct order.