### PR TITLE
Update .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,13 +34,12 @@ matrix:
   - env: BUILD_NAME=py27-acceptance-ghdl
     python: '2.7'
     os: linux
-    sudo: false
     addons:
       apt:
         packages:
         - gnat
     before_script:
-    - git clone --depth 1 https://github.com/tgingold/ghdl.git ghdl
+    - git clone --depth 1 https://github.com/ghdl/ghdl ghdl
     - cd ghdl
     - mkdir build-mcode
     - cd build-mcode
@@ -52,16 +51,16 @@ matrix:
 
   # Python 3.6 with ghdl llvm
   - env: BUILD_NAME=py36-acceptance-ghdl
+    &py36
     python: '3.6'
     os: linux
-    sudo: required
     dist: trusty
     before_install:
     - sudo apt-get update -qq
     - sudo apt-get install -y gnat-4.8 zlib1g-dev
     - sudo apt-get install -y llvm-3.5-dev llvm-3.5-tools libedit-dev
     before_script:
-    - git clone --depth 1 https://github.com/tgingold/ghdl.git ghdl
+    - git clone --depth 1 https://github.com/ghdl/ghdl ghdl
     - cd ghdl
     - mkdir build-llvm
     - cd build-llvm
@@ -73,24 +72,7 @@ matrix:
 
   # Python 3.6 with ghdl llvm
   - env: BUILD_NAME=py36-vcomponents-ghdl
-    python: '3.6'
-    os: linux
-    sudo: required
-    dist: trusty
-    before_install:
-    - sudo apt-get update -qq
-    - sudo apt-get install -y gnat-4.8 zlib1g-dev
-    - sudo apt-get install -y llvm-3.5-dev llvm-3.5-tools libedit-dev
-    before_script:
-    - git clone --depth 1 https://github.com/tgingold/ghdl.git ghdl
-    - cd ghdl
-    - mkdir build-llvm
-    - cd build-llvm
-    - ../configure --prefix=../../install-ghdl-llvm/ --with-llvm-config=llvm-config-3.5
-    - make
-    - make install
-    - cd ../../
-    - export PATH=$PATH:install-ghdl-llvm/bin/
+    <<: *py36
 
   # Deploy to GitHub pages
   - stage: deploy

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,10 +39,9 @@ matrix:
         packages:
         - gnat
     before_script:
-    - git clone --depth 1 https://github.com/ghdl/ghdl ghdl
-    - cd ghdl
-    - mkdir build-mcode
-    - cd build-mcode
+    - mkdir -p ghdl/build-mcode
+    - curl -fsSL https://codeload.github.com/ghdl/ghdl/tar.gz/master | tar xzf - -C ghdl --strip-components=1
+    - cd ghdl/build-mcode
     - ../configure --prefix=../../install-ghdl-mcode/
     - make
     - make install
@@ -50,8 +49,8 @@ matrix:
     - export PATH=$PATH:install-ghdl-mcode/bin/
 
   # Python 3.6 with ghdl llvm
-  - env: BUILD_NAME=py36-acceptance-ghdl
-    &py36
+  - &py36
+    env: BUILD_NAME=py36-acceptance-ghdl
     python: '3.6'
     os: linux
     dist: trusty
@@ -60,10 +59,9 @@ matrix:
     - sudo apt-get install -y gnat-4.8 zlib1g-dev
     - sudo apt-get install -y llvm-3.5-dev llvm-3.5-tools libedit-dev
     before_script:
-    - git clone --depth 1 https://github.com/ghdl/ghdl ghdl
-    - cd ghdl
-    - mkdir build-llvm
-    - cd build-llvm
+    - mkdir -p ghdl/build-llvm
+    - curl -fsSL https://codeload.github.com/ghdl/ghdl/tar.gz/master | tar xzf - -C ghdl --strip-components=1
+    - cd ghdl/build-llvm
     - ../configure --prefix=../../install-ghdl-llvm/ --with-llvm-config=llvm-config-3.5
     - make
     - make install
@@ -71,8 +69,8 @@ matrix:
     - export PATH=$PATH:install-ghdl-llvm/bin/
 
   # Python 3.6 with ghdl llvm
-  - env: BUILD_NAME=py36-vcomponents-ghdl
-    <<: *py36
+  - <<: *py36
+    env: BUILD_NAME=py36-vcomponents-ghdl
 
   # Deploy to GitHub pages
   - stage: deploy


### PR DESCRIPTION
- `sudo` is not required anymore: https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration
- `curl` is used instead of `git` to download GHDL sources.
- GHDL is downloaded from `ghdl/ghdl`, instead of the old `tgingold/ghdl`.
- A YAML label is used to reduce duplication.