### PR TITLE
Add method simulator_check to test/common.py

### DIFF
--- a/vunit/ghdl_interface.py
+++ b/vunit/ghdl_interface.py
@@ -124,6 +124,13 @@ class GHDLInterface(SimulatorInterface):
         print("=============================" + ("=" * 60))
         raise AssertionError("No known GHDL back-end could be detected from running 'ghdl --version'")
 
+    @classmethod
+    def supports_vhpi(cls):
+        """
+        Return if the simulator supports VHPI
+        """
+        return cls.determine_backend(cls.find_prefix_from_path()) != "mcode"
+
     def _has_output_flag(self):
         """
         Returns if backend supports output flag

--- a/vunit/simulator_interface.py
+++ b/vunit/simulator_interface.py
@@ -17,7 +17,7 @@ from vunit.exceptions import CompileError
 from vunit.color_printer import NO_COLOR_PRINTER
 
 
-class SimulatorInterface(object):
+class SimulatorInterface(object):  # pylint: disable=too-many-public-methods
     """
     Generic simulator interface
     """
@@ -142,6 +142,13 @@ class SimulatorInterface(object):
     def has_valid_exit_code():
         """
         Return if the simulation should fail with nonzero exit codes
+        """
+        return False
+
+    @staticmethod
+    def supports_vhpi():
+        """
+        Return if the simulator supports VHPI
         """
         return False
 

--- a/vunit/test/common.py
+++ b/vunit/test/common.py
@@ -32,6 +32,16 @@ def simulator_is(*names):
     return SIMULATOR_FACTORY.select_simulator().name in names
 
 
+def simulator_check(func):
+    """
+    Check some method of the selected simulator
+    """
+    simif = SIMULATOR_FACTORY.select_simulator()
+    if simif is None:
+        return False
+    return func(simif)
+
+
 def check_report(report_file, tests=None):
     """
     Check an XML report_file for the exact occurrence of specific test results


### PR DESCRIPTION
Ref #481.

Method `simulator_check` is added to `test/common.py` and `supports_vhpi` is added to `simulator_interface`. These allow to evaluate if a simulator supports VHPI, before trying to run an example that requires it.