### PR TITLE
feat(travis): skip 'deploy' stage if the repo is a fork

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,11 @@ install:
 script:
 - tox -e $BUILD_NAME
 
+stages:
+  - test
+  - name: deploy
+    if: repo = VUnit/vunit
+
 matrix:
   include:
   - env: BUILD_NAME=py27-unit


### PR DESCRIPTION
This is to avoid the master branch trying to deploy (and failing to do so) when Travis is enabled in a fork of VUnit: https://travis-ci.com/dbhi/vunit/builds/107543214