### PR TITLE
add sim_opt 'ghdl.elab_e' to run 'ghdl -e' instead of 'ghdl --elab-run --no-run'

### DIFF
--- a/vunit/ghdl_interface.py
+++ b/vunit/ghdl_interface.py
@@ -233,11 +233,11 @@ class GHDLInterface(SimulatorInterface):
         if not exists(script_path):
             os.makedirs(script_path)
 
-        ghdl_e = config.sim_options.get("ghdl.elab_e", False)
+        ghdl_e = elaborate_only and config.sim_options.get("ghdl.elab_e", False)
 
         cmd = self._get_command(config, script_path, ghdl_e)
 
-        if elaborate_only:
+        if elaborate_only and not ghdl_e:
             cmd += ["--no-run"]
 
         if self._gtkwave_fmt is not None and not ghdl_e:
@@ -261,7 +261,7 @@ class GHDLInterface(SimulatorInterface):
         except Process.NonZeroExitCode:
             status = False
 
-        if self._gui and not elaborate_only and not ghdl_e:
+        if self._gui and not elaborate_only:
             cmd = ["gtkwave"] + shlex.split(self._gtkwave_args) + [data_file_name]
 
             init_file = config.sim_options.get(self.name + ".gtkwave_script.gui", None)

--- a/vunit/ghdl_interface.py
+++ b/vunit/ghdl_interface.py
@@ -18,7 +18,8 @@ from sys import stdout  # To avoid output catched in non-verbose mode
 from vunit.ostools import Process
 from vunit.simulator_interface import (SimulatorInterface,
                                        ListOfStringOption,
-                                       StringOption)
+                                       StringOption,
+                                       BooleanOption)
 from vunit.exceptions import CompileError
 LOGGER = logging.getLogger(__name__)
 
@@ -41,6 +42,7 @@ class GHDLInterface(SimulatorInterface):
         ListOfStringOption("ghdl.sim_flags"),
         ListOfStringOption("ghdl.elab_flags"),
         StringOption("ghdl.gtkwave_script.gui"),
+        BooleanOption("ghdl.elab_e")
     ]
 
     @staticmethod
@@ -187,31 +189,35 @@ class GHDLInterface(SimulatorInterface):
         cmd += [source_file.name]
         return cmd
 
-    def _get_sim_command(self, config, output_path):
+    def _get_command(self, config, output_path, ghdl_e):
         """
         Return GHDL simulation command
         """
         cmd = [join(self._prefix, self.executable)]
-        cmd += ['--elab-run']
+
+        if ghdl_e:
+            cmd += ['-e']
+        else:
+            cmd += ['--elab-run']
+
         cmd += ['--std=%s' % self._std_str(self._vhdl_standard)]
         cmd += ['--work=%s' % config.library_name]
         cmd += ['--workdir=%s' % self._project.get_library(config.library_name).directory]
         cmd += ['-P%s' % lib.directory for lib in self._project.get_libraries()]
-
         if self._has_output_flag():
             cmd += ['-o', join(output_path, "%s-%s" % (config.entity_name,
                                                        config.architecture_name))]
         cmd += config.sim_options.get("ghdl.elab_flags", [])
         cmd += [config.entity_name, config.architecture_name]
-        cmd += config.sim_options.get("ghdl.sim_flags", [])
 
-        for name, value in config.generics.items():
-            cmd += ['-g%s=%s' % (name, value)]
+        if not ghdl_e:
+            cmd += config.sim_options.get("ghdl.sim_flags", [])
+            for name, value in config.generics.items():
+                cmd += ['-g%s=%s' % (name, value)]
+            cmd += ['--assert-level=%s' % config.vhdl_assert_stop_level]
+            if config.sim_options.get("disable_ieee_warnings", False):
+                cmd += ["--ieee-asserts=disable"]
 
-        cmd += ['--assert-level=%s' % config.vhdl_assert_stop_level]
-
-        if config.sim_options.get("disable_ieee_warnings", False):
-            cmd += ["--ieee-asserts=disable"]
         return cmd
 
     def simulate(self,  # pylint: disable=too-many-locals
@@ -227,12 +233,14 @@ class GHDLInterface(SimulatorInterface):
         if not exists(script_path):
             os.makedirs(script_path)
 
-        cmd = self._get_sim_command(config, script_path)
+        ghdl_e = config.sim_options.get("ghdl.elab_e", False)
+
+        cmd = self._get_command(config, script_path, ghdl_e)
 
         if elaborate_only:
             cmd += ["--no-run"]
 
-        if self._gtkwave_fmt is not None:
+        if self._gtkwave_fmt is not None and not ghdl_e:
             data_file_name = join(script_path, "wave.%s" % self._gtkwave_fmt)
 
             if exists(data_file_name):
@@ -253,7 +261,7 @@ class GHDLInterface(SimulatorInterface):
         except Process.NonZeroExitCode:
             status = False
 
-        if self._gui and not elaborate_only:
+        if self._gui and not elaborate_only and not ghdl_e:
             cmd = ["gtkwave"] + shlex.split(self._gtkwave_args) + [data_file_name]
 
             init_file = config.sim_options.get(self.name + ".gtkwave_script.gui", None)

--- a/vunit/test/unit/test_ghdl_interface.py
+++ b/vunit/test/unit/test_ghdl_interface.py
@@ -163,12 +163,12 @@ warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE."""
         config = Configuration("name", design_unit, sim_options={"ghdl.elab_e": True})
 
         simif = GHDLInterface(prefix="prefix", output_path="")
-        simif._vhdl_standard = "2008"
-        simif._project = Project()
-        simif._project.add_library("lib", "lib_path")
+        simif._vhdl_standard = "2008"  # pylint: disable=protected-access
+        simif._project = Project()  # pylint: disable=protected-access
+        simif._project.add_library("lib", "lib_path")  # pylint: disable=protected-access
 
         self.assertEqual(
-            simif._get_command(config, "output_path/ghdl", True),
+            simif._get_command(config, "output_path/ghdl", True),  # pylint: disable=protected-access
             [
                 join("prefix", 'ghdl'),
                 '-e',

--- a/vunit/test/unit/test_ghdl_interface.py
+++ b/vunit/test/unit/test_ghdl_interface.py
@@ -168,15 +168,15 @@ warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE."""
         simif._project.add_library("lib", "lib_path")  # pylint: disable=protected-access
 
         self.assertEqual(
-            simif._get_command(config, "output_path/ghdl", True),  # pylint: disable=protected-access
+            simif._get_command(config, join('output_path', 'ghdl'), True),  # pylint: disable=protected-access
             [
-                join("prefix", 'ghdl'),
+                join('prefix', 'ghdl'),
                 '-e',
                 '--std=08',
                 '--work=lib',
                 '--workdir=lib_path',
                 '-Plib_path',
-                '-o', 'output_path/ghdl/tb_entity-arch',
+                '-o', join('output_path', 'ghdl', 'tb_entity-arch'),
                 'tb_entity', 'arch'
             ]
         )

--- a/vunit/test/unit/test_ghdl_interface.py
+++ b/vunit/test/unit/test_ghdl_interface.py
@@ -154,6 +154,33 @@ warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE."""
             [join("prefix", 'ghdl'), '-a', '--workdir=lib_path', '--work=lib', '--std=08',
              '-Plib_path', 'custom', 'flags', 'file.vhd'], env=simif.get_env())
 
+    @mock.patch("vunit.simulator_interface.check_output", autospec=True, return_value="")
+    def test_elaborate_e_project(self, check_output):  # pylint: disable=no-self-use
+        simif = GHDLInterface(prefix="prefix", output_path="")
+        write_file("file.vhd", "")
+
+        from vunit.test.unit.test_test_bench import Entity
+        from vunit.configuration import Configuration
+
+        design_unit = Entity('tb_entity', file_name=join("tempdir", "file.vhd"))
+        design_unit.original_file_name = join("tempdir", "other_path", "original_file.vhd")
+        design_unit.generic_names = ["runner_cfg", "tb_path"]
+
+        config = Configuration("name", design_unit, sim_options={"ghdl.elab_e": True})
+        simif._vhdl_standard = "2008"
+        simif._project = Project()
+        simif._project.add_library("lib", "lib_path")
+
+        simif.simulate(
+            output_path="output_path",
+            test_suite_name="test_suite_name",
+            config=config,
+            elaborate_only=True
+        )
+        check_output.assert_called_once_with(
+            [join("prefix", 'ghdl'), '-e', '--std=08', '--work=lib', '--workdir=lib_path',
+             '-Plib_path',  '-o', 'output_path/ghdl/tb_entity-arch', 'tb_entity', 'arch'], env=simif.get_env())
+
     def test_compile_project_verilog_error(self):
         simif = GHDLInterface(prefix="prefix", output_path="")
         write_file("file.v", "")

--- a/vunit/test_suites.py
+++ b/vunit/test_suites.py
@@ -164,10 +164,9 @@ class TestRun(object):
 
         sim_ok = self._simulate(output_path)
 
-        if self._elaborate_only:
-            for name in self._test_cases:
-                results[name] = PASSED if sim_ok else FAILED
-            return results
+        if self._elaborate_only or self._config.sim_options.get("ghdl.elab_e", False):
+            status = PASSED if sim_ok else FAILED
+            return dict((name, status) for name in self._test_cases)
 
         results = self._read_test_results(file_name=get_result_file_name(output_path))
 

--- a/vunit/test_suites.py
+++ b/vunit/test_suites.py
@@ -164,7 +164,7 @@ class TestRun(object):
 
         sim_ok = self._simulate(output_path)
 
-        if self._elaborate_only or self._config.sim_options.get("ghdl.elab_e", False):
+        if self._elaborate_only:
             status = PASSED if sim_ok else FAILED
             return dict((name, status) for name in self._test_cases)
 

--- a/vunit/ui.py
+++ b/vunit/ui.py
@@ -191,6 +191,10 @@ The following simulation options are known.
    Extra simulation flags passed to ``ghdl --elab-run``.
    Must be a list of strings.
 
+``ghdl.elab_e``
+   With ``--elaborate``, execute ``ghdl -e`` instead of ``ghdl --elab-run --no-run``.
+   Must be a boolean.
+
 ``ghdl.gtkwave_script.gui``
    A user defined TCL-file that is sourced after the design has been loaded in the GUI.
    For example this can be used to configure the waveform viewer. Must be a string.


### PR DESCRIPTION
Close #466.

> The fix I suggest is to modify https://github.com/VUnit/vunit/blob/master/vunit/ghdl_interface.py#L227 so that --elab-run is replaced with -e, instead of adding --no-run. This will probably require to modify _get_sim_command too, in order to ignore sim arguments if elaborate_only.

**EDIT**

Since, VUnit expects GHDL to actually evaluate some flags and generics during elaboration-only, the first commit in this PR breaks `test_artificial_elaborate_only`. So, in the second commit the tests are changed, and all of them are expected to pass now. I don't know if this makes sense. Probably, some of these tests should be removed (`config.sim_options`, `config.generics` and `config.vhdl_assert_stop_level` are ignored now). However, I am unsure because they might be used with other simulators.
