### PR TITLE
Use docker images in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,6 @@
 language: python
-
-install:
-  - git fetch --unshallow --tags
-  - pip install tox
-
-script:
-- tox -e $BUILD_NAME
+install: pip install tox
+script: tox -e $BUILD_NAME
 
 stages:
   - test
@@ -13,10 +8,32 @@ stages:
 
 matrix:
   include:
+  - &docker
+    env:
+      - BUILD_NAME=py27-acceptance-ghdl
+      - DOCKER_IMAGE=mcode-2
+    services: docker
+    language: minimal
+    install: skip
+    script: docker run --rm -tv $(pwd):/src -w /src vunit/dev:$DOCKER_IMAGE tox -e $BUILD_NAME
+
+  - <<: *docker
+    env:
+      - BUILD_NAME=py37-acceptance-ghdl
+      - DOCKER_IMAGE=llvm
+
+  - <<: *docker
+    env:
+      - BUILD_NAME=py37-vcomponents-ghdl
+      - DOCKER_IMAGE=mcode
+
+
   - env: BUILD_NAME=py27-lint
     python: '2.7'
-  - env: BUILD_NAME=py36-lint
-    python: '3.6'
+  - env: BUILD_NAME=py37-lint
+    dist: xenial
+    python: '3.7'
+
 
   - env: BUILD_NAME=py27-unit
     python: '2.7'
@@ -26,53 +43,18 @@ matrix:
     python: '3.5'
   - env: BUILD_NAME=py36-unit
     python: '3.6'
+  - env: BUILD_NAME=py37-unit
+    dist: xenial
+    python: '3.7'
 
-  # Python 2.7 with ghdl mcode
-  - env: BUILD_NAME=py27-acceptance-ghdl
-    python: '2.7'
-    os: linux
-    addons:
-      apt:
-        packages:
-        - gnat
-    before_script:
-    - mkdir -p ghdl/build-mcode
-    - curl -fsSL https://codeload.github.com/ghdl/ghdl/tar.gz/master | tar xzf - -C ghdl --strip-components=1
-    - cd ghdl/build-mcode
-    - ../configure --prefix=../../install-ghdl-mcode/
-    - make
-    - make install
-    - cd ../../
-    - export PATH=$PATH:install-ghdl-mcode/bin/
-
-  # Python 3.6 with ghdl llvm
-  - &py36
-    env: BUILD_NAME=py36-acceptance-ghdl
-    python: '3.6'
-    os: linux
-    dist: trusty
-    before_install:
-    - sudo apt-get update -qq
-    - sudo apt-get install -y gnat-4.8 zlib1g-dev
-    - sudo apt-get install -y llvm-3.5-dev llvm-3.5-tools libedit-dev
-    before_script:
-    - mkdir -p ghdl/build-llvm
-    - curl -fsSL https://codeload.github.com/ghdl/ghdl/tar.gz/master | tar xzf - -C ghdl --strip-components=1
-    - cd ghdl/build-llvm
-    - ../configure --prefix=../../install-ghdl-llvm/ --with-llvm-config=llvm-config-3.5
-    - make
-    - make install
-    - cd ../../
-    - export PATH=$PATH:install-ghdl-llvm/bin/
-
-  - <<: *py36
-    env: BUILD_NAME=py36-vcomponents-ghdl
 
   - env: BUILD_NAME=py27-docs
     python: '2.7'
+    before_script: git fetch --unshallow --tags
   - env: BUILD_NAME=py36-docs
     python: '3.6'
-    after_script: touch .tox/py36-docs/tmp/docsbuild/.nojekyll
+    before_script: git fetch --unshallow --tags
+    after_success: touch .tox/py36-docs/tmp/docsbuild/.nojekyll
     deploy:
       provider: pages
       repo: VUnit/VUnit.github.io
@@ -91,7 +73,9 @@ matrix:
   - stage: deploy
     python: '3.6'
     if: tag IS present
-    script: python tools/new_release.py 'check'
+    script:
+      - git fetch --unshallow --tags
+      - python tools/new_release.py 'check'
     deploy:
       provider: pypi
       distributions: sdist

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{27,34,35,36}-unit, py{27,34,35,36}-acceptance-{activehdl,ghdl,modelsim,rivierapro}, py{27,34,35,36,37}-vcomponents-{activehdl,ghdl,modelsim,rivierapro}, py{27,35,36,37}-lint, py{27,35,36,37}-docs
+envlist = py{27,34,35,36,37}-unit, py{27,34,35,36,37}-acceptance-{activehdl,ghdl,modelsim,rivierapro}, py{27,34,35,36,37}-vcomponents-{activehdl,ghdl,modelsim,rivierapro}, py{27,35,36,37}-lint, py{27,35,36,37}-docs
 skip_missing_interpreters = True
 
 [testenv]


### PR DESCRIPTION
<strike>This PR is built on top of #508. It will be kept as a draft until #508 is merged.</strike>

In this PR, docker images created in vunit/docker and available through hub.docker.com/r/vunit/dev are used in order to avoid building GHDL and installing tox in each job. Three different images are used:

- vunit/dev:mcode includes Python3.7 with the latest GHDL from image ghdl/ghdl:stretch-mcode.
- vunit/dev:mcode-2 is the same but with Python2.7.
- vunit/dev:llvm includes Python3.7 and GHDL from image ghdl/ghdl:ubuntu18-llvm-5.0.

Images are used for acceptance and vcomponents. lint, unit and docs are still executed 'natively'.