### PR TITLE
revert renaming 'length' to 'len'

### DIFF
--- a/vunit/vhdl/data_types/src/integer_vector_ptr_pkg-body-200x.vhd
+++ b/vunit/vhdl/data_types/src/integer_vector_ptr_pkg-body-200x.vhd
@@ -7,8 +7,8 @@
 package body integer_vector_ptr_pkg is
  type integer_vector_ptr_storage_t is protected
     impure function new_integer_vector_ptr (
-      len   : natural := 0;
-      value : val_t := 0
+      length : natural := 0;
+      value  : val_t := 0
     ) return natural;
 
     procedure deallocate (
@@ -31,16 +31,16 @@ package body integer_vector_ptr_pkg is
     ) return val_t;
 
     procedure reallocate (
-      ref   : natural;
-      len   : natural;
-      value : val_t := 0
+      ref    : natural;
+      length : natural;
+      value  : val_t := 0
     );
 
     procedure resize (
-      ref   : natural;
-      len   : natural;
-      drop  : natural := 0;
-      value : val_t := 0
+      ref    : natural;
+      length : natural;
+      drop   : natural := 0;
+      value  : val_t := 0
     );
   end protected;
 
@@ -49,8 +49,8 @@ package body integer_vector_ptr_pkg is
     variable ptrs : vava_t := null;
 
     impure function new_integer_vector_ptr (
-      len   : natural := 0;
-      value : val_t := 0
+      length : natural := 0;
+      value  : val_t := 0
     ) return natural is
       variable old_ptrs : vava_t;
       variable retval : ptr_t := (ref => current_index);
@@ -67,7 +67,7 @@ package body integer_vector_ptr_pkg is
         end loop;
         deallocate(old_ptrs);
       end if;
-      ptrs(current_index) := new integer_vector_t'(0 to len-1 => value);
+      ptrs(current_index) := new integer_vector_t'(0 to length-1 => value);
       current_index := current_index + 1;
       return retval.ref;
     end;
@@ -101,24 +101,24 @@ package body integer_vector_ptr_pkg is
     end;
 
     procedure reallocate (
-      ref   : natural;
-      len   : natural;
-      value : val_t := 0
+      ref    : natural;
+      length : natural;
+      value  : val_t := 0
     ) is begin
       deallocate(ptrs(ref));
-      ptrs(ref) := new integer_vector_t'(0 to len - 1 => value);
+      ptrs(ref) := new integer_vector_t'(0 to length - 1 => value);
     end;
 
     procedure resize (
-      ref   : natural;
-      len   : natural;
-      drop  : natural := 0;
-      value : val_t := 0
+      ref    : natural;
+      length : natural;
+      drop   : natural := 0;
+      value  : val_t := 0
     ) is
       variable old_ptr, new_ptr : integer_vector_access_t;
-      variable min_len : natural := len;
+      variable min_len : natural := length;
     begin
-      new_ptr := new integer_vector_t'(0 to len - 1 => value);
+      new_ptr := new integer_vector_t'(0 to length - 1 => value);
       old_ptr := ptrs(ref);
       if min_len > old_ptr'length - drop then
         min_len := old_ptr'length - drop;
@@ -148,10 +148,10 @@ package body integer_vector_ptr_pkg is
   end;
 
   impure function new_integer_vector_ptr (
-    len   : natural := 0;
-    value : val_t := 0
+    length : natural := 0;
+    value  : val_t := 0
   ) return ptr_t is begin
-    return (ref => integer_vector_ptr_storage.new_integer_vector_ptr(len, value));
+    return (ref => integer_vector_ptr_storage.new_integer_vector_ptr(length, value));
   end;
 
   procedure deallocate (
@@ -182,20 +182,20 @@ package body integer_vector_ptr_pkg is
   end;
 
   procedure reallocate (
-    ptr   : ptr_t;
-    len   : natural;
-    value : val_t := 0
+    ptr    : ptr_t;
+    length : natural;
+    value  : val_t := 0
   ) is begin
-    integer_vector_ptr_storage.reallocate(ptr.ref, len, value);
+    integer_vector_ptr_storage.reallocate(ptr.ref, length, value);
   end;
 
   procedure resize (
-    ptr   : ptr_t;
-    len   : natural;
-    drop  : natural := 0;
-    value : val_t := 0
+    ptr    : ptr_t;
+    length : natural;
+    drop   : natural := 0;
+    value  : val_t := 0
   ) is begin
-    integer_vector_ptr_storage.resize(ptr.ref, len, drop, value);
+    integer_vector_ptr_storage.resize(ptr.ref, length, drop, value);
   end;
 
   function encode (

--- a/vunit/vhdl/data_types/src/integer_vector_ptr_pkg-body-93.vhd
+++ b/vunit/vhdl/data_types/src/integer_vector_ptr_pkg-body-93.vhd
@@ -9,8 +9,8 @@ package body integer_vector_ptr_pkg is
   shared variable ptrs : vava_t := null;
 
   impure function new_integer_vector_ptr (
-    len   : natural := 0;
-    value : val_t   := 0
+    length : natural := 0;
+    value  : val_t   := 0
   ) return ptr_t is
     variable old_ptrs : vava_t;
   begin
@@ -26,7 +26,7 @@ package body integer_vector_ptr_pkg is
       end loop;
       deallocate(old_ptrs);
     end if;
-    ptrs(current_index) := new integer_vector_t'(0 to len-1 => value);
+    ptrs(current_index) := new integer_vector_t'(0 to length-1 => value);
     current_index := current_index + 1;
     return (ref => current_index-1);
   end;
@@ -60,24 +60,24 @@ package body integer_vector_ptr_pkg is
   end;
 
   procedure reallocate (
-    ptr   : ptr_t;
-    len   : natural;
-    value : val_t := 0
+    ptr    : ptr_t;
+    length : natural;
+    value  : val_t := 0
   ) is begin
     deallocate(ptrs(ptr.ref));
-    ptrs(ptr.ref) := new integer_vector_t'(0 to len - 1 => value);
+    ptrs(ptr.ref) := new integer_vector_t'(0 to length - 1 => value);
   end;
 
   procedure resize (
-    ptr   : ptr_t;
-    len   : natural;
-    drop  : natural := 0;
-    value : val_t := 0
+    ptr    : ptr_t;
+    length : natural;
+    drop   : natural := 0;
+    value  : val_t := 0
   ) is
     variable old_ptr, new_ptr : integer_vector_access_t;
-    variable min_len : natural := len;
+    variable min_len : natural := length;
   begin
-    new_ptr := new integer_vector_t'(0 to len - 1 => value);
+    new_ptr := new integer_vector_t'(0 to length - 1 => value);
     old_ptr := ptrs(ptr.ref);
     if min_len > old_ptr'length - drop then
       min_len := old_ptr'length - drop;

--- a/vunit/vhdl/data_types/src/integer_vector_ptr_pkg.vhd
+++ b/vunit/vhdl/data_types/src/integer_vector_ptr_pkg.vhd
@@ -38,8 +38,8 @@ package integer_vector_ptr_pkg is
   ) return ptr_t;
 
   impure function new_integer_vector_ptr (
-    len   : natural := 0;
-    value : val_t := 0
+    length : natural := 0;
+    value  : val_t := 0
   ) return ptr_t;
 
   procedure deallocate (
@@ -62,16 +62,16 @@ package integer_vector_ptr_pkg is
   ) return val_t;
 
   procedure reallocate (
-    ptr   : ptr_t;
-    len   : natural;
-    value : val_t := 0
+    ptr    : ptr_t;
+    length : natural;
+    value  : val_t := 0
   );
 
   procedure resize (
-    ptr   : ptr_t;
-    len   : natural;
-    drop  : natural := 0;
-    value : val_t := 0
+    ptr    : ptr_t;
+    length : natural;
+    drop   : natural := 0;
+    value  : val_t := 0
   );
 
   function encode (

--- a/vunit/vhdl/logging/src/file_pkg.vhd
+++ b/vunit/vhdl/logging/src/file_pkg.vhd
@@ -29,7 +29,7 @@ end package;
 
 package body file_pkg is
 
-  constant next_id : integer_vector_ptr_t := new_integer_vector_ptr(len => 1, value => 0);
+  constant next_id : integer_vector_ptr_t := new_integer_vector_ptr(length => 1, value => 0);
 
   constant id_idx : natural := 0;
   constant open_idx : natural := 1;
@@ -153,7 +153,7 @@ package body file_pkg is
       id := get(next_id, 0);
       set(next_id, 0, id + 1);
 
-      file_id.p_data := new_integer_vector_ptr(len => file_id_length);
+      file_id.p_data := new_integer_vector_ptr(length => file_id_length);
       set(file_id.p_data, id_idx, id);
       set(file_id.p_data, name_idx, to_integer(new_string_ptr(file_name)));
     else

--- a/vunit/vhdl/logging/src/logger_pkg-body.vhd
+++ b/vunit/vhdl/logging/src/logger_pkg-body.vhd
@@ -123,7 +123,7 @@ package body logger_pkg is
 
     if log_level_filter = null_ptr then
       -- Only show valid log levels by default
-      log_level_filter := new_integer_vector_ptr(len => n_log_levels, value => log_level_invisible);
+      log_level_filter := new_integer_vector_ptr(length => n_log_levels, value => log_level_invisible);
       for log_level in log_level_t'low to log_level_t'high loop
         if is_valid(log_level) then
           set(log_level_filter, log_level_t'pos(log_level), log_level_visible);

--- a/vunit/vhdl/verification_components/src/axi_slave_private_pkg.vhd
+++ b/vunit/vhdl/verification_components/src/axi_slave_private_pkg.vhd
@@ -142,7 +142,7 @@ package body axi_slave_private_pkg is
       p_axi_slave_type := axi_slave_type;
       p_data_size := data'length/8;
       p_max_id := max_id;
-      p_id_indexes := new_integer_vector_ptr(len => max_id+1, value => 0);
+      p_id_indexes := new_integer_vector_ptr(length => max_id+1, value => 0);
       p_burst_queue_max_length := axi_slave.p_initial_address_fifo_depth;
       p_burst_queue := new_queue;
       p_burst_queue_length := 0;


### PR DESCRIPTION
As commented in [#507](https://github.com/VUnit/vunit/pull/507#issuecomment-501411395), this PR reverts renaming `length` to `len` in the sources related to `integer_vector_ptr`. This is a partial revert of #482.