### PR TITLE
[2/3] Add external modes to string_ptr and integer_vector_ptr (through VHPIDIRECT)

### DIFF
--- a/examples/vhdl/external_buffer/run.py
+++ b/examples/vhdl/external_buffer/run.py
@@ -25,47 +25,35 @@ copied/modified. The content of the buffer is printed both before and after the
 simulation.
 """
 
-from vunit import VUnit
+from vunit import VUnit, ROOT
 from os import popen
 from os.path import join, dirname
 
 src_path = join(dirname(__file__), "src")
+ext_srcs = join(ROOT, "vunit", "vhdl", "data_types", "src", "external", "ghdl")
 
 # Compile C applications to an objects
 c_iobj = join(src_path, "imain.o")
 c_bobj = join(src_path, "bmain.o")
 
-print(
-    popen(
-        " ".join(
-            [
-                "gcc",
-                "-fPIC",
-                "-DTYPE=int32_t",
-                "-c",
-                join(src_path, "main.c"),
-                "-o",
-                c_iobj,
-            ]
-        )
-    ).read()
-)
-
-print(
-    popen(
-        " ".join(
-            [
-                "gcc",
-                "-fPIC",
-                "-DTYPE=uint8_t",
-                "-c",
-                join(src_path, "main.c"),
-                "-o",
-                c_bobj,
-            ]
-        )
-    ).read()
-)
+for val in [["int32_t", c_iobj], ["uint8_t", c_bobj]]:
+    print(
+        popen(
+            " ".join(
+                [
+                    "gcc",
+                    "-fPIC",
+                    "-DTYPE=" + val[0],
+                    "-I",
+                    ext_srcs,
+                    "-c",
+                    join(src_path, "main.c"),
+                    "-o",
+                    val[1],
+                ]
+            )
+        ).read()
+    )
 
 # Enable the external feature for strings/byte_vectors and integer_vectors
 vu = VUnit.from_argv(vhdl_standard="2008", compile_builtins=False)
@@ -76,8 +64,16 @@ lib.add_source_files(join(src_path, "tb_ext_*.vhd"))
 
 # Add the C object to the elaboration of GHDL
 for tb in lib.get_test_benches(pattern="*tb_ext*", allow_empty=False):
-    tb.set_sim_option("ghdl.elab_flags", ["-Wl," + c_bobj], overwrite=True)
+    tb.set_sim_option(
+        "ghdl.elab_flags",
+        ["-Wl," + c_bobj, "-Wl,-Wl,--version-script=" + join(ext_srcs, "grt.ver")],
+        overwrite=True,
+    )
 for tb in lib.get_test_benches(pattern="*tb_ext*_integer*", allow_empty=False):
-    tb.set_sim_option("ghdl.elab_flags", ["-Wl," + c_iobj], overwrite=True)
+    tb.set_sim_option(
+        "ghdl.elab_flags",
+        ["-Wl," + c_iobj, "-Wl,-Wl,--version-script=" + join(ext_srcs, "grt.ver")],
+        overwrite=True,
+    )
 
 vu.main()

--- a/examples/vhdl/external_buffer/src/main.c
+++ b/examples/vhdl/external_buffer/src/main.c
@@ -9,7 +9,13 @@ positions. Then, the VHDL simulation is executed, where the (external) array/buf
 is used. When the simulation is finished, the results are checked. The content of
 the buffer is printed both before and after the simulation.
 
-NOTE: This file is expected to be used along with tb_ext_byte_vector.vhd or tb_ext_string.vhd
+This source file is used for both string/byte_vector and integer_vector.
+Accordingly, TYPE must be defined as uint8_t or int32_t during compilation.
+Keep in mind that the buffer (D) is of type uint8_t*, independently of TYPE, i.e.
+accesses are casted.
+
+NOTE: This file is expected to be used along with tb_ext_string.vhd, tb_ext_byte_vector.vhd
+or tb_ext_integer_vector.vhd
 */
 
 #include <stdio.h>
@@ -21,13 +27,15 @@ extern int ghdl_main (int argc, char **argv);
 uint8_t *D[1];
 const uint32_t length = 5;
 
-// Check procedure, to be executed when GHDL exits.
-// The simulation is expected to copy the first 1/3 elements to positions [1/3, 2/3),
-// while incrementing each value by one, and then copy elements from [1/3, 2/3) to
-// [2/3, 3/3), while incrementing each value by two.
+/*
+ Check procedure, to be executed when GHDL exits.
+ The simulation is expected to copy the first 1/3 elements to positions [1/3, 2/3),
+ while incrementing each value by one, and then copy elements from [1/3, 2/3) to
+ [2/3, 3/3), while incrementing each value by two.
+*/
 static void exit_handler(void) {
-  int i, j, z, k;
-  uint8_t expected, got;
+  uint i, j, z, k;
+  TYPE expected, got;
   k = 0;
   for (j=0; j<3; j++) {
     k += j;
@@ -35,7 +43,7 @@ static void exit_handler(void) {
       z = (length*j)+i;
 
       expected = (i+1)*11 + k;
-      got = D[0][z];
+      got = ((TYPE*)D[0])[z];
       if (expected != got) {
         printf("check error %d: %d %d\n", z, expected, got);
         exit(1);
@@ -50,7 +58,7 @@ static void exit_handler(void) {
 int main(int argc, char **argv) {
   // Allocate a buffer which is three times the number of values
   // that we want to copy/modify
-  D[0] = (uint8_t *) malloc(3*length*sizeof(uint8_t));
+  D[0] = (uint8_t *) malloc(3*length*sizeof(TYPE));
   if ( D[0] == NULL ) {
     perror("execution of malloc() failed!\n");
     return -1;
@@ -58,11 +66,12 @@ int main(int argc, char **argv) {
   // Initialize the first 1/3 of the buffer
   int i;
   for(i=0; i<length; i++) {
-    D[0][i] = (i+1)*11;
+    ((TYPE*)D[0])[i] = (i+1)*11;
   }
   // Print all the buffer
+  printf("sizeof: %lu\n", sizeof(TYPE));
   for(i=0; i<3*length; i++) {
-    printf("%d: %d\n", i, D[0][i]);
+    printf("%d: %d\n", i, ((TYPE*)D[0])[i]);
   }
 
   // Register a function to be called when GHDL exits
@@ -72,26 +81,42 @@ int main(int argc, char **argv) {
   return ghdl_main(argc, argv);
 }
 
-// External through access (mode = extacc)
+// External string/byte_vector through access (mode = extacc)
 
 void set_string_ptr(uint8_t id, uint8_t *p) {
-  //printf("C set_string_ptr(%d, %p)\n", id, p);
   D[id] = p;
 }
 
 uintptr_t get_string_ptr(uint8_t id) {
-  //printf("C get_string_ptr(%d): %p\n", id, D[id]);
   return (uintptr_t)D[id];
 }
 
-// External through functions (mode = extfnc)
+// External string/byte_vector through functions (mode = extfnc)
 
 void write_char(uint8_t id, uint32_t i, uint8_t v ) {
-  //printf("C write_char(%d, %d): %d\n", id, i, v);
   D[id][i] = v;
 }
 
 uint8_t read_char(uint8_t id, uint32_t i) {
-  //printf("C read_char(%d, %d): %d\n", id, i, D[id][i]);
   return D[id][i];
+}
+
+// External integer_vector through access (mode = extacc)
+
+void set_intvec_ptr(uint8_t id, uintptr_t *p) {
+  D[id] = (uint8_t*)p;
+}
+
+uintptr_t get_intvec_ptr(uint8_t id) {
+  return (uintptr_t)D[id];
+}
+
+// External integer_vector through functions (mode = extfnc)
+
+void write_integer(uint8_t id, uint32_t i, int32_t v) {
+  ((int32_t*)D[id])[i] = v;
+}
+
+int32_t read_integer(uint8_t id, uint32_t i) {
+  return ((int32_t*)D[id])[i];
 }

--- a/examples/vhdl/external_buffer/src/main.c
+++ b/examples/vhdl/external_buffer/src/main.c
@@ -21,10 +21,8 @@ or tb_ext_integer_vector.vhd
 #include <stdio.h>
 #include <stdlib.h>
 #include <stdint.h>
+#include "vhpidirect_user.h"
 
-extern int ghdl_main (int argc, char **argv);
-
-uint8_t *D[1];
 const uint32_t length = 5;
 
 /*
@@ -34,7 +32,7 @@ const uint32_t length = 5;
  [2/3, 3/3), while incrementing each value by two.
 */
 static void exit_handler(void) {
-  uint i, j, z, k;
+  unsigned i, j, z, k;
   TYPE expected, got;
   k = 0;
   for (j=0; j<3; j++) {
@@ -79,44 +77,4 @@ int main(int argc, char **argv) {
 
   // Start the simulation
   return ghdl_main(argc, argv);
-}
-
-// External string/byte_vector through access (mode = extacc)
-
-void set_string_ptr(uint8_t id, uint8_t *p) {
-  D[id] = p;
-}
-
-uintptr_t get_string_ptr(uint8_t id) {
-  return (uintptr_t)D[id];
-}
-
-// External string/byte_vector through functions (mode = extfnc)
-
-void write_char(uint8_t id, uint32_t i, uint8_t v ) {
-  D[id][i] = v;
-}
-
-uint8_t read_char(uint8_t id, uint32_t i) {
-  return D[id][i];
-}
-
-// External integer_vector through access (mode = extacc)
-
-void set_intvec_ptr(uint8_t id, uintptr_t *p) {
-  D[id] = (uint8_t*)p;
-}
-
-uintptr_t get_intvec_ptr(uint8_t id) {
-  return (uintptr_t)D[id];
-}
-
-// External integer_vector through functions (mode = extfnc)
-
-void write_integer(uint8_t id, uint32_t i, int32_t v) {
-  ((int32_t*)D[id])[i] = v;
-}
-
-int32_t read_integer(uint8_t id, uint32_t i) {
-  return ((int32_t*)D[id])[i];
 }

--- a/examples/vhdl/external_buffer/src/tb_ext_integer_vector.vhd
+++ b/examples/vhdl/external_buffer/src/tb_ext_integer_vector.vhd
@@ -1,0 +1,55 @@
+-- This Source Code Form is subject to the terms of the Mozilla Public
+-- License, v. 2.0. If a copy of the MPL was not distributed with this file,
+-- You can obtain one at http://mozilla.org/MPL/2.0/.
+--
+-- Copyright (c) 2014-2019, Lars Asplund lars.anders.asplund@gmail.com
+
+-- NOTE: This file is expected to be used along with foreign languages (C)
+-- through VHPIDIRECT: https://ghdl.readthedocs.io/en/latest/using/Foreign.html
+-- See main.c for an example of a wrapper application.
+
+--library vunit_lib;
+--context vunit_lib.vunit_context;
+
+library vunit_lib;
+use vunit_lib.run_pkg.all;
+use vunit_lib.logger_pkg.all;
+use vunit_lib.types_pkg.all;
+use vunit_lib.integer_vector_ptr_pkg.all;
+
+entity tb_external_integer_vector is
+  generic ( runner_cfg : string );
+end entity;
+
+architecture tb of tb_external_integer_vector is
+
+  constant block_len : natural := 5;
+
+  constant ebuf: integer_vector_ptr_t := new_integer_vector_ptr( 3*block_len, extfnc, 0);  -- external through VHPIDIRECT functions 'read_char' and 'write_char'
+  constant abuf: integer_vector_ptr_t := new_integer_vector_ptr( 3*block_len, extacc, 0);  -- external through access (requires VHPIDIRECT function 'get_string_ptr')
+
+begin
+
+  main: process
+    variable val, ind: integer;
+  begin
+    test_runner_setup(runner, runner_cfg);
+    info("Init test");
+    for x in 0 to block_len-1 loop
+      val := get(ebuf, x) + 1;
+      ind := block_len+x;
+      set(ebuf, ind, val);
+      info("SET " & to_string(ind) & ": " & to_string(val));
+    end loop;
+    for x in block_len to 2*block_len-1 loop
+      val := get(abuf, x) + 2;
+      ind := block_len+x;
+      set(abuf, ind, val);
+      info("SET " & to_string(ind) & ": " & to_string(val));
+    end loop;
+    info("End test");
+    test_runner_cleanup(runner);
+    wait;
+  end process;
+
+end architecture;

--- a/vunit/ui/vunit.py
+++ b/vunit/ui/vunit.py
@@ -945,8 +945,9 @@ avoid location preprocessing of other functions sharing name with a VUnit log or
         """
         Add vunit VHDL builtin libraries
 
-        :param external: struct to select whether to enable external models for 'string'. Allowed values are:
-                         None, {'string': False}, {'string': True} or {'string': ['path/to/custom/file']}.
+        :param external: struct to select whether to enable external models for 'string' and/or 'integer' vectors.
+                         {'string': <VAL>, 'integer': <VAL>}. Allowed values are: None, False/True or
+                         ['path/to/custom/file'].
         """
         self._builtins.add_vhdl_builtins(external=external)
 

--- a/vunit/vhdl/data_types/src/external/external_integer_vector-body.vhd
+++ b/vunit/vhdl/data_types/src/external/external_integer_vector-body.vhd
@@ -1,0 +1,28 @@
+-- This Source Code Form is subject to the terms of the Mozilla Public
+-- License, v. 2.0. If a copy of the MPL was not distributed with this file,
+-- You can obtain one at http://mozilla.org/MPL/2.0/.
+--
+-- Copyright (c) 2014-2019, Lars Asplund lars.anders.asplund@gmail.com
+
+package body external_integer_vector_pkg is
+  procedure write_integer (
+    id : integer;
+    i  : integer;
+    v  : integer
+  )is begin
+    assert false report "VHPI write_integer" severity failure;
+  end;
+
+  impure function read_integer (
+    id : integer;
+    i  : integer
+  ) return integer is begin
+    assert false report "VHPI read_integer" severity failure;
+  end;
+
+  impure function get_ptr (
+    id : integer
+  ) return extintvec_access_t is begin
+    assert false report "VHPI get_intvec_ptr" severity failure;
+  end;
+end package body;

--- a/vunit/vhdl/data_types/src/external/external_integer_vector-novhpi.vhd
+++ b/vunit/vhdl/data_types/src/external/external_integer_vector-novhpi.vhd
@@ -1,0 +1,24 @@
+-- This Source Code Form is subject to the terms of the Mozilla Public
+-- License, v. 2.0. If a copy of the MPL was not distributed with this file,
+-- You can obtain one at http://mozilla.org/MPL/2.0/.
+--
+-- Copyright (c) 2014-2019, Lars Asplund lars.anders.asplund@gmail.com
+
+use work.types_pkg.all;
+
+package external_integer_vector_pkg is
+  procedure write_integer (
+    id : integer;
+    i  : integer;
+    v  : integer
+  );
+
+  impure function read_integer (
+    id : integer;
+    i  : integer
+  ) return integer;
+
+  impure function get_ptr (
+    id : integer
+  ) return extintvec_access_t;
+end package;

--- a/vunit/vhdl/data_types/src/external/external_integer_vector-vhpi.vhd
+++ b/vunit/vhdl/data_types/src/external/external_integer_vector-vhpi.vhd
@@ -1,0 +1,28 @@
+-- This Source Code Form is subject to the terms of the Mozilla Public
+-- License, v. 2.0. If a copy of the MPL was not distributed with this file,
+-- You can obtain one at http://mozilla.org/MPL/2.0/.
+--
+-- Copyright (c) 2014-2019, Lars Asplund lars.anders.asplund@gmail.com
+
+use work.types_pkg.all;
+
+package external_integer_vector_pkg is
+  procedure write_integer (
+    id : integer;
+    i  : integer;
+    v  : integer
+  );
+
+  impure function read_integer (
+    id : integer;
+    i  : integer
+  ) return integer;
+
+  impure function get_ptr (
+    id : integer
+  ) return extintvec_access_t;
+
+  attribute foreign of write_integer : procedure is "VHPIDIRECT write_integer";
+  attribute foreign of read_integer  : function  is "VHPIDIRECT read_integer";
+  attribute foreign of get_ptr       : function  is "VHPIDIRECT get_intvec_ptr";
+end package;

--- a/vunit/vhdl/data_types/src/external/ghdl/grt.ver
+++ b/vunit/vhdl/data_types/src/external/ghdl/grt.ver
@@ -1,0 +1,16 @@
+VHPIDIRECT {
+  global:
+main;
+oct_main;
+ghdl_main;
+read_char;
+write_char;
+read_integer;
+write_integer;
+set_string_ptr;
+get_string_ptr;
+set_intvec_ptr;
+get_intvec_ptr;
+  local:
+	*;
+};

--- a/vunit/vhdl/data_types/src/external/ghdl/stubs.c
+++ b/vunit/vhdl/data_types/src/external/ghdl/stubs.c
@@ -1,0 +1,53 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdint.h>
+
+void set_string_ptr(uint8_t id, uint8_t *p) {
+  printf("ERROR set_string_ptr: THIS IS A STUB\n");
+  exit(1);
+  return;
+}
+
+uintptr_t get_string_ptr(uint8_t id) {
+  printf("ERROR get_string_ptr: THIS IS A STUB\n");
+  exit(1);
+  return NULL;
+}
+
+void write_char( uint8_t id, uint32_t i, uint8_t v ) {
+  printf("ERROR write_char: THIS IS A STUB\n");
+  exit(1);
+  return;
+}
+
+uint8_t read_char( uint8_t id, uint32_t i ) {
+  printf("ERROR read_char: THIS IS A STUB\n");
+  exit(1);
+  return 0;
+}
+
+//---
+
+void set_intvec_ptr(uint8_t id, uint8_t *p) {
+  printf("ERROR set_intvec_ptr: THIS IS A STUB\n");
+  exit(1);
+  return;
+}
+
+uintptr_t get_intvec_ptr(uint8_t id) {
+  printf("ERROR get_intvec_ptr: THIS IS A STUB\n");
+  exit(1);
+  return NULL;
+}
+
+void write_integer(uint8_t id, uint32_t i, int32_t v) {
+  printf("ERROR write_integer: THIS IS A STUB\n");
+  exit(1);
+  return;
+}
+
+int32_t read_integer(uint8_t id, uint32_t i) {
+  printf("ERROR read_integer: THIS IS A STUB\n");
+  exit(1);
+  return 0;
+}

--- a/vunit/vhdl/data_types/src/external/ghdl/vhpidirect_user.h
+++ b/vunit/vhdl/data_types/src/external/ghdl/vhpidirect_user.h
@@ -1,0 +1,49 @@
+#include <stdint.h>
+
+extern int ghdl_main (int argc, char **argv);
+
+uint8_t *D[256];
+
+//---
+
+// External string/byte_vector through access (mode = extacc)
+
+void set_string_ptr(uint8_t id, uintptr_t p) {
+  D[id] = (uint8_t*)p;
+}
+
+uintptr_t get_string_ptr(uint8_t id) {
+  return (uintptr_t)D[id];
+}
+
+// External string/byte_vector through functions (mode = extfnc)
+
+void write_char(uint8_t id, uint32_t i, uint8_t v) {
+  ((uint8_t*)D[id])[i] = v;
+}
+
+uint8_t read_char(uint8_t id, uint32_t i) {
+  return ((uint8_t*)D[id])[i];
+}
+
+//---
+
+// External integer_vector through access (mode = extacc)
+
+void set_intvec_ptr(uint8_t id, uintptr_t p) {
+  D[id] = (uint8_t*)p;
+}
+
+uintptr_t get_intvec_ptr(uint8_t id) {
+  return (uintptr_t)D[id];
+}
+
+// External integer_vector through functions (mode = extfnc)
+
+void write_integer(uint8_t id, uint32_t i, int32_t v) {
+  ((int32_t*)D[id])[i] = v;
+}
+
+int32_t read_integer(uint8_t id, uint32_t i) {
+  return ((int32_t*)D[id])[i];
+}

--- a/vunit/vhdl/data_types/src/integer_vector_ptr_pkg-body-93.vhd
+++ b/vunit/vhdl/data_types/src/integer_vector_ptr_pkg-body-93.vhd
@@ -5,88 +5,219 @@
 -- Copyright (c) 2014-2019, Lars Asplund lars.anders.asplund@gmail.com
 
 package body integer_vector_ptr_pkg is
-  shared variable current_index : integer := 0;
-  shared variable ptrs : vava_t := null;
+  type storage_t is record
+    id     : integer;
+    mode   : storage_mode_t;
+    length : integer;
+  end record;
+  constant null_storage : storage_t := (integer'low, internal, integer'low);
+
+  type storage_vector_t is array (natural range <>) of storage_t;
+  type storage_vector_access_t is access storage_vector_t;
+
+  type ptr_storage is record
+    idx   : natural;
+    ptr   : natural;
+    eptr  : natural;
+    idxs  : storage_vector_access_t;
+    ptrs  : vava_t;
+    eptrs : evava_t;
+  end record;
+
+  shared variable st : ptr_storage := (0, 0, 0, null, null, null);
+
+  procedure reallocate_ptrs (
+    acc    : inout vava_t;
+    length : integer
+  ) is
+    variable old : vava_t := acc;
+  begin
+    if old = null then
+      acc := new vav_t'(0 => null);
+    elsif old'length <= length then
+      -- Reallocate ptr pointers to larger ptr; use more size to trade size for speed
+      acc     := new vav_t'(0 to acc'length + 2**16 => null);
+      for i in old'range loop acc(i) := old(i); end loop;
+      deallocate(old);
+    end if;
+  end;
+
+  procedure reallocate_eptrs (
+    acc    : inout evava_t;
+    length : integer
+  ) is
+    variable old : evava_t := acc;
+  begin
+    if old = null then
+      acc := new evav_t'(0 => null);
+    elsif old'length <= length then
+      acc := new evav_t'(0 to acc'length + 2**16 => null);
+      for i in old'range loop acc(i) := old(i); end loop;
+      deallocate(old);
+    end if;
+  end;
+
+  procedure reallocate_ids (
+    acc    : inout storage_vector_access_t;
+    length : integer
+  ) is
+    variable old : storage_vector_access_t := acc;
+  begin
+    if old = null then
+      acc := new storage_vector_t(0 to 0);
+    elsif old'length <= length then
+      acc := new storage_vector_t(0 to acc'length + 2**16);
+      for i in old'range loop acc(i) := old(i); end loop;
+      deallocate(old);
+    end if;
+  end;
 
   impure function new_integer_vector_ptr (
     length : natural := 0;
+    mode   : storage_mode_t := internal;
+    eid    : index_t := -1;
     value  : val_t   := 0
-  ) return ptr_t is
-    variable old_ptrs : vava_t;
-  begin
-    if ptrs = null then
-      ptrs := new vav_t'(0 => null);
-    elsif ptrs'length <= current_index then
-      -- Reallocate ptr pointers to larger ptr
-      -- Use more size to trade size for speed
-      old_ptrs := ptrs;
-      ptrs := new vav_t'(0 to ptrs'length + 2**16 => null);
-      for i in old_ptrs'range loop
-        ptrs(i) := old_ptrs(i);
-      end loop;
-      deallocate(old_ptrs);
-    end if;
-    ptrs(current_index) := new integer_vector_t'(0 to length-1 => value);
-    current_index := current_index + 1;
-    return (ref => current_index-1);
+  ) return ptr_t is begin
+    reallocate_ids(st.idxs, st.idx);
+    case mode is
+      when internal =>
+        st.idxs(st.idx) := (
+          id     => st.ptr,
+          mode   => internal,
+          length => 0
+        );
+        reallocate_ptrs(st.ptrs, st.ptr);
+        st.ptrs(st.ptr) := new vec_t'(0 to length-1 => value);
+        st.ptr := st.ptr + 1;
+      when extacc =>
+        st.idxs(st.idx) := (
+          id     => st.eptr,
+          mode   => extacc,
+          length => length
+        );
+        reallocate_eptrs(st.eptrs, st.eptr);
+        st.eptrs(st.eptr) := get_ptr(eid);
+        st.eptr := st.eptr + 1;
+      when extfnc =>
+        st.idxs(st.idx) := (
+          id     => eid,
+          mode   => extfnc,
+          length => length
+        );
+    end case;
+    st.idx := st.idx + 1;
+    return (ref => st.idx-1);
+  end;
+
+  impure function is_external (
+    ptr : ptr_t
+  ) return boolean is begin
+    return st.idxs(ptr.ref).mode /= internal;
+  end;
+
+  -- @TODO Remove check_external when all the functions/procedures are implemented
+  procedure check_external (
+    ptr : ptr_t;
+    s   : string
+  ) is begin
+    assert not is_external(ptr) report s & " not implemented for external model" severity error;
   end;
 
   procedure deallocate (
     ptr : ptr_t
-  ) is begin
-    deallocate(ptrs(ptr.ref));
-    ptrs(ptr.ref) := null;
+  ) is
+    variable s : storage_t := st.idxs(ptr.ref);
+  begin
+    -- @TODO Implement deallocate for external models
+    check_external(ptr, "deallocate");
+    deallocate(st.ptrs(s.id));
+    st.ptrs(s.id) := null;
   end;
 
   impure function length (
     ptr : ptr_t
-  ) return integer is begin
-    return ptrs(ptr.ref)'length;
+  ) return integer is
+    variable s : storage_t := st.idxs(ptr.ref);
+  begin
+    case s.mode is
+      when internal => return st.ptrs(s.id)'length;
+      when others   => return abs(s.length);
+    end case;
   end;
 
   procedure set (
     ptr   : ptr_t;
     index : natural;
     value : val_t
-  ) is begin
-    ptrs(ptr.ref)(index) := value;
+  ) is
+    variable s : storage_t := st.idxs(ptr.ref);
+  begin
+    case s.mode is
+      when extfnc   => write_integer(s.id, index, value);
+      when extacc   => st.eptrs(s.id)(index) := value;
+      when internal => st.ptrs(s.id)(index) := value;
+    end case;
   end;
 
   impure function get (
     ptr   : ptr_t;
     index : natural
-  ) return val_t is begin
-    return ptrs(ptr.ref)(index);
+  ) return val_t is
+    variable s : storage_t := st.idxs(ptr.ref);
+  begin
+    case s.mode is
+      when extfnc   => return read_integer(s.id, index);
+      when extacc   => return st.eptrs(s.id)(index);
+      when internal => return st.ptrs(s.id)(index);
+    end case;
   end;
 
   procedure reallocate (
     ptr    : ptr_t;
     length : natural;
     value  : val_t := 0
-  ) is begin
-    deallocate(ptrs(ptr.ref));
-    ptrs(ptr.ref) := new integer_vector_t'(0 to length - 1 => value);
+  ) is
+    variable s : storage_t := st.idxs(ptr.ref);
+  begin
+    case s.mode is
+      when extfnc  =>
+        -- @FIXME The reallocation request is just ignored. What should we do here?
+        --check_external(ptr, "reallocate");
+      when extacc   =>
+        -- @TODO Implement reallocate for external models (through access)
+        check_external(ptr, "reallocate");
+      when internal =>
+        deallocate(st.ptrs(s.id));
+        st.ptrs(s.id) := new vec_t'(0 to length - 1 => value);
+    end case;
   end;
 
   procedure resize (
     ptr    : ptr_t;
     length : natural;
     drop   : natural := 0;
-    value  : val_t := 0
+    value  : val_t   := 0
   ) is
-    variable old_ptr, new_ptr : integer_vector_access_t;
+    variable oldp, newp : integer_vector_access_t;
     variable min_len : natural := length;
+    variable s : storage_t := st.idxs(ptr.ref);
   begin
-    new_ptr := new integer_vector_t'(0 to length - 1 => value);
-    old_ptr := ptrs(ptr.ref);
-    if min_len > old_ptr'length - drop then
-      min_len := old_ptr'length - drop;
-    end if;
-    for i in 0 to min_len-1 loop
-      new_ptr(i) := old_ptr(drop + i);
-    end loop;
-    ptrs(ptr.ref) := new_ptr;
-    deallocate(old_ptr);
+    case s.mode is
+      when internal =>
+        newp := new vec_t'(0 to length-1 => value);
+        oldp := st.ptrs(s.id);
+        if min_len > oldp'length - drop then
+          min_len := oldp'length - drop;
+        end if;
+        for i in 0 to min_len-1 loop
+          newp(i) := oldp(drop + i);
+        end loop;
+        st.ptrs(s.id) := newp;
+        deallocate(oldp);
+      when others =>
+        -- @TODO Implement resize for external models
+        check_external(ptr, "resize");
+      end case;
   end;
 
   function to_integer (

--- a/vunit/vhdl/data_types/src/integer_vector_ptr_pkg.vhd
+++ b/vunit/vhdl/data_types/src/integer_vector_ptr_pkg.vhd
@@ -3,7 +3,6 @@
 -- You can obtain one at http://mozilla.org/MPL/2.0/.
 --
 -- Copyright (c) 2014-2019, Lars Asplund lars.anders.asplund@gmail.com
-
 --
 -- The purpose of this package is to provide an integer vector access type (pointer)
 -- that can itself be used in arrays and returned from functions unlike a
@@ -12,34 +11,45 @@
 --
 
 use work.types_pkg.all;
+use work.external_integer_vector_pkg.all;
+
 use work.codec_pkg.all;
 use work.codec_builder_pkg.all;
 
 package integer_vector_ptr_pkg is
-  subtype index_t is integer range -1 to integer'high;
+
   type integer_vector_ptr_t is record
     ref : index_t;
   end record;
-  constant null_ptr : integer_vector_ptr_t := (ref => -1);
+  constant null_integer_vector_ptr : integer_vector_ptr_t := (ref => -1);
+  alias null_ptr is null_integer_vector_ptr;
 
   alias  ptr_t  is integer_vector_ptr_t;
   alias  val_t  is integer;
   alias  vec_t  is integer_vector_t;
   alias  vav_t  is integer_vector_access_vector_t;
+  alias evav_t  is extintvec_access_vector_t;
   alias  vava_t is integer_vector_access_vector_access_t;
+  alias evava_t is extintvec_access_vector_access_t;
 
   function to_integer (
     value : ptr_t
   ) return integer;
 
   impure function to_integer_vector_ptr (
-    value : val_t
+    value : integer
   ) return ptr_t;
 
   impure function new_integer_vector_ptr (
     length : natural := 0;
-    value  : val_t := 0
+    mode   : storage_mode_t := internal;
+    eid    : index_t := -1;
+    value  : val_t   := 0
   ) return ptr_t;
+
+  impure function is_external (
+    ptr : ptr_t
+  ) return boolean;
 
   procedure deallocate (
     ptr : ptr_t
@@ -70,7 +80,7 @@ package integer_vector_ptr_pkg is
     ptr    : ptr_t;
     length : natural;
     drop   : natural := 0;
-    value  : val_t := 0
+    value  : val_t   := 0
   );
 
   function encode (
@@ -87,8 +97,8 @@ package integer_vector_ptr_pkg is
     variable result : out ptr_t
   );
 
-  alias encode_integer_vector_ptr_t is encode[ptr_t return string];
-  alias decode_integer_vector_ptr_t is decode[string return ptr_t];
+  alias encode_ptr_t is encode[ptr_t return string];
+  alias decode_ptr_t is decode[string return ptr_t];
 
   constant integer_vector_ptr_t_code_length : positive := integer_code_length;
 

--- a/vunit/vhdl/data_types/src/types.vhd
+++ b/vunit/vhdl/data_types/src/types.vhd
@@ -29,5 +29,9 @@ package types_pkg is
   type integer_vector_access_t is access integer_vector_t;
   type integer_vector_access_vector_t is array (natural range <>) of integer_vector_access_t;
   type integer_vector_access_vector_access_t is access integer_vector_access_vector_t;
+
+  type extintvec_access_t is access integer_vector_t(0 to integer'high);
+  type extintvec_access_vector_t is array (natural range <>) of extintvec_access_t;
+  type extintvec_access_vector_access_t is access extintvec_access_vector_t;
 end package;
 


### PR DESCRIPTION
Based on #482 and #507.
Refs #462, #465, #470.

> @kraigher [wrote](https://github.com/VUnit/vunit/pull/470#issuecomment-482924422):
> So in this case the first task becomes to add a dynamic byte array data type to VUnit that can have an external implementation in a C-object. It is easier to review if such a task is done in isolation as a separate PR.

In this PR, external modes are added to `integer_vector_ptr.vhd`, following the same approach as in #507.

---

In order to support using `*_ptr` with or without VHPI, two different implementations of the external resources are provided. One of them, `external_*_pkg-vhpi.vhd`, declares the functions/procedures as external; therefore, C implementations must be provided. The other one, `external_*_pkg-novhpi.vhd` does not declare the functions/procedures as external; C implementations are not required, but it is not possible to create vectors with `id/=0` (an assertion of level error is raised).

The list of objects is added through `set_sim_option("ghdl.elab_flags", ["-Wl," + " ".join(files)])`.

---

An example is added, `external_buffer`, to test accessing the same external buffer/array using two methods. The external C application allocates a buffer of length 15 and writes to the first 5 positions. In the VHDL testbench, two `integer_vector_ptr` are created. The first one is used to copy the first five elements to positions 5-9. And the second one is used to copy data from positions 5-9, to positions 10-14. The C application prints all the positions before and after the execution of the simulation.

---

`deallocate`, `reallocate` and `resize` are not implemented for external models. For the case `id>0`, it would be easy to implement it. Since the 'connection' is a pointer, it is possible to use `malloc` or `mmap` in the C implementation. Coherently, it would be possible to update the length in the VHDL model according to the actual size in the C app.

However, when `extfnc`, it can be complex or not possible. Since `read_byte`/`write_byte` can be used to interact with external services/processes through pipes, sockets, packets, messages, etc., the implementation is likely to be very specific. Nonetheless, in this example the implementation can be the same for both 'access' modes.

---

ghdl/ghdl#797