### PR TITLE
Updated ghdl_interface.py per #458

### DIFF
--- a/vunit/ghdl_interface.py
+++ b/vunit/ghdl_interface.py
@@ -40,7 +40,7 @@ class GHDLInterface(SimulatorInterface):
     sim_options = [
         ListOfStringOption("ghdl.sim_flags"),
         ListOfStringOption("ghdl.elab_flags"),
-        StringOption("ghdl.init_file.gui"),
+        StringOption("ghdl.gtkwave_script.gui"),
     ]
 
     @staticmethod
@@ -250,7 +250,7 @@ class GHDLInterface(SimulatorInterface):
         if self._gui and not elaborate_only:
             cmd = ["gtkwave"] + shlex.split(self._gtkwave_args) + [data_file_name]
 
-            init_file = config.sim_options.get(self.name + ".init_file.gui", None)
+            init_file = config.sim_options.get(self.name + ".gtkwave_script.gui", None)
             if init_file is not None:
                 cmd += ["--script", "\"{}\"".format(abspath(init_file))]
 

--- a/vunit/ghdl_interface.py
+++ b/vunit/ghdl_interface.py
@@ -252,10 +252,9 @@ class GHDLInterface(SimulatorInterface):
 
             init_file = config.sim_options.get(self.name + ".init_file.gui", None)
             if init_file is not None:
-                cmd += ["--script", "\"{}\"".format(abspath(init_file))] 
+                cmd += ["--script", "\"{}\"".format(abspath(init_file))]
 
             stdout.write("%s\n" % " ".join(cmd))
             subprocess.call(cmd)
 
         return status
-

--- a/vunit/ghdl_interface.py
+++ b/vunit/ghdl_interface.py
@@ -10,14 +10,15 @@ Interface for GHDL simulator
 
 from __future__ import print_function
 import logging
-from os.path import exists, join
+from os.path import exists, join, abspath
 import os
 import subprocess
 import shlex
 from sys import stdout  # To avoid output catched in non-verbose mode
 from vunit.ostools import Process
 from vunit.simulator_interface import (SimulatorInterface,
-                                       ListOfStringOption)
+                                       ListOfStringOption,
+                                       StringOption)
 from vunit.exceptions import CompileError
 LOGGER = logging.getLogger(__name__)
 
@@ -39,6 +40,7 @@ class GHDLInterface(SimulatorInterface):
     sim_options = [
         ListOfStringOption("ghdl.sim_flags"),
         ListOfStringOption("ghdl.elab_flags"),
+        StringOption("ghdl.init_file.gui"),
     ]
 
     @staticmethod
@@ -247,7 +249,13 @@ class GHDLInterface(SimulatorInterface):
 
         if self._gui and not elaborate_only:
             cmd = ["gtkwave"] + shlex.split(self._gtkwave_args) + [data_file_name]
+
+            init_file = config.sim_options.get(self.name + ".init_file.gui", None)
+            if init_file is not None:
+                cmd += ["--script", "\"{}\"".format(abspath(init_file))] 
+
             stdout.write("%s\n" % " ".join(cmd))
             subprocess.call(cmd)
 
         return status
+

--- a/vunit/ui.py
+++ b/vunit/ui.py
@@ -191,6 +191,16 @@ The following simulation options are known.
    Extra simulation flags passed to ``ghdl --elab-run``.
    Must be a list of strings.
 
+``ghdl.gtkwave_script.gui``
+   A user defined TCL-file that is sourced after the design has been loaded in the GUI.
+   For example this can be used to configure the waveform viewer.
+   During script evaluation the ``vunit_tb_path`` variable is defined
+   as the path of the folder containing the test bench.
+   Must be a string. There are currently limitations in the HEAD revision of GTKWave
+   that prevent the user from sourcing a list of scripts directly. The following is the
+   current work around to sourcing multiple user TCL-files:
+   ``source <path/to/script.tcl>``
+
 .. |compile_option| replace::
    The name of the compile option (See :ref:`Compilation options <compile_options>`)
 

--- a/vunit/ui.py
+++ b/vunit/ui.py
@@ -193,12 +193,10 @@ The following simulation options are known.
 
 ``ghdl.gtkwave_script.gui``
    A user defined TCL-file that is sourced after the design has been loaded in the GUI.
-   For example this can be used to configure the waveform viewer.
-   During script evaluation the ``vunit_tb_path`` variable is defined
-   as the path of the folder containing the test bench.
-   Must be a string. There are currently limitations in the HEAD revision of GTKWave
-   that prevent the user from sourcing a list of scripts directly. The following is the
-   current work around to sourcing multiple user TCL-files:
+   For example this can be used to configure the waveform viewer. Must be a string.
+   There are currently limitations in the HEAD revision of GTKWave that prevent the
+   user from sourcing a list of scripts directly. The following is the current work
+   around to sourcing multiple user TCL-files:
    ``source <path/to/script.tcl>``
 
 .. |compile_option| replace::


### PR DESCRIPTION
This update allows a TCL script to be passed to GTKWave when the `-g` flag is passed if the environment has the `set_sim_option('ghdl.init_file.gui', '<fileName>.tcl')` set. The limitation is that only a single file can be passed, however `<fileName>.tcl` can source other TCL scripts if desired.