### PR TITLE
New queue implementation

### DIFF
--- a/vunit/vhdl/data_types/src/codec.vhd
+++ b/vunit/vhdl/data_types/src/codec.vhd
@@ -451,9 +451,10 @@ package body codec_pkg is
   function get_range (
     constant code : string)
     return range_t is
-    constant range_left         : integer := decode(code(1 to 4));
-    constant range_right        : integer := decode(code(5 to 8));
-    constant is_ascending       : boolean := decode(code(9 to 9));
+    constant left               : positive := code'left;
+    constant range_left         : integer := decode(code(left to left + 3));
+    constant range_right        : integer := decode(code(left + 4 to left + 7));
+    constant is_ascending       : boolean := decode(code(left + 8 to left + 8));
     constant ret_val_ascending  : range_t(range_left to range_right) := (others => '0');
     constant ret_val_descending : range_t(range_left downto range_right) := (others => '0');
   begin

--- a/vunit/vhdl/data_types/src/integer_array_pkg-body.vhd
+++ b/vunit/vhdl/data_types/src/integer_array_pkg-body.vhd
@@ -6,6 +6,9 @@
 
 use std.textio.all;
 
+use work.codec_pkg.all;
+use work.codec_builder_pkg.all;
+
 package body integer_array_pkg is
   type binary_file_t is file of character;
 
@@ -453,4 +456,45 @@ package body integer_array_pkg is
     file_close(fread);
     return arr;
   end;
+
+  function encode (
+    data : integer_array_t
+  ) return string is begin
+    return encode(data.length) &
+           encode(data.width) &
+           encode(data.height) &
+           encode(data.depth) &
+           encode(data.bit_width) &
+           encode(data.is_signed) &
+           encode(data.lower_limit) &
+           encode(data.upper_limit) &
+           encode(data.data);
+  end;
+
+  procedure decode (
+    code   : string;
+    index  : inout positive;
+    result : out   integer_array_t
+  ) is begin
+    decode(code, index, result.length);
+    decode(code, index, result.width);
+    decode(code, index, result.height);
+    decode(code, index, result.depth);
+    decode(code, index, result.bit_width);
+    decode(code, index, result.is_signed);
+    decode(code, index, result.lower_limit);
+    decode(code, index, result.upper_limit);
+    decode(code, index, result.data);
+  end;
+
+  function decode (
+    code : string
+  ) return integer_array_t is
+    variable ret_val : integer_array_t;
+    variable index   : positive := code'left;
+  begin
+    decode(code, index, ret_val);
+    return ret_val;
+  end;
+
 end package body;

--- a/vunit/vhdl/data_types/src/integer_array_pkg.vhd
+++ b/vunit/vhdl/data_types/src/integer_array_pkg.vhd
@@ -178,4 +178,19 @@ package integer_array_pkg is
     arr       : integer_array_t;
     file_name : string
   );
+
+  function encode (
+    data : integer_array_t
+  ) return string;
+
+  procedure decode (
+    code   : string;
+    index  : inout positive;
+    result : out   integer_array_t
+  );
+
+  function decode (
+    code : string
+  ) return integer_array_t;
+
 end package;

--- a/vunit/vhdl/data_types/src/integer_vector_ptr_pkg-body-200x.vhd
+++ b/vunit/vhdl/data_types/src/integer_vector_ptr_pkg-body-200x.vhd
@@ -5,14 +5,24 @@
 -- Copyright (c) 2014-2019, Lars Asplund lars.anders.asplund@gmail.com
 
 package body integer_vector_ptr_pkg is
+
  type integer_vector_ptr_storage_t is protected
-    impure function new_integer_vector_ptr (
+
+    impure function new_ptr (
       length : natural := 0;
       value  : val_t := 0
     ) return natural;
 
     procedure deallocate (
       ref : natural
+    );
+
+    procedure reallocate_storage (
+      length : positive
+    );
+
+    procedure reallocate_stack (
+      length : positive
     );
 
     impure function length (
@@ -39,50 +49,83 @@ package body integer_vector_ptr_pkg is
     procedure resize (
       ref    : natural;
       length : natural;
-      drop   : natural := 0;
+      rotate : natural := 0;
       value  : val_t := 0
     );
   end protected;
 
   type integer_vector_ptr_storage_t is protected body
-    variable current_index : integer := 0;
-    variable ptrs : vava_t := null;
 
-    impure function new_integer_vector_ptr (
+    -- Pointer storage
+    variable storage : vava_t := new vav_t'(0 to 2**16 - 1 => null);
+    variable storage_index : natural := 0;
+
+    -- Stack of unused storage indices
+    variable stack : integer_vector_access_t := new integer_vector_t'(0 to 2**16 - 1 => -1);
+    variable stack_index : natural := 0;
+
+    impure function new_ptr (
       length : natural := 0;
       value  : val_t := 0
     ) return natural is
-      variable old_ptrs : vava_t;
-      variable retval : ptr_t := (ref => current_index);
+      variable ref : index_t;
     begin
-      if ptrs = null then
-        ptrs := new vav_t'(0 => null);
-      elsif ptrs'length <= current_index then
-        -- Reallocate ptr pointers to larger ptr
-        -- Use more size to trade size for speed
-        old_ptrs := ptrs;
-        ptrs := new vav_t'(0 to ptrs'length + 2**16 => null);
-        for i in old_ptrs'range loop
-          ptrs(i) := old_ptrs(i);
-        end loop;
-        deallocate(old_ptrs);
+      if stack_index > 0 then
+        stack_index := stack_index - 1;
+        ref := stack(stack_index);
+      else
+        if storage_index >= storage'length then
+          reallocate_storage(storage'length + 2**16);
+        end if;
+        ref := storage_index;
+        storage_index := storage_index + 1;
       end if;
-      ptrs(current_index) := new integer_vector_t'(0 to length-1 => value);
-      current_index := current_index + 1;
-      return retval.ref;
+      storage(ref) := new vec_t'(0 to length - 1 => value);
+      return ref;
     end;
 
     procedure deallocate (
       ref : natural
     ) is begin
-      deallocate(ptrs(ref));
-      ptrs(ref) := null;
+      if stack_index >= stack'length then
+        reallocate_stack(stack'length + 2**16);
+      end if;
+      stack(stack_index) := ref;
+      stack_index := stack_index + 1;
+      deallocate(storage(ref));
+      storage(ref) := null;
+    end;
+
+    procedure reallocate_storage (
+      length : positive
+    ) is
+      variable old_storage : vava_t;
+    begin
+      old_storage := storage;
+      storage := new vav_t'(0 to length - 1 => null);
+      for i in old_storage'range loop
+        storage(i) := old_storage(i);
+      end loop;
+      deallocate(old_storage);
+    end;
+
+    procedure reallocate_stack (
+      length : positive
+    ) is
+      variable old_stack : integer_vector_access_t;
+    begin
+      old_stack := stack;
+      stack := new integer_vector_t'(0 to length - 1 => -1);
+      for i in old_stack'range loop
+        stack(i) := old_stack(i);
+      end loop;
+      deallocate(old_stack);
     end;
 
     impure function length (
       ref : natural
     ) return integer is begin
-      return ptrs(ref)'length;
+      return storage(ref)'length;
     end;
 
     procedure set (
@@ -90,14 +133,14 @@ package body integer_vector_ptr_pkg is
       index : natural;
       value : val_t
     ) is begin
-      ptrs(ref)(index) := value;
+      storage(ref)(index) := value;
     end;
 
     impure function get (
       ref   : natural;
       index : natural
     ) return val_t is begin
-      return ptrs(ref)(index);
+      return storage(ref)(index);
     end;
 
     procedure reallocate (
@@ -105,34 +148,33 @@ package body integer_vector_ptr_pkg is
       length : natural;
       value  : val_t := 0
     ) is begin
-      deallocate(ptrs(ref));
-      ptrs(ref) := new integer_vector_t'(0 to length - 1 => value);
+      deallocate(storage(ref));
+      storage(ref) := new vec_t'(0 to length - 1 => value);
     end;
 
     procedure resize (
       ref    : natural;
       length : natural;
-      drop   : natural := 0;
+      rotate : natural := 0;
       value  : val_t := 0
     ) is
-      variable old_ptr, new_ptr : integer_vector_access_t;
-      variable min_len : natural := length;
+      variable old_ptr : va_t := storage(ref);
+      variable new_ptr : va_t := new vec_t'(0 to length - 1 => value);
+      variable min_length : natural := old_ptr'length;
     begin
-      new_ptr := new integer_vector_t'(0 to length - 1 => value);
-      old_ptr := ptrs(ref);
-      if min_len > old_ptr'length - drop then
-        min_len := old_ptr'length - drop;
+      if length < old_ptr'length then
+        min_length := length;
       end if;
-      for i in 0 to min_len-1 loop
-        new_ptr(i) := old_ptr(drop + i);
+      for i in 0 to min_length - 1 loop
+        new_ptr(i) := old_ptr((rotate + i) mod old_ptr'length);
       end loop;
-      ptrs(ref) := new_ptr;
+      storage(ref) := new_ptr;
       deallocate(old_ptr);
     end;
 
   end protected body;
 
-  shared variable integer_vector_ptr_storage : integer_vector_ptr_storage_t;
+  shared variable ptr_storage : integer_vector_ptr_storage_t;
 
   function to_integer (
     value : ptr_t
@@ -141,7 +183,7 @@ package body integer_vector_ptr_pkg is
   end;
 
   impure function to_integer_vector_ptr (
-    value : val_t
+    value : integer
   ) return ptr_t is begin
     -- @TODO maybe assert that the ref is valid
     return (ref => value);
@@ -151,19 +193,19 @@ package body integer_vector_ptr_pkg is
     length : natural := 0;
     value  : val_t := 0
   ) return ptr_t is begin
-    return (ref => integer_vector_ptr_storage.new_integer_vector_ptr(length, value));
+    return (ref => ptr_storage.new_ptr(length, value));
   end;
 
   procedure deallocate (
     ptr : ptr_t
   ) is begin
-    integer_vector_ptr_storage.deallocate(ptr.ref);
+    ptr_storage.deallocate(ptr.ref);
   end;
 
   impure function length (
     ptr : ptr_t
   ) return integer is begin
-    return integer_vector_ptr_storage.length(ptr.ref);
+    return ptr_storage.length(ptr.ref);
   end;
 
   procedure set (
@@ -171,14 +213,14 @@ package body integer_vector_ptr_pkg is
     index : natural;
     value : val_t
   ) is begin
-    integer_vector_ptr_storage.set(ptr.ref, index, value);
+    ptr_storage.set(ptr.ref, index, value);
   end;
 
   impure function get (
     ptr   : ptr_t;
     index : natural
   ) return val_t is begin
-    return integer_vector_ptr_storage.get(ptr.ref, index);
+    return ptr_storage.get(ptr.ref, index);
   end;
 
   procedure reallocate (
@@ -186,16 +228,16 @@ package body integer_vector_ptr_pkg is
     length : natural;
     value  : val_t := 0
   ) is begin
-    integer_vector_ptr_storage.reallocate(ptr.ref, length, value);
+    ptr_storage.reallocate(ptr.ref, length, value);
   end;
 
   procedure resize (
     ptr    : ptr_t;
     length : natural;
-    drop   : natural := 0;
+    rotate : natural := 0;
     value  : val_t := 0
   ) is begin
-    integer_vector_ptr_storage.resize(ptr.ref, length, drop, value);
+    ptr_storage.resize(ptr.ref, length, rotate, value);
   end;
 
   function encode (
@@ -223,3 +265,4 @@ package body integer_vector_ptr_pkg is
   end;
 
 end package body;
+

--- a/vunit/vhdl/data_types/src/integer_vector_ptr_pkg-body-93.vhd
+++ b/vunit/vhdl/data_types/src/integer_vector_ptr_pkg-body-93.vhd
@@ -5,43 +5,77 @@
 -- Copyright (c) 2014-2019, Lars Asplund lars.anders.asplund@gmail.com
 
 package body integer_vector_ptr_pkg is
-  shared variable current_index : integer := 0;
-  shared variable ptrs : vava_t := null;
+
+  -- Pointer storage
+  shared variable storage : vava_t := new vav_t'(0 to 2**16 - 1 => null);
+  shared variable storage_index : natural := 0;
+
+  -- Stack of unused storage indices
+  shared variable stack : integer_vector_access_t := new integer_vector_t'(0 to 2**16 - 1 => -1);
+  shared variable stack_index : natural := 0;
+
+  procedure reallocate_storage (
+    length : positive
+  ) is
+    variable old_storage : vava_t;
+  begin
+    old_storage := storage;
+    storage := new vav_t'(0 to length - 1 => null);
+    for i in old_storage'range loop
+      storage(i) := old_storage(i);
+    end loop;
+    deallocate(old_storage);
+  end;
+
+  procedure reallocate_stack (
+    length : positive
+  ) is
+    variable old_stack : integer_vector_access_t;
+  begin
+    old_stack := stack;
+    stack := new integer_vector_t'(0 to length - 1 => -1);
+    for i in old_stack'range loop
+      stack(i) := old_stack(i);
+    end loop;
+    deallocate(old_stack);
+  end;
 
   impure function new_integer_vector_ptr (
     length : natural := 0;
     value  : val_t   := 0
   ) return ptr_t is
-    variable old_ptrs : vava_t;
+    variable ref : index_t;
   begin
-    if ptrs = null then
-      ptrs := new vav_t'(0 => null);
-    elsif ptrs'length <= current_index then
-      -- Reallocate ptr pointers to larger ptr
-      -- Use more size to trade size for speed
-      old_ptrs := ptrs;
-      ptrs := new vav_t'(0 to ptrs'length + 2**16 => null);
-      for i in old_ptrs'range loop
-        ptrs(i) := old_ptrs(i);
-      end loop;
-      deallocate(old_ptrs);
+    if stack_index > 0 then
+      stack_index := stack_index - 1;
+      ref := stack(stack_index);
+    else
+      if storage_index >= storage'length then
+        reallocate_storage(storage'length + 2**16);
+      end if;
+      ref := storage_index;
+      storage_index := storage_index + 1;
     end if;
-    ptrs(current_index) := new integer_vector_t'(0 to length-1 => value);
-    current_index := current_index + 1;
-    return (ref => current_index-1);
+    storage(ref) := new vec_t'(0 to length - 1 => value);
+    return (ref => ref);
   end;
 
   procedure deallocate (
     ptr : ptr_t
   ) is begin
-    deallocate(ptrs(ptr.ref));
-    ptrs(ptr.ref) := null;
+    if stack_index >= stack'length then
+      reallocate_stack(stack'length + 2**16);
+    end if;
+    stack(stack_index) := ptr.ref;
+    stack_index := stack_index + 1;
+    deallocate(storage(ptr.ref));
+    storage(ptr.ref) := null;
   end;
 
   impure function length (
     ptr : ptr_t
   ) return integer is begin
-    return ptrs(ptr.ref)'length;
+    return storage(ptr.ref)'length;
   end;
 
   procedure set (
@@ -49,14 +83,14 @@ package body integer_vector_ptr_pkg is
     index : natural;
     value : val_t
   ) is begin
-    ptrs(ptr.ref)(index) := value;
+    storage(ptr.ref)(index) := value;
   end;
 
   impure function get (
     ptr   : ptr_t;
     index : natural
   ) return val_t is begin
-    return ptrs(ptr.ref)(index);
+    return storage(ptr.ref)(index);
   end;
 
   procedure reallocate (
@@ -64,28 +98,27 @@ package body integer_vector_ptr_pkg is
     length : natural;
     value  : val_t := 0
   ) is begin
-    deallocate(ptrs(ptr.ref));
-    ptrs(ptr.ref) := new integer_vector_t'(0 to length - 1 => value);
+    deallocate(storage(ptr.ref));
+    storage(ptr.ref) := new vec_t'(0 to length - 1 => value);
   end;
 
   procedure resize (
     ptr    : ptr_t;
     length : natural;
-    drop   : natural := 0;
+    rotate : natural := 0;
     value  : val_t := 0
   ) is
-    variable old_ptr, new_ptr : integer_vector_access_t;
-    variable min_len : natural := length;
+    variable old_ptr : va_t := storage(ptr.ref);
+    variable new_ptr : va_t := new vec_t'(0 to length - 1 => value);
+    variable min_length : natural := old_ptr'length;
   begin
-    new_ptr := new integer_vector_t'(0 to length - 1 => value);
-    old_ptr := ptrs(ptr.ref);
-    if min_len > old_ptr'length - drop then
-      min_len := old_ptr'length - drop;
+    if length < old_ptr'length then
+      min_length := length;
     end if;
-    for i in 0 to min_len-1 loop
-      new_ptr(i) := old_ptr(drop + i);
+    for i in 0 to min_length - 1 loop
+      new_ptr(i) := old_ptr((rotate + i) mod old_ptr'length);
     end loop;
-    ptrs(ptr.ref) := new_ptr;
+    storage(ptr.ref) := new_ptr;
     deallocate(old_ptr);
   end;
 
@@ -127,3 +160,4 @@ package body integer_vector_ptr_pkg is
   end;
 
 end package body;
+

--- a/vunit/vhdl/data_types/src/integer_vector_ptr_pkg.vhd
+++ b/vunit/vhdl/data_types/src/integer_vector_ptr_pkg.vhd
@@ -3,7 +3,6 @@
 -- You can obtain one at http://mozilla.org/MPL/2.0/.
 --
 -- Copyright (c) 2014-2019, Lars Asplund lars.anders.asplund@gmail.com
-
 --
 -- The purpose of this package is to provide an integer vector access type (pointer)
 -- that can itself be used in arrays and returned from functions unlike a
@@ -17,24 +16,29 @@ use work.codec_pkg.all;
 use work.codec_builder_pkg.all;
 
 package integer_vector_ptr_pkg is
+
   subtype index_t is integer range -1 to integer'high;
+
   type integer_vector_ptr_t is record
     ref : index_t;
   end record;
-  constant null_ptr : integer_vector_ptr_t := (ref => -1);
 
-  alias  ptr_t  is integer_vector_ptr_t;
-  alias  val_t  is integer;
-  alias  vec_t  is integer_vector_t;
-  alias  vav_t  is integer_vector_access_vector_t;
-  alias  vava_t is integer_vector_access_vector_access_t;
+  constant null_integer_vector_ptr : integer_vector_ptr_t := (ref => -1);
+  alias null_ptr is null_integer_vector_ptr;
+
+  alias ptr_t  is integer_vector_ptr_t;
+  alias val_t  is integer;
+  alias vec_t  is integer_vector_t;
+  alias va_t   is integer_vector_access_t;
+  alias vav_t  is integer_vector_access_vector_t;
+  alias vava_t is integer_vector_access_vector_access_t;
 
   function to_integer (
     value : ptr_t
   ) return integer;
 
   impure function to_integer_vector_ptr (
-    value : val_t
+    value : integer
   ) return ptr_t;
 
   impure function new_integer_vector_ptr (
@@ -70,7 +74,7 @@ package integer_vector_ptr_pkg is
   procedure resize (
     ptr    : ptr_t;
     length : natural;
-    drop   : natural := 0;
+    rotate : natural := 0;
     value  : val_t := 0
   );
 
@@ -94,3 +98,4 @@ package integer_vector_ptr_pkg is
   constant integer_vector_ptr_t_code_length : positive := integer_code_length;
 
 end package;
+

--- a/vunit/vhdl/data_types/src/queue_pkg-2008.vhd
+++ b/vunit/vhdl/data_types/src/queue_pkg-2008.vhd
@@ -10,9 +10,9 @@ use ieee.float_pkg.all;
 
 use work.queue_pkg.all;
 use work.codec_2008_pkg.all;
-use work.codec_builder_2008_pkg.all;
 
 package queue_2008_pkg is
+
   procedure push (
     queue : queue_t;
     value : boolean_vector
@@ -96,111 +96,129 @@ package queue_2008_pkg is
 
   alias push_float is push[queue_t, float];
   alias pop_float is pop[queue_t return float];
+
 end package;
 
 package body queue_2008_pkg is
+
   procedure push (
     queue : queue_t;
     value : boolean_vector
   ) is begin
-    push_type(queue, vhdl_boolean_vector);
-    push_variable_string(queue, encode(value));
+    push_item(queue, encode(vhdl_boolean_vector) & encode(value));
   end;
 
   impure function pop (
     queue : queue_t
-  ) return boolean_vector is begin
-    check_type(queue, vhdl_boolean_vector);
-    return decode(pop_variable_string(queue));
+  ) return boolean_vector is
+    constant str : string := pop_item(queue);
+    constant typ : queue_item_type_t := decode(str(1));
+  begin
+    check_type(typ, vhdl_boolean_vector);
+    return decode(str(2 to str'right));
   end;
 
   procedure push (
     queue : queue_t;
     value : integer_vector
   ) is begin
-    push_type(queue, vhdl_integer_vector);
-    push_variable_string(queue, encode(value));
+    push_item(queue, encode(vhdl_integer_vector) & encode(value));
   end;
 
   impure function pop (
     queue : queue_t
-  ) return integer_vector is begin
-    check_type(queue, vhdl_integer_vector);
-    return decode(pop_variable_string(queue));
+  ) return integer_vector is
+    constant str : string := pop_item(queue);
+    constant typ : queue_item_type_t := decode(str(1));
+  begin
+    check_type(typ, vhdl_integer_vector);
+    return decode(str(2 to str'right));
   end;
 
   procedure push (
     queue : queue_t;
     value : real_vector
   ) is begin
-    push_type(queue, vhdl_real_vector);
-    push_variable_string(queue, encode(value));
+    push_item(queue, encode(vhdl_real_vector) & encode(value));
   end;
 
   impure function pop (
     queue : queue_t
-  ) return real_vector is begin
-    check_type(queue, vhdl_real_vector);
-    return decode(pop_variable_string(queue));
+  ) return real_vector is
+    constant str : string := pop_item(queue);
+    constant typ : queue_item_type_t := decode(str(1));
+  begin
+    check_type(typ, vhdl_real_vector);
+    return decode(str(2 to str'right));
   end;
 
   procedure push (
     queue : queue_t;
     value : time_vector
   ) is begin
-    push_type(queue, vhdl_time_vector);
-    push_variable_string(queue, encode(value));
+    push_item(queue, encode(vhdl_time_vector) & encode(value));
   end;
 
   impure function pop (
     queue : queue_t
-  ) return time_vector is begin
-    check_type(queue, vhdl_time_vector);
-    return decode(pop_variable_string(queue));
+  ) return time_vector is
+    constant str : string := pop_item(queue);
+    constant typ : queue_item_type_t := decode(str(1));
+  begin
+    check_type(typ, vhdl_time_vector);
+    return decode(str(2 to str'right));
   end;
 
   procedure push (
     queue : queue_t;
     value : ufixed
   ) is begin
-    push_type(queue, ieee_ufixed);
-    push_variable_string(queue, encode(value));
+    push_item(queue, encode(ieee_ufixed) & encode(value));
   end;
 
   impure function pop (
     queue : queue_t
-  ) return ufixed is begin
-    check_type(queue, ieee_ufixed);
-    return decode(pop_variable_string(queue));
+  ) return ufixed is
+    constant str : string := pop_item(queue);
+    constant typ : queue_item_type_t := decode(str(1));
+  begin
+    check_type(typ, ieee_ufixed);
+    return decode(str(2 to str'right));
   end;
 
   procedure push (
     queue : queue_t;
     value : sfixed
   ) is begin
-    push_type(queue, ieee_sfixed);
-    push_variable_string(queue, encode(value));
+    push_item(queue, encode(ieee_sfixed) & encode(value));
   end;
 
   impure function pop (
     queue : queue_t
-  ) return sfixed is begin
-    check_type(queue, ieee_sfixed);
-    return decode(pop_variable_string(queue));
+  ) return sfixed is
+    constant str : string := pop_item(queue);
+    constant typ : queue_item_type_t := decode(str(1));
+  begin
+    check_type(typ, ieee_sfixed);
+    return decode(str(2 to str'right));
   end;
 
   procedure push (
     queue : queue_t;
     value : float
   ) is begin
-    push_type(queue, ieee_float);
-    push_variable_string(queue, encode(value));
+    push_item(queue, encode(ieee_float) & encode(value));
   end;
 
   impure function pop (
     queue : queue_t
-  ) return float is begin
-    check_type(queue, ieee_float);
-    return decode(pop_variable_string(queue));
+  ) return float is
+    constant str : string := pop_item(queue);
+    constant typ : queue_item_type_t := decode(str(1));
+  begin
+    check_type(typ, ieee_float);
+    return decode(str(2 to str'right));
   end;
+
 end package body;
+

--- a/vunit/vhdl/data_types/src/queue_pkg-body.vhd
+++ b/vunit/vhdl/data_types/src/queue_pkg-body.vhd
@@ -4,22 +4,20 @@
 --
 -- Copyright (c) 2014-2019, Lars Asplund lars.anders.asplund@gmail.com
 
-library ieee;
-use ieee.math_real.all;
-use ieee.math_complex.all;
 use work.codec_pkg.all;
-use work.codec_builder_pkg.all;
 
 package body queue_pkg is
+
   constant tail_idx : natural := 0;
   constant head_idx : natural := 1;
-  constant num_meta : natural := head_idx + 1;
-  constant queue_t_code_length : positive := integer_vector_ptr_t_code_length + string_ptr_t_code_length;
+  constant wrap_idx : natural := 2;
+  constant num_meta : natural := wrap_idx + 1;
 
   impure function new_queue
-  return queue_t is begin
-    return (p_meta => new_integer_vector_ptr(num_meta),
-            data   => new_string_ptr);
+    return queue_t is
+  begin
+    return (p_meta => new_integer_vector_ptr(length => num_meta),
+            data   => new_integer_vector_ptr(length => 256, value => -1));
   end;
 
   impure function length (
@@ -27,8 +25,13 @@ package body queue_pkg is
   ) return natural is
     constant head : integer := get(queue.p_meta, head_idx);
     constant tail : integer := get(queue.p_meta, tail_idx);
+    constant wrap : integer := get(queue.p_meta, wrap_idx);
   begin
-    return tail - head;
+    if wrap = 0 then
+      return head - tail;
+    else
+      return length(queue.data) - (head - tail);
+    end if;
   end;
 
   impure function is_empty (
@@ -37,21 +40,100 @@ package body queue_pkg is
     return length(queue) = 0;
   end;
 
+  impure function is_full (
+    queue : queue_t
+  ) return boolean is begin
+    return length(queue) = length(queue.data);
+  end;
+
   procedure flush (
     queue : queue_t
-  ) is begin
+  ) is
+    variable ref : integer;
+  begin
     assert queue /= null_queue report "Flush null queue";
     set(queue.p_meta, head_idx, 0);
     set(queue.p_meta, tail_idx, 0);
+    set(queue.p_meta, wrap_idx, 0);
+    for i in 0 to length(queue.data) - 1 loop
+      ref := get(queue.data, i);
+      if ref > -1 then
+        deallocate(to_string_ptr(ref));
+      end if;
+    end loop;
+  end;
+
+  procedure unsafe_push (
+    queue : queue_t;
+    value : string_ptr_t
+  ) is
+    variable head : integer  := get(queue.p_meta, head_idx);
+    variable tail : integer  := get(queue.p_meta, tail_idx);
+    variable wrap : integer  := get(queue.p_meta, wrap_idx);
+    variable size : positive := length(queue.data);
+  begin
+    assert queue /= null_queue report "Push to null queue";
+    if is_full(queue) then
+      resize(queue.data, 2 * size, rotate => tail);
+      tail := 0;
+      head := size;
+      wrap := 0;
+      size := 2 * size;
+      set(queue.p_meta, tail_idx, tail);
+      set(queue.p_meta, wrap_idx, wrap);
+    end if;
+    set(queue.data, head, to_integer(value));
+    head := head + 1;
+    if head >= size then
+      head := head mod size;
+      if wrap = 0 then
+        wrap := 1;
+      else
+        wrap := 0;
+      end if;
+      set(queue.p_meta, wrap_idx, wrap);
+    end if;
+    set(queue.p_meta, head_idx, head);
+  end;
+
+  impure function unsafe_pop (
+    queue : queue_t
+  ) return string_ptr_t is
+    constant size : positive := length(queue.data);
+    variable tail : integer  := get(queue.p_meta, tail_idx);
+    variable wrap : integer  := get(queue.p_meta, wrap_idx);
+    variable data : string_ptr_t;
+  begin
+    assert queue /= null_queue report "Pop from null queue";
+    assert length(queue) > 0 report "Pop from empty queue";
+    data := to_string_ptr(get(queue.data, tail));
+    tail := tail + 1;
+    if tail >= size then
+      tail := tail mod size;
+      if wrap = 0 then
+        wrap := 1;
+      else
+        wrap := 0;
+      end if;
+      set(queue.p_meta, wrap_idx, wrap);
+    end if;
+    set(queue.p_meta, tail_idx, tail);
+    return data;
   end;
 
   impure function copy (
     queue : queue_t
   ) return queue_t is
+    constant tail   : positive := get(queue.p_meta, tail_idx);
+    constant size   : positive := length(queue.data);
     constant result : queue_t := new_queue;
+    variable idx    : natural;
+    variable ptr    : string_ptr_t;
   begin
     for i in 0 to length(queue) - 1 loop
-      unsafe_push(result, get(queue.data, 1 + i));
+      idx := (tail + i) mod size;
+      ptr := to_string_ptr(get(queue.data, idx));
+      unsafe_push(result, new_string_ptr(to_string(ptr)));
     end loop;
     return result;
   end;
@@ -59,7 +141,7 @@ package body queue_pkg is
   function encode (
     data : queue_t
   ) return string is begin
-    return encode(data.p_meta) & encode(to_integer(data.data));
+    return encode(data.p_meta) & encode(data.data);
   end;
 
   procedure decode (
@@ -81,524 +163,461 @@ package body queue_pkg is
     return ret_val;
   end;
 
-  procedure unsafe_push (
-    queue : queue_t;
-    value : character
-  ) is
-    variable tail : integer;
-    variable head : integer;
-  begin
-    assert queue /= null_queue report "Push to null queue";
-    tail := get(queue.p_meta, tail_idx);
-    head := get(queue.p_meta, head_idx);
-    if length(queue.data) < tail + 1 then
-      -- Allocate more new data, double data to avoid
-      -- to much copying.
-      -- Also normalize the queue by dropping unnused data before head
-      resize(queue.data, 2 * length(queue) + 1, drop => head);
-      tail := tail - head;
-      head := 0;
-      set(queue.p_meta, head_idx, head);
-    end if;
-    set(queue.data, 1 + tail, value);
-    set(queue.p_meta, tail_idx, tail + 1);
-  end;
-
-  impure function unsafe_pop (
-    queue : queue_t
+  function encode (
+    item_type : queue_item_type_t
   ) return character is
-    variable head : integer;
-    variable data : character;
   begin
-    assert queue /= null_queue report "Pop from null queue";
-    assert length(queue) > 0 report "Pop from empty queue";
-    head := get(queue.p_meta, head_idx);
-    data := get(queue.data, 1 + head);
-    set(queue.p_meta, head_idx, head + 1);
-    return data;
+    return character'val(queue_item_type_t'pos(item_type));
   end;
 
-  procedure push_type (
-    queue        : queue_t;
-    element_type : queue_element_type_t
-  ) is begin
-    unsafe_push(queue, character'val(queue_element_type_t'pos(element_type)));
-  end;
-
-  impure function pop_type (
-    queue : queue_t
-  ) return queue_element_type_t is begin
-    return queue_element_type_t'val(character'pos(unsafe_pop(queue)));
+  function decode (
+    char : character
+  ) return queue_item_type_t is
+  begin
+    return queue_item_type_t'val(character'pos(char));
   end;
 
   procedure check_type (
-    queue        : queue_t;
-    element_type : queue_element_type_t
+    got      : queue_item_type_t;
+    expected : queue_item_type_t
   ) is
-    constant popped_type : queue_element_type_t := pop_type(queue);
   begin
-    if popped_type /= element_type then
-      report "Got queue element of type " & queue_element_type_t'image(popped_type) &
-        ", expected " & queue_element_type_t'image(element_type) & "." severity error;
+    if got /= expected then
+      report "Got queue item of type " & queue_item_type_t'image(got) &
+        ", expected " & queue_item_type_t'image(expected) & "." severity error;
     end if;
+  end;
+
+  procedure push_item (
+    queue : queue_t;
+    value : string
+  ) is
+  begin
+    unsafe_push(queue, new_string_ptr(value));
+  end;
+
+  impure function pop_item (
+    queue : queue_t
+  ) return string is
+    constant ptr : string_ptr_t := unsafe_pop(queue);
+    constant str : string       := to_string(ptr);
+  begin
+    deallocate(ptr);
+    return str;
   end;
 
   procedure push (
     queue : queue_t;
     value : character
   ) is begin
-    push_type(queue, vhdl_character);
-    unsafe_push(queue, value);
+    push_item(queue, encode(vhdl_character) & encode(value));
   end;
 
   impure function pop (
     queue : queue_t
-  ) return character is begin
-    check_type(queue, vhdl_character);
-    return unsafe_pop(queue);
-  end;
-
-  procedure push_fix_string (
-    queue : queue_t;
-    value : string
-  ) is begin
-    for i in value'range loop
-      unsafe_push(queue, value(i));
-    end loop;
-  end;
-
-  impure function pop_fix_string (
-    queue  : queue_t;
-    length : natural
-  ) return string is
-    variable result : string(1 to length);
+  ) return character is
+    constant str : string := pop_item(queue);
+    constant typ : queue_item_type_t := decode(str(1));
   begin
-    for i in result'range loop
-      result(i) := unsafe_pop(queue);
-    end loop;
-
-    return result;
-  end;
-
-  procedure unsafe_push (
-    queue : queue_t;
-    value : integer
-  ) is begin
-    push_fix_string(queue, encode(value));
-  end;
-
-  impure function unsafe_pop (
-    queue : queue_t
-  ) return integer is begin
-    return decode(pop_fix_string(queue, integer_code_length));
+    check_type(typ, vhdl_character);
+    return decode(str(2 to str'right));
   end;
 
   procedure push (
     queue : queue_t;
     value : integer
   ) is begin
-    push_type(queue, vhdl_integer);
-    push_fix_string(queue, encode(value));
+    push_item(queue, encode(vhdl_integer) & encode(value));
   end;
 
   impure function pop (
     queue : queue_t
-  ) return integer is begin
-    check_type(queue, vhdl_integer);
-    return decode(pop_fix_string(queue, integer_code_length));
+  ) return integer is
+    constant str : string := pop_item(queue);
+    constant typ : queue_item_type_t := decode(str(1));
+  begin
+    check_type(typ, vhdl_integer);
+    return decode(str(2 to str'right));
   end;
 
   procedure push_byte (
     queue : queue_t;
     value : natural range 0 to 255
   ) is begin
-    push_type(queue, vunit_byte);
-    unsafe_push(queue, character'val(value));
+    push_item(queue, encode(vunit_byte) & encode(character'val(value)));
   end;
 
   impure function pop_byte (
     queue : queue_t
-  ) return integer is begin
-    check_type(queue, vunit_byte);
-    return character'pos(unsafe_pop(queue));
-  end;
-
-  procedure push_variable_string (
-    queue : queue_t;
-    value : string
-  ) is begin
-    unsafe_push(queue, value'length);
-    push_fix_string(queue, value);
-  end;
-
-  impure function pop_variable_string (
-    queue : queue_t
-  ) return string is
-    constant length : integer := unsafe_pop(queue);
+  ) return integer is
+    constant str : string := pop_item(queue);
+    constant typ : queue_item_type_t := decode(str(1));
   begin
-    return pop_fix_string(queue, length);
+    check_type(typ, vunit_byte);
+    return character'pos(decode(str(2 to str'right)));
   end;
 
   procedure push (
     queue : queue_t;
     value : boolean
   ) is begin
-    push_type(queue, vhdl_boolean);
-    push_fix_string(queue, encode(value));
+    push_item(queue, encode(vhdl_boolean) & encode(value));
   end;
 
   impure function pop (
     queue : queue_t
-  ) return boolean is begin
-    check_type(queue, vhdl_boolean);
-    return decode(pop_fix_string(queue, boolean_code_length));
-  end;
-
-  procedure unsafe_push (
-    queue : queue_t;
-    value : boolean
-  ) is begin
-    push_fix_string(queue, encode(value));
-  end;
-
-  impure function unsafe_pop (
-    queue : queue_t
-  ) return boolean is begin
-    return decode(pop_fix_string(queue, boolean_code_length));
+  ) return boolean is
+    constant str : string := pop_item(queue);
+    constant typ : queue_item_type_t := decode(str(1));
+  begin
+    check_type(typ, vhdl_boolean);
+    return decode(str(2 to str'right));
   end;
 
   procedure push (
     queue : queue_t;
     value : real
   ) is begin
-    push_type(queue, vhdl_real);
-    push_fix_string(queue, encode(value));
+    push_item(queue, encode(vhdl_real) & encode(value));
   end;
 
   impure function pop (
     queue : queue_t
-  ) return real is begin
-    check_type(queue, vhdl_real);
-    return decode(pop_fix_string(queue, real_code_length));
+  ) return real is
+    constant str : string := pop_item(queue);
+    constant typ : queue_item_type_t := decode(str(1));
+  begin
+    check_type(typ, vhdl_real);
+    return decode(str(2 to str'right));
   end;
 
   procedure push (
     queue : queue_t;
     value : bit
   ) is begin
-    push_type(queue, vhdl_bit);
-    push_fix_string(queue, encode(value));
+    push_item(queue, encode(vhdl_bit) & encode(value));
   end;
 
   impure function pop (
     queue : queue_t
-  ) return bit is begin
-    check_type(queue, vhdl_bit);
-    return decode(pop_fix_string(queue, bit_code_length));
+  ) return bit is
+    constant str : string := pop_item(queue);
+    constant typ : queue_item_type_t := decode(str(1));
+  begin
+    check_type(typ, vhdl_bit);
+    return decode(str(2 to str'right));
   end;
 
   procedure push (
     queue : queue_t;
     value : std_ulogic
   ) is begin
-    push_type(queue, ieee_std_ulogic);
-    push_fix_string(queue, encode(value));
+    push_item(queue, encode(ieee_std_ulogic) & encode(value));
   end;
 
   impure function pop (
     queue : queue_t
-  ) return std_ulogic is begin
-    check_type(queue, ieee_std_ulogic);
-    return decode(pop_fix_string(queue, std_ulogic_code_length));
+  ) return std_ulogic is
+    constant str : string := pop_item(queue);
+    constant typ : queue_item_type_t := decode(str(1));
+  begin
+    check_type(typ, ieee_std_ulogic);
+    return decode(str(2 to str'right));
   end;
 
   procedure push (
     queue : queue_t;
     value : severity_level
   ) is begin
-    push_type(queue, vhdl_severity_level);
-    push_fix_string(queue, encode(value));
+    push_item(queue, encode(vhdl_severity_level) & encode(value));
   end;
 
   impure function pop (
     queue : queue_t
-  ) return severity_level is begin
-    check_type(queue, vhdl_severity_level);
-    return decode(pop_fix_string(queue, severity_level_code_length));
+  ) return severity_level is
+    constant str : string := pop_item(queue);
+    constant typ : queue_item_type_t := decode(str(1));
+  begin
+    check_type(typ, vhdl_severity_level);
+    return decode(str(2 to str'right));
   end;
 
   procedure push (
     queue : queue_t;
     value : file_open_status
   ) is begin
-    push_type(queue, vhdl_file_open_status);
-    push_fix_string(queue, encode(value));
+    push_item(queue, encode(vhdl_file_open_status) & encode(value));
   end;
 
   impure function pop (
     queue : queue_t
-  ) return file_open_status is begin
-    check_type(queue, vhdl_file_open_status);
-    return decode(pop_fix_string(queue, file_open_status_code_length));
+  ) return file_open_status is
+    constant str : string := pop_item(queue);
+    constant typ : queue_item_type_t := decode(str(1));
+  begin
+    check_type(typ, vhdl_file_open_status);
+    return decode(str(2 to str'right));
   end;
 
   procedure push (
     queue : queue_t;
     value : file_open_kind
   ) is begin
-    push_type(queue, vhdl_file_open_kind);
-    push_fix_string(queue, encode(value));
+    push_item(queue, encode(vhdl_file_open_kind) & encode(value));
   end;
 
   impure function pop (
     queue : queue_t
-  ) return file_open_kind is begin
-    check_type(queue, vhdl_file_open_kind);
-    return decode(pop_fix_string(queue, file_open_kind_code_length));
+  ) return file_open_kind is
+    constant str : string := pop_item(queue);
+    constant typ : queue_item_type_t := decode(str(1));
+  begin
+    check_type(typ, vhdl_file_open_kind);
+    return decode(str(2 to str'right));
   end;
 
   procedure push (
     queue : queue_t;
     value : bit_vector
   ) is begin
-    push_type(queue, vhdl_bit_vector);
-    push_variable_string(queue, encode(value));
+    push_item(queue, encode(vhdl_bit_vector) & encode(value));
   end;
 
   impure function pop (
     queue : queue_t
-  ) return bit_vector is begin
-    check_type(queue, vhdl_bit_vector);
-    return decode(pop_variable_string(queue));
+  ) return bit_vector is
+    constant str : string := pop_item(queue);
+    constant typ : queue_item_type_t := decode(str(1));
+  begin
+    check_type(typ, vhdl_bit_vector);
+    return decode(str(2 to str'right));
   end;
 
   procedure push (
     queue : queue_t;
     value : std_ulogic_vector
   ) is begin
-    push_type(queue, vhdl_std_ulogic_vector);
-    push_variable_string(queue, encode(value));
+    push_item(queue, encode(ieee_std_ulogic_vector) & encode(value));
   end;
 
   impure function pop (
     queue : queue_t
-  ) return std_ulogic_vector is begin
-    check_type(queue, vhdl_std_ulogic_vector);
-    return decode(pop_variable_string(queue));
+  ) return std_ulogic_vector is
+    constant str : string := pop_item(queue);
+    constant typ : queue_item_type_t := decode(str(1));
+  begin
+    check_type(typ, ieee_std_ulogic_vector);
+    report str;
+    return decode(str(2 to str'right));
   end;
 
   procedure push (
     queue : queue_t;
     value : complex
   ) is begin
-    push_type(queue, ieee_complex);
-    push_fix_string(queue, encode(value));
+    push_item(queue, encode(ieee_complex) & encode(value));
   end;
 
   impure function pop (
     queue : queue_t
-  ) return complex is begin
-    check_type(queue, ieee_complex);
-    return decode(pop_fix_string(queue, complex_code_length));
+  ) return complex is
+    constant str : string := pop_item(queue);
+    constant typ : queue_item_type_t := decode(str(1));
+  begin
+    check_type(typ, ieee_complex);
+    return decode(str(2 to str'right));
   end;
 
   procedure push (
     queue : queue_t;
     value : complex_polar
   ) is begin
-    push_type(queue, ieee_complex_polar);
-    push_fix_string(queue, encode(value));
+    push_item(queue, encode(ieee_complex_polar) & encode(value));
   end;
 
   impure function pop (
     queue : queue_t
-  ) return complex_polar is begin
-    check_type(queue, ieee_complex_polar);
-    return decode(pop_fix_string(queue, complex_polar_code_length));
+  ) return complex_polar is
+    constant str : string := pop_item(queue);
+    constant typ : queue_item_type_t := decode(str(1));
+  begin
+    check_type(typ, ieee_complex_polar);
+    return decode(str(2 to str'right));
   end;
 
   procedure push (
     queue : queue_t;
     value : ieee.numeric_bit.unsigned
   ) is begin
-    push_type(queue, ieee_numeric_bit_unsigned);
-    push_variable_string(queue, encode(value));
+    push_item(queue, encode(ieee_numeric_bit_unsigned) & encode(value));
   end;
 
   impure function pop (
     queue : queue_t
-  ) return ieee.numeric_bit.unsigned is begin
-    check_type(queue, ieee_numeric_bit_unsigned);
-    return decode(pop_variable_string(queue));
+  ) return ieee.numeric_bit.unsigned is
+    constant str : string := pop_item(queue);
+    constant typ : queue_item_type_t := decode(str(1));
+  begin
+    check_type(typ, ieee_numeric_bit_unsigned);
+    return decode(str(2 to str'right));
   end;
 
   procedure push (
     queue : queue_t;
     value : ieee.numeric_bit.signed
   ) is begin
-    push_type(queue, ieee_numeric_bit_signed);
-    push_variable_string(queue, encode(value));
+    push_item(queue, encode(ieee_numeric_bit_signed) & encode(value));
   end;
 
   impure function pop (
     queue : queue_t
-  ) return ieee.numeric_bit.signed is begin
-    check_type(queue, ieee_numeric_bit_signed);
-    return decode(pop_variable_string(queue));
+  ) return ieee.numeric_bit.signed is
+    constant str : string := pop_item(queue);
+    constant typ : queue_item_type_t := decode(str(1));
+  begin
+    check_type(typ, ieee_numeric_bit_signed);
+    return decode(str(2 to str'right));
   end;
 
   procedure push (
     queue : queue_t;
     value : ieee.numeric_std.unsigned
   ) is begin
-    push_type(queue, ieee_numeric_std_unsigned);
-    push_variable_string(queue, encode(value));
+    push_item(queue, encode(ieee_numeric_std_unsigned) & encode(value));
   end;
 
   impure function pop (
     queue : queue_t
-  ) return ieee.numeric_std.unsigned is begin
-    check_type(queue, ieee_numeric_std_unsigned);
-    return decode(pop_variable_string(queue));
+  ) return ieee.numeric_std.unsigned is
+    constant str : string := pop_item(queue);
+    constant typ : queue_item_type_t := decode(str(1));
+  begin
+    check_type(typ, ieee_numeric_std_unsigned);
+    return decode(str(2 to str'right));
   end;
 
   procedure push (
     queue : queue_t;
     value : ieee.numeric_std.signed
   ) is begin
-    push_type(queue, ieee_numeric_std_signed);
-    push_variable_string(queue, encode(value));
+    push_item(queue, encode(ieee_numeric_std_signed) & encode(value));
   end;
 
   impure function pop (
     queue : queue_t
-  ) return ieee.numeric_std.signed is begin
-    check_type(queue, ieee_numeric_std_signed);
-    return decode(pop_variable_string(queue));
+  ) return ieee.numeric_std.signed is
+    constant str : string := pop_item(queue);
+    constant typ : queue_item_type_t := decode(str(1));
+  begin
+    check_type(typ, ieee_numeric_std_signed);
+    return decode(str(2 to str'right));
   end;
 
   procedure push (
     queue : queue_t;
     value : string
   ) is begin
-    push_type(queue, vhdl_string);
-    push_variable_string(queue, encode(value));
+    push_item(queue, encode(vhdl_string) & encode(value));
   end;
 
   impure function pop (
     queue : queue_t
-  ) return string is begin
-    check_type(queue, vhdl_string);
-    return decode(pop_variable_string(queue));
+  ) return string is
+    constant str : string := pop_item(queue);
+    constant typ : queue_item_type_t := decode(str(1));
+  begin
+    check_type(typ, vhdl_string);
+    return decode(str(2 to str'right));
   end;
 
   procedure push (
     queue : queue_t;
     value : time
   ) is begin
-    push_type(queue, vhdl_time);
-    push_fix_string(queue, encode(value));
+    push_item(queue, encode(vhdl_time) & encode(value));
   end;
 
   impure function pop (
     queue : queue_t
-  ) return time is begin
-    check_type(queue, vhdl_time);
-    return decode(pop_fix_string(queue, time_code_length));
+  ) return time is
+    constant str : string := pop_item(queue);
+    constant typ : queue_item_type_t := decode(str(1));
+  begin
+    check_type(typ, vhdl_time);
+    return decode(str(2 to str'right));
   end;
 
   procedure push (
     queue : queue_t;
     variable value : inout integer_vector_ptr_t
   ) is begin
-    push_type(queue, vunit_integer_vector_ptr_t);
-    push_fix_string(queue, encode(value));
-    value := null_ptr;
+    push_item(queue, encode(vunit_integer_vector_ptr) & encode(value));
+    value := null_integer_vector_ptr;
   end;
 
   impure function pop (
     queue : queue_t
-  ) return integer_vector_ptr_t is begin
-    check_type(queue, vunit_integer_vector_ptr_t);
-    return decode(pop_fix_string(queue, integer_vector_ptr_t_code_length));
-  end;
-
-  procedure unsafe_push (
-    queue : queue_t;
-    value : integer_vector_ptr_t
-  ) is begin
-    push_fix_string(queue, encode(value));
-  end;
-
-  impure function unsafe_pop (
-    queue : queue_t
-  ) return integer_vector_ptr_t is begin
-    return decode(pop_fix_string(queue, integer_vector_ptr_t_code_length));
+  ) return integer_vector_ptr_t is
+    constant str : string := pop_item(queue);
+    constant typ : queue_item_type_t := decode(str(1));
+  begin
+    check_type(typ, vunit_integer_vector_ptr);
+    return decode(str(2 to str'right));
   end;
 
   procedure push (
     queue : queue_t;
     variable value : inout string_ptr_t
   ) is begin
-    push_type(queue, vunit_string_ptr_t);
-    push_fix_string(queue, encode(value));
+    push_item(queue, encode(vunit_string_ptr) & encode(value));
     value := null_string_ptr;
   end;
 
   impure function pop (
     queue : queue_t
-  ) return string_ptr_t is begin
-    check_type(queue, vunit_string_ptr_t);
-    return decode(pop_fix_string(queue, string_ptr_t_code_length));
+  ) return string_ptr_t is
+    constant str : string := pop_item(queue);
+    constant typ : queue_item_type_t := decode(str(1));
+  begin
+    check_type(typ, vunit_string_ptr);
+    return decode(str(2 to str'right));
   end;
 
   procedure push (
     queue : queue_t;
     variable value : inout queue_t
   ) is begin
-    push_type(queue, vunit_queue_t);
-    push_fix_string(queue, encode(value));
+    push_item(queue, encode(vunit_queue) & encode(value));
     value := null_queue;
   end;
 
   impure function pop (
     queue : queue_t
-  ) return queue_t is begin
-    check_type(queue, vunit_queue_t);
-    return decode(pop_fix_string(queue, queue_t_code_length));
+  ) return queue_t is
+    constant str : string := pop_item(queue);
+    constant typ : queue_item_type_t := decode(str(1));
+  begin
+    check_type(typ, vunit_queue);
+    return decode(str(2 to str'right));
   end;
 
-  procedure push_ref (
+  procedure push (
     constant queue : queue_t;
     value : inout integer_array_t
   ) is begin
-    push_type(queue, vunit_integer_array_t);
-    unsafe_push(queue, value.length);
-    unsafe_push(queue, value.width);
-    unsafe_push(queue, value.height);
-    unsafe_push(queue, value.depth);
-    unsafe_push(queue, value.bit_width);
-    unsafe_push(queue, value.is_signed);
-    unsafe_push(queue, value.lower_limit);
-    unsafe_push(queue, value.upper_limit);
-    unsafe_push(queue, value.data);
+    push_item(queue, encode(vunit_integer_array) & encode(value));
     value := null_integer_array;
   end;
 
-  impure function pop_ref (
+  impure function pop (
     queue : queue_t
-  ) return integer_array_t is begin
-    check_type(queue, vunit_integer_array_t);
-    return (
-      length      => unsafe_pop(queue),
-      width       => unsafe_pop(queue),
-      height      => unsafe_pop(queue),
-      depth       => unsafe_pop(queue),
-      bit_width   => unsafe_pop(queue),
-      is_signed   => unsafe_pop(queue),
-      lower_limit => unsafe_pop(queue),
-      upper_limit => unsafe_pop(queue),
-      data        => unsafe_pop(queue)
-    );
+  ) return integer_array_t is
+    constant str : string := pop_item(queue);
+    constant typ : queue_item_type_t := decode(str(1));
+  begin
+    check_type(typ, vunit_integer_array);
+    return decode(str(2 to str'right));
   end;
+
 end package body;
+

--- a/vunit/vhdl/data_types/src/queue_pkg.vhd
+++ b/vunit/vhdl/data_types/src/queue_pkg.vhd
@@ -14,17 +14,53 @@ use work.string_ptr_pkg.all;
 use work.integer_array_pkg.all;
 
 package queue_pkg is
+
+  type queue_item_type_t is (
+    vhdl_boolean,
+    vhdl_boolean_vector,
+    vhdl_bit,
+    vhdl_bit_vector,
+    vhdl_character,
+    vhdl_string,
+    vhdl_integer,
+    vhdl_integer_vector,
+    vhdl_real,
+    vhdl_real_vector,
+    vhdl_time,
+    vhdl_time_vector,
+    vhdl_severity_level,
+    vhdl_file_open_status,
+    vhdl_file_open_kind,
+    ieee_complex,
+    ieee_complex_polar,
+    ieee_std_ulogic,
+    ieee_std_ulogic_vector,
+    ieee_numeric_bit_unsigned,
+    ieee_numeric_bit_signed,
+    ieee_numeric_std_unsigned,
+    ieee_numeric_std_signed,
+    ieee_ufixed,
+    ieee_sfixed,
+    ieee_float,
+    vunit_byte,
+    vunit_integer_vector_ptr,
+    vunit_string_ptr,
+    vunit_integer_array,
+    vunit_queue
+  );
+
   type queue_t is record
     p_meta : integer_vector_ptr_t;
-    data   : string_ptr_t;
+    data   : integer_vector_ptr_t;
   end record;
+
   type queue_vec_t is array(integer range <>) of queue_t;
-  constant null_queue : queue_t := (p_meta => null_ptr, data => null_string_ptr);
+
+  constant null_queue : queue_t := (p_meta => null_ptr, data => null_ptr);
 
   impure function new_queue
-  return queue_t;
+    return queue_t;
 
-  -- Returns the length of the queue in bytes
   impure function length (
     queue : queue_t
   ) return natural;
@@ -40,6 +76,28 @@ package queue_pkg is
   impure function copy (
     queue : queue_t
   ) return queue_t;
+
+  function encode (
+    item_type : queue_item_type_t
+  ) return character;
+
+  function decode (
+    char : character
+  ) return queue_item_type_t;
+
+  procedure push_item (
+    queue : queue_t;
+    value : string
+  );
+
+  impure function pop_item (
+    queue : queue_t
+  ) return string;
+
+  procedure check_type (
+    got      : queue_item_type_t;
+    expected : queue_item_type_t
+  );
 
   procedure push (
     queue : queue_t;
@@ -314,27 +372,17 @@ package queue_pkg is
   alias push_queue_ref is push[queue_t, queue_t];
   alias pop_queue_ref is pop[queue_t return queue_t];
 
-  procedure push_ref (
+  procedure push (
     constant queue : queue_t;
     value : inout integer_array_t
   );
 
-  impure function pop_ref (
+  impure function pop (
     queue : queue_t
   ) return integer_array_t;
 
-  alias push_integer_array_t_ref is push_ref[queue_t, integer_array_t];
-  alias pop_integer_array_t_ref is pop_ref[queue_t return integer_array_t];
-
-  -- Private
-  type queue_element_type_t is (
-    vhdl_character, vhdl_integer, vunit_byte, vhdl_string, vhdl_boolean, vhdl_real, vhdl_bit, ieee_std_ulogic,
-    vhdl_severity_level, vhdl_file_open_status, vhdl_file_open_kind, vhdl_bit_vector, vhdl_std_ulogic_vector,
-    ieee_complex, ieee_complex_polar, ieee_numeric_bit_unsigned, ieee_numeric_bit_signed,
-    ieee_numeric_std_unsigned, ieee_numeric_std_signed, vhdl_time, vunit_integer_vector_ptr_t,
-    vunit_string_ptr_t, vunit_queue_t, vunit_integer_array_t, vhdl_boolean_vector, vhdl_integer_vector,
-    vhdl_real_vector, vhdl_time_vector, ieee_ufixed, ieee_sfixed, ieee_float
-  );
+  alias push_integer_array_t_ref is push[queue_t, integer_array_t];
+  alias pop_integer_array_t_ref is pop[queue_t return integer_array_t];
 
   function encode (
     data : queue_t
@@ -353,41 +401,5 @@ package queue_pkg is
   alias encode_queue_t is encode[queue_t return string];
   alias decode_queue_t is decode[string return queue_t];
 
-  procedure push_type (
-    queue        : queue_t;
-    element_type : queue_element_type_t
-  );
-
-  procedure check_type (
-    queue        : queue_t;
-    element_type : queue_element_type_t
-  );
-
-  procedure unsafe_push (
-    queue : queue_t;
-    value : character
-  );
-
-  impure function unsafe_pop (
-    queue : queue_t
-  ) return character;
-
-  procedure push_variable_string (
-    queue : queue_t;
-    value : string
-  );
-
-  impure function pop_variable_string (
-    queue : queue_t
-  ) return string;
-
-  procedure push_fix_string (
-    queue : queue_t;
-    value : string
-  );
-
-  impure function pop_fix_string (
-    queue  : queue_t;
-    length : natural
-  ) return string;
 end package;
+

--- a/vunit/vhdl/data_types/src/queue_pool_pkg.vhd
+++ b/vunit/vhdl/data_types/src/queue_pool_pkg.vhd
@@ -9,13 +9,15 @@ use work.string_ptr_pool_pkg.all;
 use work.queue_pkg.all;
 
 package queue_pool_pkg is
+
   type queue_pool_t is record
     index_pool : integer_vector_ptr_pool_t;
-    data_pool : string_ptr_pool_t;
+    data_pool : integer_vector_ptr_pool_t;
   end record;
+
   constant null_queue_pool : queue_pool_t := (
     index_pool => null_integer_vector_ptr_pool,
-    data_pool => null_string_ptr_pool);
+    data_pool => null_integer_vector_ptr_pool);
 
   impure function new_queue_pool
   return queue_pool_t;
@@ -28,14 +30,16 @@ package queue_pool_pkg is
     pool : queue_pool_t;
     variable queue : inout queue_t
   );
+
 end package;
 
 package body queue_pool_pkg is
+
   impure function new_queue_pool
   return queue_pool_t is begin
     return (
       index_pool => new_integer_vector_ptr_pool,
-      data_pool  => new_string_ptr_pool
+      data_pool  => new_integer_vector_ptr_pool
     );
   end;
 
@@ -45,8 +49,8 @@ package body queue_pool_pkg is
     variable queue : queue_t;
   begin
     queue := (
-      p_meta => new_integer_vector_ptr(pool.index_pool, 2),
-      data => new_string_ptr(pool.data_pool, 0)
+      p_meta => new_integer_vector_ptr(pool.index_pool, 3),
+      data => new_integer_vector_ptr(pool.data_pool, 256)
     );
     flush(queue);
     return queue;
@@ -59,4 +63,6 @@ package body queue_pool_pkg is
     recycle(pool.index_pool, queue.p_meta);
     recycle(pool.data_pool, queue.data);
   end;
+
 end package body;
+

--- a/vunit/vhdl/data_types/src/string_ptr_pkg-body-200x.vhd
+++ b/vunit/vhdl/data_types/src/string_ptr_pkg-body-200x.vhd
@@ -4,14 +4,30 @@
 --
 -- Copyright (c) 2014-2019, Lars Asplund lars.anders.asplund@gmail.com
 
+use work.integer_vector_pkg.all;
+
 package body string_ptr_pkg is
+
   type string_ptr_storage_t is protected
-    impure function new_string_ptr (
+
+    impure function new_ptr (
       length : natural := 0
+    ) return natural;
+
+    impure function new_ptr (
+      value : vec_t
     ) return natural;
 
     procedure deallocate (
       ref : natural
+    );
+
+    procedure reallocate_storage (
+      length : positive
+    );
+
+    procedure reallocate_stack (
+      length : positive
     );
 
     impure function length (
@@ -36,57 +52,99 @@ package body string_ptr_pkg is
 
     procedure reallocate (
       ref   : natural;
-      value : string
+      value : vec_t
     );
 
     procedure resize (
       ref    : natural;
-      length : natural;
-      drop   : natural := 0
+      length : natural
     );
 
     impure function to_string (
       ref : natural
     ) return string;
+
   end protected;
 
   type string_ptr_storage_t is protected body
-    variable current_index : integer := 0;
-    variable ptrs : vava_t := null;
 
-    impure function new_string_ptr (
+    -- Pointer storage
+    variable storage : vava_t := new vav_t'(0 to 2**16 - 1 => null);
+    variable storage_index : natural := 0;
+
+    -- Stack of unused storage indices
+    variable stack : integer_vector_access_t := new integer_vector_t'(0 to 2**16 - 1 => -1);
+    variable stack_index : natural := 0;
+
+    impure function new_ptr (
       length : natural := 0
     ) return natural is
-      variable old_ptrs : string_access_vector_access_t;
+      constant value : vec_t(1 to length) := (others => val_t'low);
     begin
-      if ptrs = null then
-        ptrs := new vav_t'(0 => null);
-      elsif ptrs'length <= current_index then
-        -- Reallocate ptr pointers to larger ptr
-        -- Use more size to trade size for speed
-        old_ptrs := ptrs;
-        ptrs := new vav_t'(0 to ptrs'length + 2**16 => null);
-        for i in old_ptrs'range loop
-          ptrs(i) := old_ptrs(i);
-        end loop;
-        deallocate(old_ptrs);
+      return new_ptr(value);
+    end;
+
+    impure function new_ptr (
+      value : vec_t
+    ) return natural is
+      variable ref : index_t;
+    begin
+      if stack_index > 0 then
+        stack_index := stack_index - 1;
+        ref := stack(stack_index);
+      else
+        if storage_index >= storage'length then
+          reallocate_storage(storage'length + 2**16);
+        end if;
+        ref := storage_index;
+        storage_index := storage_index + 1;
       end if;
-      ptrs(current_index) := new string'(1 to length => val_t'low);
-      current_index := current_index + 1;
-      return current_index-1;
+      storage(ref) := new vec_t'(value);
+      return ref;
     end;
 
     procedure deallocate (
       ref : natural
     ) is begin
-      deallocate(ptrs(ref));
-      ptrs(ref) := null;
+      if stack_index >= stack'length then
+        reallocate_stack(stack'length + 2**16);
+      end if;
+      stack(stack_index) := ref;
+      stack_index := stack_index + 1;
+      deallocate(storage(ref));
+      storage(ref) := null;
+    end;
+
+    procedure reallocate_storage (
+      length : positive
+    ) is
+      variable old_storage : vava_t;
+    begin
+      old_storage := storage;
+      storage := new vav_t'(0 to length - 1 => null);
+      for i in old_storage'range loop
+        storage(i) := old_storage(i);
+      end loop;
+      deallocate(old_storage);
+    end;
+
+    procedure reallocate_stack (
+      length : positive
+    ) is
+      variable old_stack : integer_vector_access_t;
+    begin
+      old_stack := stack;
+      stack := new integer_vector_t'(0 to length - 1 => -1);
+      for i in old_stack'range loop
+        stack(i) := old_stack(i);
+      end loop;
+      deallocate(old_stack);
     end;
 
     impure function length (
       ref : natural
     ) return integer is begin
-      return ptrs(ref)'length;
+      return storage(ref)'length;
     end;
 
     procedure set (
@@ -94,66 +152,60 @@ package body string_ptr_pkg is
       index : natural;
       value : val_t
     ) is begin
-      ptrs(ref)(index) := value;
+      storage(ref)(index) := value;
     end;
 
     impure function get (
       ref   : natural;
       index : natural
     ) return val_t is begin
-      return ptrs(ref)(index);
+      return storage(ref)(index);
     end;
 
     procedure reallocate (
       ref    : natural;
       length : natural
     ) is
-      variable old_ptr, new_ptr : string_access_t;
+      variable value : vec_t(1 to length) := (others => val_t'low);
     begin
-      deallocate(ptrs(ref));
-      ptrs(ref) := new string'(1 to length => val_t'low);
+      reallocate(ref, value);
     end;
 
     procedure reallocate (
       ref   : natural;
-      value : string
-    ) is
-      variable old_ptr, new_ptr : string_access_t;
-      variable n_value : string(1 to value'length) := value;
-    begin
-      deallocate(ptrs(ref));
-      ptrs(ref) := new string'(n_value);
+      value : vec_t
+    ) is begin
+      deallocate(storage(ref));
+      storage(ref) := new vec_t'(value);
     end;
 
     procedure resize (
       ref    : natural;
-      length : natural;
-      drop   : natural := 0
+      length : natural
     ) is
-      variable old_ptr, new_ptr : string_access_t;
-      variable min_length : natural := length;
+      variable old_ptr : va_t := storage(ref);
+      variable new_ptr : va_t := new vec_t'(1 to length => val_t'low);
+      variable min_length : natural := old_ptr'length;
     begin
-      new_ptr := new string'(1 to length => val_t'low);
-      old_ptr := ptrs(ref);
-      if min_length > old_ptr'length - drop then
-        min_length := old_ptr'length - drop;
+      if length < old_ptr'length then
+        min_length := length;
       end if;
       for i in 1 to min_length loop
-        new_ptr(i) := old_ptr(drop + i);
+        new_ptr(i) := old_ptr(i);
       end loop;
-      ptrs(ref) := new_ptr;
+      storage(ref) := new_ptr;
       deallocate(old_ptr);
     end;
 
     impure function to_string (
       ref : natural
     ) return string is begin
-      return ptrs(ref).all;
+      return storage(ref).all;
     end;
 
   end protected body;
 
-  shared variable string_ptr_storage : string_ptr_storage_t;
+  shared variable ptr_storage : string_ptr_storage_t;
 
   function to_integer (
     value : ptr_t
@@ -171,32 +223,25 @@ package body string_ptr_pkg is
   impure function new_string_ptr (
     length : natural := 0
   ) return ptr_t is begin
-    return (ref => string_ptr_storage.new_string_ptr(length));
+    return (ref => ptr_storage.new_ptr(length));
   end;
 
   impure function new_string_ptr (
-    value : string
-  ) return ptr_t is
-    variable result : ptr_t := new_string_ptr(value'length);
-    variable n_value : string(1 to value'length) := value;
-  begin
-    for i in 1 to n_value'length loop
-      set(result, i, n_value(i));
-    end loop;
-    return result;
+    value : vec_t
+  ) return ptr_t is begin
+    return (ref => ptr_storage.new_ptr(value));
   end;
 
   procedure deallocate (
     ptr : ptr_t
-  ) is
-  begin
-    string_ptr_storage.deallocate(ptr.ref);
+  ) is begin
+    ptr_storage.deallocate(ptr.ref);
   end;
 
   impure function length (
     ptr : ptr_t
   ) return integer is begin
-    return string_ptr_storage.length(ptr.ref);
+    return ptr_storage.length(ptr.ref);
   end;
 
   procedure set (
@@ -204,42 +249,41 @@ package body string_ptr_pkg is
     index : natural;
     value : val_t
   ) is begin
-    string_ptr_storage.set(ptr.ref, index, value);
+    ptr_storage.set(ptr.ref, index, value);
   end;
 
   impure function get (
-    ptr : ptr_t;
+    ptr   : ptr_t;
     index : natural
   ) return val_t is begin
-    return string_ptr_storage.get(ptr.ref, index);
+    return ptr_storage.get(ptr.ref, index);
   end;
 
   procedure reallocate (
-    ptr : ptr_t;
+    ptr    : ptr_t;
     length : natural
   ) is begin
-    string_ptr_storage.reallocate(ptr.ref, length);
+    ptr_storage.reallocate(ptr.ref, length);
   end;
 
   procedure reallocate (
     ptr   : ptr_t;
-    value : string
+    value : vec_t
   ) is begin
-    string_ptr_storage.reallocate(ptr.ref, value);
+    ptr_storage.reallocate(ptr.ref, value);
   end;
 
   procedure resize (
     ptr    : ptr_t;
-    length : natural;
-    drop   : natural := 0
+    length : natural
   ) is begin
-    string_ptr_storage.resize(ptr.ref, length, drop);
+    ptr_storage.resize(ptr.ref, length);
   end;
 
   impure function to_string (
     ptr : ptr_t
   ) return string is begin
-    return string_ptr_storage.to_string(ptr.ref);
+    return ptr_storage.to_string(ptr.ref);
   end;
 
   function encode (
@@ -252,18 +296,19 @@ package body string_ptr_pkg is
     code : string
   ) return ptr_t is
     variable ret_val : ptr_t;
-    variable index : positive := code'left;
+    variable index   : positive := code'left;
   begin
     decode(code, index, ret_val);
     return ret_val;
   end;
 
   procedure decode (
-    constant code : string;
-    variable index : inout positive;
+    constant code   : string;
+    variable index  : inout positive;
     variable result : out ptr_t
   ) is begin
     decode(code, index, result.ref);
   end;
 
 end package body;
+

--- a/vunit/vhdl/data_types/src/string_ptr_pkg-body-93.vhd
+++ b/vunit/vhdl/data_types/src/string_ptr_pkg-body-93.vhd
@@ -4,44 +4,87 @@
 --
 -- Copyright (c) 2014-2019, Lars Asplund lars.anders.asplund@gmail.com
 
+use work.integer_vector_pkg.all;
+
 package body string_ptr_pkg is
-  shared variable current_index : integer := 0;
-  shared variable ptrs : vava_t := null;
+
+  -- Pointer storage
+  shared variable storage : vava_t := new vav_t'(0 to 2**16 - 1 => null);
+  shared variable storage_index : natural := 0;
+
+  -- Stack of unused storage indices
+  shared variable stack : integer_vector_access_t := new integer_vector_t'(0 to 2**16 - 1 => -1);
+  shared variable stack_index : natural := 0;
+
+  procedure reallocate_storage (
+    length : positive
+  ) is
+    variable old_storage : vava_t;
+  begin
+    old_storage := storage;
+    storage := new vav_t'(0 to length - 1 => null);
+    for i in old_storage'range loop
+      storage(i) := old_storage(i);
+    end loop;
+    deallocate(old_storage);
+  end;
+
+  procedure reallocate_stack (
+    length : positive
+  ) is
+    variable old_stack : integer_vector_access_t;
+  begin
+    old_stack := stack;
+    stack := new integer_vector_t'(0 to length - 1 => -1);
+    for i in old_stack'range loop
+      stack(i) := old_stack(i);
+    end loop;
+    deallocate(old_stack);
+  end;
 
   impure function new_string_ptr (
     length : natural := 0
   ) return ptr_t is
-    variable old_ptrs : vava_t;
-    variable retval : ptr_t := (ref => current_index);
+    constant value : vec_t(1 to length) := (others => val_t'low);
   begin
-    if ptrs = null then
-      ptrs := new vav_t'(0 => null);
-    elsif ptrs'length <= current_index then
-      -- Reallocate ptr pointers to larger ptr
-      -- Use more size to trade size for speed
-      old_ptrs := ptrs;
-      ptrs := new vav_t'(0 to ptrs'length + 2**16 => null);
-      for i in old_ptrs'range loop
-        ptrs(i) := old_ptrs(i);
-      end loop;
-      deallocate(old_ptrs);
+    return new_string_ptr(value);
+  end;
+
+  impure function new_string_ptr (
+    value : vec_t
+  ) return ptr_t is
+    variable ref : index_t;
+  begin
+    if stack_index > 0 then
+      stack_index := stack_index - 1;
+      ref := stack(stack_index);
+    else
+      if storage_index >= storage'length then
+        reallocate_storage(storage'length + 2**16);
+      end if;
+      ref := storage_index;
+      storage_index := storage_index + 1;
     end if;
-    ptrs(current_index) := new string'(1 to length => val_t'low);
-    current_index := current_index + 1;
-    return retval;
+    storage(ref) := new vec_t'(value);
+    return (ref => ref);
   end;
 
   procedure deallocate (
     ptr : ptr_t
   ) is begin
-    deallocate(ptrs(ptr.ref));
-    ptrs(ptr.ref) := null;
+    if stack_index >= stack'length then
+      reallocate_stack(stack'length + 2**16);
+    end if;
+    stack(stack_index) := ptr.ref;
+    stack_index := stack_index + 1;
+    deallocate(storage(ptr.ref));
+    storage(ptr.ref) := null;
   end;
 
   impure function length (
     ptr : ptr_t
   ) return integer is begin
-    return ptrs(ptr.ref)'length;
+    return storage(ptr.ref)'length;
   end;
 
   procedure set (
@@ -49,61 +92,55 @@ package body string_ptr_pkg is
     index : natural;
     value : val_t
   ) is begin
-    ptrs(ptr.ref)(index) := value;
+    storage(ptr.ref)(index) := value;
   end;
 
   impure function get (
     ptr   : ptr_t;
     index : natural
   ) return val_t is begin
-    return ptrs(ptr.ref)(index);
+    return storage(ptr.ref)(index);
   end;
 
   procedure reallocate (
     ptr    : ptr_t;
     length : natural
   ) is
-    variable old_ptr, new_ptr : string_access_t;
+    variable value : vec_t(1 to length) := (others => val_t'low);
   begin
-    deallocate(ptrs(ptr.ref));
-    ptrs(ptr.ref) := new string'(1 to length => val_t'low);
+    reallocate(ptr, value);
   end;
 
   procedure reallocate (
     ptr   : ptr_t;
-    value : string
-  ) is
-    variable old_ptr, new_ptr : string_access_t;
-    variable n_value : string(1 to value'length) := value;
-  begin
-    deallocate(ptrs(ptr.ref));
-    ptrs(ptr.ref) := new string'(n_value);
+    value : vec_t
+  ) is begin
+    deallocate(storage(ptr.ref));
+    storage(ptr.ref) := new vec_t'(value);
   end;
 
   procedure resize (
     ptr    : ptr_t;
-    length : natural;
-    drop   : natural := 0
+    length : natural
   ) is
-    variable old_ptr, new_ptr : string_access_t;
-    variable min_length : natural := length;
+    variable old_ptr : va_t := storage(ptr.ref);
+    variable new_ptr : va_t := new vec_t'(1 to length => val_t'low);
+    variable min_length : natural := old_ptr'length;
   begin
-    new_ptr := new string'(1 to length => val_t'low);
-    old_ptr := ptrs(ptr.ref);
-    if min_length > old_ptr'length - drop then
-      min_length := old_ptr'length - drop;
+    if length < old_ptr'length then
+      min_length := length;
     end if;
     for i in 1 to min_length loop
-      new_ptr(i) := old_ptr(drop + i);
+      new_ptr(i) := old_ptr(i);
     end loop;
-    ptrs(ptr.ref) := new_ptr;
+    storage(ptr.ref) := new_ptr;
     deallocate(old_ptr);
   end;
 
   impure function to_string (
     ptr : ptr_t
   ) return string is begin
-    return ptrs(ptr.ref).all;
+    return storage(ptr.ref).all;
   end;
 
   function to_integer (
@@ -117,18 +154,6 @@ package body string_ptr_pkg is
   ) return ptr_t is begin
     -- @TODO maybe assert that the ref is valid
     return (ref => value);
-  end;
-
-  impure function new_string_ptr (
-    value : string
-  ) return ptr_t is
-    variable result : ptr_t := new_string_ptr(value'length);
-    variable n_value : string(1 to value'length) := value;
-  begin
-    for i in 1 to n_value'length loop
-      set(result, i, n_value(i));
-    end loop;
-    return result;
   end;
 
   function encode (
@@ -156,3 +181,4 @@ package body string_ptr_pkg is
   end;
 
 end package body;
+

--- a/vunit/vhdl/data_types/src/string_ptr_pkg.vhd
+++ b/vunit/vhdl/data_types/src/string_ptr_pkg.vhd
@@ -16,16 +16,21 @@ use work.codec_pkg.all;
 use work.codec_builder_pkg.all;
 
 package string_ptr_pkg is
+
   subtype index_t is integer range -1 to integer'high;
+
   type string_ptr_t is record
     ref : index_t;
   end record;
+
   constant null_string_ptr : string_ptr_t := (ref => -1);
 
-  alias  ptr_t  is string_ptr_t;
-  alias  val_t  is character;
-  alias  vav_t  is string_access_vector_t;
-  alias  vava_t is string_access_vector_access_t;
+  alias ptr_t  is string_ptr_t;
+  alias val_t  is character;
+  alias vec_t  is string;
+  alias va_t   is string_access_t;
+  alias vav_t  is string_access_vector_t;
+  alias vava_t is string_access_vector_access_t;
 
   function to_integer (
     value : ptr_t
@@ -40,7 +45,7 @@ package string_ptr_pkg is
   ) return ptr_t;
 
   impure function new_string_ptr (
-    value : string
+    value : vec_t
   ) return ptr_t;
 
   procedure deallocate (
@@ -69,13 +74,12 @@ package string_ptr_pkg is
 
   procedure reallocate (
     ptr   : ptr_t;
-    value : string
+    value : vec_t
   );
 
   procedure resize (
     ptr    : ptr_t;
-    length : natural;
-    drop   : natural := 0
+    length : natural
   );
 
   impure function to_string (
@@ -96,9 +100,10 @@ package string_ptr_pkg is
     variable result : out ptr_t
   );
 
-  alias encode_ptr_t is encode[ptr_t return string];
-  alias decode_ptr_t is decode[string return ptr_t];
+  alias encode_string_ptr_t is encode[ptr_t return string];
+  alias decode_string_ptr_t is decode[string return ptr_t];
 
   constant string_ptr_t_code_length : positive := integer_code_length;
 
 end package;
+

--- a/vunit/vhdl/data_types/test/tb_integer_vector_ptr.vhd
+++ b/vunit/vhdl/data_types/test/tb_integer_vector_ptr.vhd
@@ -77,15 +77,28 @@ begin
         check_equal(get(ptr, 0), a_random_value,
                     "Checking that shrunk ptr still contain old value");
 
-      elsif run("test_resize_with_drop") then
+      elsif run("test_resize_with_rotate") then
         ptr := new_integer_vector_ptr(8);
         for i in 0 to 7 loop
           set(ptr, i, i);
         end loop;
-        resize(ptr, 4, drop => 4);
+        resize(ptr, 16, rotate => 6, value => -1);
+
+        for i in 0 to 7 loop
+          check_equal(get(ptr, i), (6+i) mod 8);
+        end loop;
+        for i in 8 to 15 loop
+          check_equal(get(ptr, i), -1);
+        end loop;
+
+        ptr := new_integer_vector_ptr(8);
+        for i in 0 to 7 loop
+          set(ptr, i, i);
+        end loop;
+        resize(ptr, 4, rotate => 6);
 
         for i in 0 to 3 loop
-          check_equal(get(ptr, i), 4+i);
+          check_equal(get(ptr, i), (6+i) mod 8);
         end loop;
 
       elsif run("test_resize_with_default") then

--- a/vunit/vhdl/data_types/test/tb_queue.vhd
+++ b/vunit/vhdl/data_types/test/tb_queue.vhd
@@ -57,12 +57,12 @@ begin
       check_equal(length(queue), 0, "Empty queue length");
 
       push_integer(queue, 11);
-      check_equal(length(queue), 5, "Length");
+      check_equal(length(queue), 1, "Length");
       push_integer(queue, 22);
-      check_equal(length(queue), 10, "Length");
+      check_equal(length(queue), 2, "Length");
 
       check_equal(pop_integer(queue), 11, "data");
-      check_equal(length(queue), 5, "Length");
+      check_equal(length(queue), 1, "Length");
       check_equal(pop_integer(queue), 22, "data");
       check_equal(length(queue), 0, "Length");
 
@@ -91,21 +91,21 @@ begin
       check_equal(length(queue), 0, "Empty queue length");
 
       push_character(queue, '1');
-      check_equal(length(queue), 2, "Length");
+      check_equal(length(queue), 1, "Length");
       push_character(queue, '2');
-      check_equal(length(queue), 4, "Length");
+      check_equal(length(queue), 2, "Length");
 
       assert pop_character(queue) = '1';
-      check_equal(length(queue), 2, "Length");
+      check_equal(length(queue), 1, "Length");
       assert pop_character(queue) = '2';
       check_equal(length(queue), 0, "Length");
 
     elsif run("Test flush queue") then
       queue := new_queue;
       push_character(queue, '1');
-      check_equal(length(queue), 2, "Length");
+      check_equal(length(queue), 1, "Length");
       push_character(queue, '2');
-      check_equal(length(queue), 4, "Length");
+      check_equal(length(queue), 2, "Length");
       flush(queue);
       check_equal(length(queue), 0, "Length");
 

--- a/vunit/vhdl/data_types/test/tb_string_ptr.vhd
+++ b/vunit/vhdl/data_types/test/tb_string_ptr.vhd
@@ -82,18 +82,6 @@ begin
         assert get(ptr, 1) = a_random_value report
           "Checking that shrunk ptr still contain old value";
 
-      elsif run("test_resize_with_drop") then
-
-        ptr := new_string_ptr(8);
-        for i in 1 to 8 loop
-          set(ptr, i, character'val(i));
-        end loop;
-        resize(ptr, 4, drop => 4);
-
-        for i in 1 to 4 loop
-          assert get(ptr, i) = character'val(4+i);
-        end loop;
-
       elsif run("test_from_and_to_integer") then
         ptr := new_string_ptr(2);
         assert to_string_ptr(to_integer(ptr)) = ptr;


### PR DESCRIPTION
This is a first step toward #521. Introducing a new implementation of `queue_t` will allow me to create a new, generalized `element_t` or `item_t` that can represent any VHDL value. Performance tests indicate that this implementation is faster than the current implementation.

I'm creating a draft PR for now, so that you can start to review the changes. I tried to group the changes into 3 reasonable commits. I still need to update `com` to use support the new `queue_pkg` before this will be ready to pull.