### PR TITLE
Add method 'set_objects'

### DIFF
--- a/vunit/configuration.py
+++ b/vunit/configuration.py
@@ -111,6 +111,12 @@ class Configuration(object):  # pylint: disable=too-many-instance-attributes
         else:
             self.generics[name] = value
 
+    def set_objects(self, files):
+        """
+        Set list of pre-built objects to be linked
+        """
+        self.set_sim_option("objects", files)
+
     def set_sim_option(self, name, value):
         """
         Set sim option
@@ -198,6 +204,12 @@ class ConfigurationVisitor(object):
         for configs in self.get_configuration_dicts():
             for config in configs.values():
                 config.set_generic(name, value)
+
+    def set_objects(self, files, overwrite=True):
+        """
+        Set list of pre-built objects to be linked
+        """
+        self.set_sim_option("objects", files, overwrite)
 
     def set_sim_option(self, name, value, overwrite=True):
         """

--- a/vunit/ghdl_interface.py
+++ b/vunit/ghdl_interface.py
@@ -124,6 +124,13 @@ class GHDLInterface(SimulatorInterface):
         print("=============================" + ("=" * 60))
         raise AssertionError("No known GHDL back-end could be detected from running 'ghdl --version'")
 
+    @classmethod
+    def supports_vhpi(cls):
+        """
+        Return if the simulator supports VHPI
+        """
+        return cls.determine_backend(cls.find_prefix_from_path()) == "mcode"
+
     def _has_output_flag(self):
         """
         Returns if backend supports output flag

--- a/vunit/ghdl_interface.py
+++ b/vunit/ghdl_interface.py
@@ -129,7 +129,7 @@ class GHDLInterface(SimulatorInterface):
         """
         Return if the simulator supports VHPI
         """
-        return cls.determine_backend(cls.find_prefix_from_path()) == "mcode"
+        return cls.determine_backend(cls.find_prefix_from_path()) != "mcode"
 
     def _has_output_flag(self):
         """
@@ -215,6 +215,10 @@ class GHDLInterface(SimulatorInterface):
             cmd += ['-o', join(output_path, "%s-%s" % (config.entity_name,
                                                        config.architecture_name))]
         cmd += config.sim_options.get("ghdl.elab_flags", [])
+        objs = config.sim_options.get("objects", [])
+        if objs:
+            cmd += ["-Wl," + " ".join(objs)]
+
         cmd += [config.entity_name, config.architecture_name]
 
         if not ghdl_e:

--- a/vunit/simulator_factory.py
+++ b/vunit/simulator_factory.py
@@ -57,7 +57,8 @@ class SimulatorFactory(object):
                       [VHDLAssertLevelOption(),
                        BooleanOption("disable_ieee_warnings"),
                        BooleanOption("enable_coverage"),
-                       ListOfStringOption("pli")])
+                       ListOfStringOption("pli"),
+                       ListOfStringOption("objects")])
 
         for sim_class in self.supported_simulators():
             for opt in sim_class.sim_options:

--- a/vunit/simulator_interface.py
+++ b/vunit/simulator_interface.py
@@ -17,7 +17,7 @@ from vunit.exceptions import CompileError
 from vunit.color_printer import NO_COLOR_PRINTER
 
 
-class SimulatorInterface(object):
+class SimulatorInterface(object):  # pylint: disable=too-many-public-methods
     """
     Generic simulator interface
     """
@@ -142,6 +142,13 @@ class SimulatorInterface(object):
     def has_valid_exit_code():
         """
         Return if the simulation should fail with nonzero exit codes
+        """
+        return False
+
+    @staticmethod
+    def supports_vhpi():
+        """
+        Return if the simulator supports VHPI
         """
         return False
 

--- a/vunit/test/common.py
+++ b/vunit/test/common.py
@@ -32,6 +32,16 @@ def simulator_is(*names):
     return SIMULATOR_FACTORY.select_simulator().name in names
 
 
+def simulator_check(func):
+    """
+    Check some method of the selected simulator
+    """
+    simif = SIMULATOR_FACTORY.select_simulator()
+    if simif is None:
+        return False
+    return func(simif)
+
+
 def check_report(report_file, tests=None):
     """
     Check an XML report_file for the exact occurrence of specific test results

--- a/vunit/ui.py
+++ b/vunit/ui.py
@@ -568,6 +568,12 @@ class VUnit(object):  # pylint: disable=too-many-instance-attributes, too-many-p
         for test_bench in check_not_empty(test_benches, allow_empty, "No test benches found"):
             test_bench.set_generic(name, value)
 
+    def set_objects(self, files, overwrite=True):
+        """
+        Set list of pre-built objects to be linked
+        """
+        self.set_sim_option("objects", files, overwrite=overwrite)
+
     def set_sim_option(self, name, value, allow_empty=False, overwrite=True):
         """
         Set simulation option in all |configurations|
@@ -1199,6 +1205,12 @@ class Library(object):
         for test_bench in self.get_test_benches(allow_empty=allow_empty):
             test_bench.set_generic(name, value)
 
+    def set_objects(self, files, allow_empty=False, overwrite=True):
+        """
+        Set list of pre-built objects to be linked
+        """
+        self.set_sim_option("objects", files, allow_empty=allow_empty, overwrite=overwrite)
+
     def set_sim_option(self, name, value, allow_empty=False, overwrite=True):
         """
         Set simulation option within all |configurations| of test benches and tests this library
@@ -1512,6 +1524,12 @@ class TestBench(object):
         """
         self._test_bench.set_generic(name, value)
 
+    def set_objects(self, files, overwrite=True):
+        """
+        Set list of pre-built objects to be linked
+        """
+        self.set_sim_option("objects", files, overwrite)
+
     def set_sim_option(self, name, value, overwrite=True):
         """
         Set simulation option within all |configurations| of this test bench or test cases within it
@@ -1792,6 +1810,12 @@ class Test(object):
 
         """
         self._test_case.set_generic(name, value)
+
+    def set_objects(self, files, overwrite=True):
+        """
+        Set list of pre-built objects to be linked
+        """
+        self.set_sim_option("objects", files, overwrite)
 
     def set_sim_option(self, name, value, overwrite=True):
         """


### PR DESCRIPTION
As commented in [#476](https://github.com/VUnit/vunit/pull/476#discussion_r2763721469), this PR allows to provide some pre-built object (typically from C sources) to have them built with the VHDL design. The primary use case for this is to provide VHPI implementations, but it can also be used to just wrap a GHDL simulation.

The objects are saved in a new sim option named `objects`. Currently, these are only used in `ghdl_interface`. However, in the future it is possible to extend it to ModelSim/QuestaSim and/or Riviera-Pro.

Moreover, method `simulator_check` is added to `test/common.py` and `supports_vhpi` is added to `simulator_interface`. These allow to evaluate if a simulator supports VHPI, before trying to run an example that requires it.

Note that neither tests nor examples are provided in this PR, because those are implemented in #465 and #476.