### PR TITLE
Modified merge_coverage to handle long vcover merge commands.

### DIFF
--- a/vunit/modelsim_interface.py
+++ b/vunit/modelsim_interface.py
@@ -339,14 +339,16 @@ proc _vunit_sim_restart {} {
         if args is None:
             args = []
 
-        vcover_cmd = [join(self._prefix, 'vcover'), 'merge'] + args + [file_name]
-
-        for coverage_file in self._coverage_files:
-            if file_exists(coverage_file):
-                vcover_cmd.append(coverage_file)
-            else:
-                LOGGER.warning("Missing coverage file: %s", coverage_file)
-
+        vcover_cmd = [join(self._prefix, 'vcover'), 'merge', '-inputs',  join(self._output_path, 'coverage_files.txt')] + args + [file_name]
+        coverage_files = join(self._output_path, 'coverage_files.txt')
+        with open(coverage_files, "w") as fptr:
+          for coverage_file in self._coverage_files:
+              if file_exists(coverage_file):
+                  fptr.write(str(coverage_file) + "\n")
+              else:
+                  LOGGER.warning("Missing coverage file: %s", coverage_file)
+        fptr.close() 
+          
         print("Merging coverage files into %s..." % file_name)
         vcover_merge_process = Process(vcover_cmd,
                                        env=self.get_env())

--- a/vunit/modelsim_interface.py
+++ b/vunit/modelsim_interface.py
@@ -339,16 +339,16 @@ proc _vunit_sim_restart {} {
         if args is None:
             args = []
 
-        vcover_cmd = [join(self._prefix, 'vcover'), 'merge', '-inputs',  join(self._output_path, 'coverage_files.txt')] + args + [file_name]
         coverage_files = join(self._output_path, 'coverage_files.txt')
+        vcover_cmd = [join(self._prefix, 'vcover'), 'merge', '-inputs'] + [coverage_files] + args + [file_name]
         with open(coverage_files, "w") as fptr:
-          for coverage_file in self._coverage_files:
-              if file_exists(coverage_file):
-                  fptr.write(str(coverage_file) + "\n")
-              else:
-                  LOGGER.warning("Missing coverage file: %s", coverage_file)
-        fptr.close() 
-          
+            for coverage_file in self._coverage_files:
+                if file_exists(coverage_file):
+                    fptr.write(str(coverage_file) + "\n")
+                else:
+                    LOGGER.warning("Missing coverage file: %s", coverage_file)
+        fptr.close()
+
         print("Merging coverage files into %s..." % file_name)
         vcover_merge_process = Process(vcover_cmd,
                                        env=self.get_env())

--- a/vunit/modelsim_interface.py
+++ b/vunit/modelsim_interface.py
@@ -347,7 +347,6 @@ proc _vunit_sim_restart {} {
                     fptr.write(str(coverage_file) + "\n")
                 else:
                     LOGGER.warning("Missing coverage file: %s", coverage_file)
-        fptr.close()
 
         print("Merging coverage files into %s..." % file_name)
         vcover_merge_process = Process(vcover_cmd,


### PR DESCRIPTION
The vcover command (launched with python subprocess) may exceed the
limit of 32768 characters in the Win32 API when merging too many
coverage files.

This is avoided by creating a temporary text file with the path to
all coverage files to be merged and applying the new text file using
the vcover merge -inputs flag.