### PR TITLE
Avoid compiling IP cores within the block design

### DIFF
--- a/vunit/vivado/tcl/extract_compile_order.tcl
+++ b/vunit/vivado/tcl/extract_compile_order.tcl
@@ -5,11 +5,13 @@ open_project ${project_file}
 
 set file_out [open ${output_file} w]
 foreach ip [get_ips] {
-    generate_target {simulation synthesis} ${ip}
-    foreach src_file [get_files -used_in simulation -compile_order sources -of_objects ${ip}] {
-        set library [get_property LIBRARY ${src_file}]
-        set file_type [get_property FILE_TYPE ${src_file}]
-        puts ${file_out} "${library},${file_type},${src_file}"
+    if {[get_property SCOPE ${ip}] eq ""} {
+        generate_target {simulation synthesis} ${ip}
+        foreach src_file [get_files -used_in simulation -compile_order sources -of_objects ${ip}] {
+            set library [get_property LIBRARY ${src_file}]
+            set file_type [get_property FILE_TYPE ${src_file}]
+            puts ${file_out} "${library},${file_type},${src_file}"
+        }
     }
 }
 close ${file_out}


### PR DESCRIPTION
When runnning the `extract_compile_order` script on a project that has a block design you get an error like this

`ERROR: [Vivado 12-3563] The Nested sub-design '<path>/project.srcs/sources_1/bd/cpu/ip/cpu_processing_system7_0_0/cpu_processing_system7_0_0.xci' can only be generated by its parent sub-design.`

from the `generate_target {simulation synthesis} ${ip}` call.

This is because the `get_ips` command returns search paths to all IP xci files, including those within the block design. Generating simulation files for the block design, if one would like to do that, is instead done with a command along the lines of `generate_target simulation [get_files <path to block design>.bd]`.

So I found that IPs in the block design have a property `SCOPE` set to the search path of the .bd file. Other IP cores do not have this property set. This PR avoids the issue by only running `generate_target` etc. on IPs that have an empty `SCOPE` property.

I know that IP core handling in Vivado is very sketchy. While this fix works for me it might break things for someone else. I am very open to suggestions if there is another way of solving this. I was looking for an alternative to the `get_ips` command that would not return block design IPs, but I could not find anything suitable.