### PR TITLE
check_axi_stream non-blocking

### DIFF
--- a/vunit/vhdl/verification_components/src/axi_stream_pkg.vhd
+++ b/vunit/vhdl/verification_components/src/axi_stream_pkg.vhd
@@ -678,22 +678,22 @@ package body axi_stream_pkg is
     variable got_tuser : std_logic_vector(user_length(axi_stream)-1 downto 0);
   begin
     pop_axi_stream(net, axi_stream, got_tdata, got_tlast, got_tkeep, got_tstrb, got_tid, got_tdest, got_tuser);
-    check_equal(got_tdata, expected, msg);
-    check_equal(got_tlast, tlast, msg);
+    check_equal(got_tdata, expected, "TDATA mismatch, " & msg);
+    check_equal(got_tlast, tlast, "TLAST mismatch, " & msg);
     if tkeep'length > 0 then
-      check_equal(got_tkeep, tkeep, msg);
+      check_equal(got_tkeep, tkeep, "TKEEP mismatch, " & msg);
     end if;
     if tstrb'length > 0 then
-      check_equal(got_tstrb, tstrb, msg);
+      check_equal(got_tstrb, tstrb, "TSTRB mismatch, " & msg);
     end if;
     if tid'length > 0 then
-      check_equal(got_tid, tid, msg);
+      check_equal(got_tid, tid, "TID mismatch, " & msg);
     end if;
     if tdest'length > 0 then
-      check_equal(got_tdest, tdest, msg);
+      check_equal(got_tdest, tdest, "TDEST mismatch, " & msg);
     end if;
     if tuser'length > 0 then
-      check_equal(got_tuser, tuser, msg);
+      check_equal(got_tuser, tuser, "TUSER mismatch, " & msg);
     end if;
   end procedure;
 

--- a/vunit/vhdl/verification_components/test/tb_axi_stream.vhd
+++ b/vunit/vhdl/verification_components/test/tb_axi_stream.vhd
@@ -335,7 +335,7 @@ begin
         if i = 14 then
           last := '1';
         end if;
-        push_axi_stream(net, master_axi_stream, 
+        push_axi_stream(net, master_axi_stream,
                         tdata => std_logic_vector(to_unsigned(i, 8)),
                         tlast => last,
                         tkeep => "1",
@@ -371,7 +371,7 @@ begin
       wait until rising_edge(aclk);
       timestamp := now;
 
-      push_axi_stream(net, master_axi_stream, 
+      push_axi_stream(net, master_axi_stream,
                       tdata => std_logic_vector(to_unsigned(3, 8)),
                       tlast => '1',
                       tkeep => "0",

--- a/vunit/vhdl/verification_components/test/tb_axi_stream.vhd
+++ b/vunit/vhdl/verification_components/test/tb_axi_stream.vhd
@@ -316,13 +316,13 @@ begin
       mock(mocklogger);
 
       check_axi_stream(net, slave_axi_stream, x"12", '1', "1", "1", x"23", x"34", x"45", "checking axi stream");
-      check_log(mocklogger, "checking axi stream - Got 0001_0001 (17). Expected 0001_0010 (18).", error);
-      check_log(mocklogger, "checking axi stream - Got 0. Expected 1.", error);
-      check_log(mocklogger, "checking axi stream - Got 0 (0). Expected 1 (1).", error);
-      check_log(mocklogger, "checking axi stream - Got 0 (0). Expected 1 (1).", error);
-      check_log(mocklogger, "checking axi stream - Got 0010_0010 (34). Expected 0010_0011 (35).", error);
-      check_log(mocklogger, "checking axi stream - Got 0011_0011 (51). Expected 0011_0100 (52).", error);
-      check_log(mocklogger, "checking axi stream - Got 0100_0100 (68). Expected 0100_0101 (69).", error);
+      check_log(mocklogger, "TDATA mismatch, checking axi stream - Got 0001_0001 (17). Expected 0001_0010 (18).", error);
+      check_log(mocklogger, "TLAST mismatch, checking axi stream - Got 0. Expected 1.", error);
+      check_log(mocklogger, "TKEEP mismatch, checking axi stream - Got 0 (0). Expected 1 (1).", error);
+      check_log(mocklogger, "TSTRB mismatch, checking axi stream - Got 0 (0). Expected 1 (1).", error);
+      check_log(mocklogger, "TID mismatch, checking axi stream - Got 0010_0010 (34). Expected 0010_0011 (35).", error);
+      check_log(mocklogger, "TDEST mismatch, checking axi stream - Got 0011_0011 (51). Expected 0011_0100 (52).", error);
+      check_log(mocklogger, "TUSER mismatch, checking axi stream - Got 0100_0100 (68). Expected 0100_0101 (69).", error);
 
       unmock(mocklogger);
 

--- a/vunit/vhdl/verification_components/test/tb_axi_stream.vhd
+++ b/vunit/vhdl/verification_components/test/tb_axi_stream.vhd
@@ -326,6 +326,91 @@ begin
 
       unmock(mocklogger);
 
+    elsif run("test back-to-back passing check") then
+      wait until rising_edge(aclk);
+      timestamp := now;
+
+      last := '0';
+      for i in 3 to 14 loop
+        if i = 14 then
+          last := '1';
+        end if;
+        push_axi_stream(net, master_axi_stream, 
+                        tdata => std_logic_vector(to_unsigned(i, 8)),
+                        tlast => last,
+                        tkeep => "1",
+                        tstrb => "1",
+                        tid => std_logic_vector(to_unsigned(42, 8)),
+                        tdest => std_logic_vector(to_unsigned(i+1, 8)),
+                        tuser => std_logic_vector(to_unsigned(i*2, 8)));
+      end loop;
+
+      last := '0';
+      for i in 3 to 14 loop
+        if i = 14 then
+          last := '1';
+        end if;
+        check_axi_stream(net, slave_axi_stream,
+                         expected => std_logic_vector(to_unsigned(i, 8)),
+                         tlast => last,
+                         tkeep => "1",
+                         tstrb => "1",
+                         tid => std_logic_vector(to_unsigned(42, 8)),
+                         tdest => std_logic_vector(to_unsigned(i+1, 8)),
+                         tuser => std_logic_vector(to_unsigned(i*2, 8)),
+                         msg  => "check blocking",
+                         blocking  => false);
+      end loop;
+
+      check_equal(now, timestamp, result(" setting up transaction stalled"));
+
+      wait_until_idle(net, as_sync(slave_axi_stream));
+      check_equal(now, timestamp + (12+1)*10 ns, " transaction time incorrect");
+
+    elsif run("test back-to-back failing check") then
+      wait until rising_edge(aclk);
+      timestamp := now;
+
+      push_axi_stream(net, master_axi_stream, 
+                      tdata => std_logic_vector(to_unsigned(3, 8)),
+                      tlast => '1',
+                      tkeep => "0",
+                      tstrb => "0",
+                      tid => std_logic_vector(to_unsigned(42, 8)),
+                      tdest => std_logic_vector(to_unsigned(4, 8)),
+                      tuser => std_logic_vector(to_unsigned(7, 8)));
+
+      check_axi_stream(net, slave_axi_stream,
+                       expected => std_logic_vector(to_unsigned(6, 8)),
+                       tlast => '0',
+                       tkeep => "1",
+                       tstrb => "1",
+                       tid => std_logic_vector(to_unsigned(44, 8)),
+                       tdest => std_logic_vector(to_unsigned(5, 8)),
+                       tuser => std_logic_vector(to_unsigned(8, 8)),
+                       msg => "check non-blocking",
+                       blocking  => false);
+
+      check_equal(now, timestamp, result(" setting up transaction stalled"));
+
+      wait until rising_edge(aclk);
+      mocklogger := get_logger("check");
+      mock(mocklogger);
+
+      wait until rising_edge(aclk) and tvalid = '1';
+
+      check_log(mocklogger, "TDATA mismatch, check non-blocking - Got 0000_0011 (3). Expected 0000_0110 (6).", error);
+      check_log(mocklogger, "TLAST mismatch, check non-blocking - Got 1. Expected 0.", error);
+      check_log(mocklogger, "TKEEP mismatch, check non-blocking - Got 0 (0). Expected 1 (1).", error);
+      check_log(mocklogger, "TSTRB mismatch, check non-blocking - Got 0 (0). Expected 1 (1).", error);
+      check_log(mocklogger, "TID mismatch, check non-blocking - Got 0010_1010 (42). Expected 0010_1100 (44).", error);
+      check_log(mocklogger, "TDEST mismatch, check non-blocking - Got 0000_0100 (4). Expected 0000_0101 (5).", error);
+      check_log(mocklogger, "TUSER mismatch, check non-blocking - Got 0000_0111 (7). Expected 0000_1000 (8).", error);
+
+      unmock(mocklogger);
+
+      check_equal(now, timestamp + 20 ns, " transaction time incorrect");
+
     end if;
     test_runner_cleanup(runner);
   end process;


### PR DESCRIPTION
This resolves #477 

I reused the same function with an additional argument with default value for backward compatibility (compared to the current master).
I prefer that to a separate function, but let me know if you think otherwise.

Only the specific axi_stream stuff is updated. One could think of doing the same to the generic stream_slave, but I can't handle the consequences (would need to update the uart...).

Running all checks in verification_components seems to fail with questa due to some delta-cycle differences with GHDL... :-/ GHDL looks fine here.