### PR TITLE
Update incisive vhdl fixup so that contexts are replaced with correct…

### DIFF
--- a/tools/incisive_vhdl_fixup.py
+++ b/tools/incisive_vhdl_fixup.py
@@ -47,28 +47,45 @@ def replace_context_with_use_clauses(file_name):
 
     text = text.replace("context vunit_lib.vunit_context;", """\
 -- context vunit_lib.vunit_context; -- Not supported by Cadence Incisive
-use vunit_lib.lang.all;
+
+use vunit_lib.integer_vector_ptr_pkg.all;
+use vunit_lib.integer_vector_ptr_pool_pkg.all;
+use vunit_lib.integer_array_pkg.all;
+use vunit_lib.string_ptr_pkg.all;
+use vunit_lib.queue_pkg.all;
+use vunit_lib.queue_pool_pkg.all;
+use vunit_lib.string_ptr_pkg.all;
+use vunit_lib.string_ptr_pool_pkg.all;
+use vunit_lib.dict_pkg.all;
+
 use vunit_lib.string_ops.all;
 use vunit_lib.dictionary.all;
 use vunit_lib.path.all;
-use vunit_lib.log_types_pkg.all;
-use vunit_lib.log_special_types_pkg.all;
-use vunit_lib.check_types_pkg.all;
-use vunit_lib.check_special_types_pkg.all;
+use vunit_lib.print_pkg.all;
+use vunit_lib.log_levels_pkg.all;
+use vunit_lib.logger_pkg.all;
+use vunit_lib.log_handler_pkg.all;
+use vunit_lib.log_deprecated_pkg.all;
+use vunit_lib.ansi_pkg.all;
+use vunit_lib.checker_pkg.all;
 use vunit_lib.check_pkg.all;
+use vunit_lib.check_deprecated_pkg.all;
 use vunit_lib.run_types_pkg.all;
-use vunit_lib.run_special_types_pkg.all;
-use vunit_lib.run_base_pkg.all;
-use vunit_lib.run_pkg.all;""")
+use vunit_lib.run_pkg.all;
+use vunit_lib.run_deprecated_pkg.all;""")
 
     text = text.replace("context vunit_lib.com_context;", """\
 -- context vunit_lib.com_context; -- Not supported by Cadence Incisive
 use vunit_lib.com_pkg.all;
 use vunit_lib.com_types_pkg.all;
-use vunit_lib.com_codec_pkg.all;
+use vunit_lib.codec_pkg.all;
+use vunit_lib.codec_2008_pkg.all;
 use vunit_lib.com_string_pkg.all;
+use vunit_lib.codec_builder_pkg.all;
+use vunit_lib.codec_builder_2008_pkg.all;
 use vunit_lib.com_debug_codec_builder_pkg.all;
-use vunit_lib.com_std_codec_builder_pkg.all;
+use vunit_lib.com_deprecated_pkg.all;
+use vunit_lib.com_common_pkg.all;
 """)
 
     with open(file_name, "w") as fptr:


### PR DESCRIPTION
… packages.

This script replaces the 'vunit_context' uses with an explicit use of the libraries for tools that don't support using context.
The libraries that it was replacing the context with had got out of date.
This pull request just updates the libraries.