### PR TITLE
WIP: Add option to check log message by finding a substring

### DIFF
--- a/vunit/vhdl/logging/src/logger_pkg-body.vhd
+++ b/vunit/vhdl/logging/src/logger_pkg-body.vhd
@@ -798,17 +798,43 @@ package body logger_pkg is
     set(p_mock_queue_length, 0, get(p_mock_queue_length, 0) - 1);
     return make_string(got_logger_name, got_msg, got_level, got_log_time, got_line_num, got_file_name, check_time);
   end;
+  
+  impure function pop_log_item_with_substring(check_time : boolean; substr : string) return string is
+    constant SUBSTR_PREFIX : string := "Substring: ";
+    constant got_logger_name : string := pop_string(mock_queue);
+    constant got_level : log_level_t := log_level_t'val(pop_byte(mock_queue));
+    constant got_msg : string := pop_string(mock_queue);
+    constant got_log_time : time := pop_time(mock_queue);
+    constant got_line_num : natural := pop_integer(mock_queue);
+    constant got_file_name : string := pop_string(mock_queue);
+	variable found_str : string(1 to SUBSTR_PREFIX'length + substr'length) := SUBSTR_PREFIX & substr;
+  begin
+    set(p_mock_queue_length, 0, get(p_mock_queue_length, 0) - 1);
+    
+    if find(got_msg, substr) = 0 then
+		found_str := (SUBSTR_PREFIX'range => SUBSTR_PREFIX, others => ' ');
+    end if;
+    
+    return make_string(got_logger_name, found_str, got_level, got_log_time, got_line_num, got_file_name, check_time);
+  end;
 
   procedure check_log(logger : logger_t;
                       msg : string;
                       log_level : log_level_t;
                       log_time : time := no_time_check;
                       line_num : natural := 0;
-                      file_name : string := "") is
+                      file_name : string := "";
+                      msg_is_substr : boolean := false) is
 
+	constant SUBSTR_PREFIX : string := "Substring: ";
+                      
     constant expected_item : string := make_string(get_full_name(logger),
                                                    msg, log_level, log_time, line_num, file_name,
                                                    log_time /= no_time_check);
+                                                   
+    constant expected_item_with_substr : string := make_string(get_full_name(logger),
+                                                               SUBSTR_PREFIX & msg, log_level, log_time, line_num, file_name,
+                                                               log_time /= no_time_check);
 
     procedure check_log_when_not_empty is
       constant got_item : string := pop_log_item_string(log_time /= no_time_check);
@@ -817,9 +843,24 @@ package body logger_pkg is
         core_failure("log item mismatch:" & LF & LF & "Got:" & LF & got_item & LF & LF & "expected:" & LF & expected_item & LF);
       end if;
     end;
+    
+	procedure check_log_when_not_empty_with_substring is
+      constant got_item : string := pop_log_item_with_substring(log_time /= no_time_check, msg);
+    begin
+      if expected_item_with_substr /= got_item then
+        core_failure("log item mismatch:" & LF & LF & "Got:" & LF & got_item & LF & LF & "expected:" & LF & expected_item & LF);
+      end if;
+    end;   
+    
   begin
     if length(mock_queue) > 0 then
-      check_log_when_not_empty;
+    
+      if msg_is_substr then
+        check_log_when_not_empty_with_substring;
+      else
+        check_log_when_not_empty;
+      end if;    
+
     else
       core_failure("log item mismatch - Got no log item " & LF & LF & "expected" & LF & expected_item & LF);
     end if;
@@ -830,9 +871,10 @@ package body logger_pkg is
                            log_level : log_level_t;
                            log_time : time := no_time_check;
                            line_num : natural := 0;
-                           file_name : string := "") is
+                           file_name : string := "";
+                           msg_is_substr : boolean := false) is
   begin
-    check_log(logger, msg, log_level, log_time, line_num, file_name);
+    check_log(logger, msg, log_level, log_time, line_num, file_name, msg_is_substr);
     check_no_log;
   end;
 

--- a/vunit/vhdl/logging/src/logger_pkg.vhd
+++ b/vunit/vhdl/logging/src/logger_pkg.vhd
@@ -367,7 +367,8 @@ package logger_pkg is
                       log_level : log_level_t;
                       log_time : time := no_time_check;
                       line_num : natural := 0;
-                      file_name : string := "");
+                      file_name : string := "";
+                      msg_is_substr : boolean := false);
 
   -- Check that there is only one recorded log call remaining
   procedure check_only_log(logger : logger_t;


### PR DESCRIPTION
This is just a first iteration for the implementation which is discussed in #517.

The implementation is working, I simply verified it using:

```vhdl
	logging_proc : process
		variable my_logger : logger_t := get_logger("My Logger");
	begin

		test_runner_setup(runner, runner_cfg);

		mock(my_logger, error);
		
		error(my_logger, "Fifo is full now, let's read data back.");		
		check_log(my_logger, "", error, msg_is_substr => true);
		
		error(my_logger, "Fifo is full now.");		
		check_log(my_logger, "Fifo is full now.", error, msg_is_substr => false);
		
		unmock(my_logger);

		test_runner_cleanup(runner);

	end process;
```

I'm not very deep in the Vunit VHDL sources, maybe there are string helper functions which could help to improve the code (which is a bit ugly in my opinion). But this first iteration should be good enough for having further discussions.