### PR TITLE
Simplify extract_compile_order.tcl

### DIFF
--- a/vunit/vivado/tcl/extract_compile_order.tcl
+++ b/vunit/vivado/tcl/extract_compile_order.tcl
@@ -4,14 +4,12 @@ set output_file [lindex $argv 1]
 open_project ${project_file}
 
 set file_out [open ${output_file} w]
-foreach ip [get_ips] {
-    if {[get_property SCOPE ${ip}] eq ""} {
-        generate_target {simulation synthesis} ${ip}
-        foreach src_file [get_files -used_in simulation -compile_order sources -of_objects ${ip}] {
-            set library [get_property LIBRARY ${src_file}]
-            set file_type [get_property FILE_TYPE ${src_file}]
-            puts ${file_out} "${library},${file_type},${src_file}"
-        }
+foreach ip [get_ips -filter {SCOPE == ""}] {
+    generate_target {simulation synthesis} ${ip}
+    foreach src_file [get_files -used_in simulation -compile_order sources -of_objects ${ip}] {
+        set library [get_property LIBRARY ${src_file}]
+        set file_type [get_property FILE_TYPE ${src_file}]
+        puts ${file_out} "${library},${file_type},${src_file}"
     }
 }
 close ${file_out}


### PR DESCRIPTION
Followup from #454. Do the filtering directly in the `get_ips` call.