### PR TITLE
Improve `remove_comments` function in the VHDL parser

### DIFF
--- a/vunit/vhdl_parser.py
+++ b/vunit/vhdl_parser.py
@@ -988,7 +988,7 @@ class VHDLReference(object):
         return self.name_within == "all"
 
 
-VHDL_REMOVE_COMMENT_RE = re.compile(r'^([^\"\-]*(?:\"[^\"]*\"[^\"\-]*)*)--.*')
+VHDL_REMOVE_COMMENT_RE = re.compile(r'^([^\"\-]*(?:\"(?:\"\"|[^\"])*\"[^\"\-]*)*)--.*', re.MULTILINE)
 
 
 def _comment_repl(match):

--- a/vunit/vhdl_parser.py
+++ b/vunit/vhdl_parser.py
@@ -996,7 +996,7 @@ def _comment_repl(match):
     Replace comment with equal amount of whitespace to make
     lexical position unaffected
     """
-    return match.group(1) + " "*len(match.group(2))
+    return match.group(1) + (" " * len(match.group(2)))
 
 
 def remove_comments(code):

--- a/vunit/vhdl_parser.py
+++ b/vunit/vhdl_parser.py
@@ -988,7 +988,7 @@ class VHDLReference(object):
         return self.name_within == "all"
 
 
-VHDL_REMOVE_COMMENT_RE = re.compile(r'^([^\"\-]*(?:\"(?:\"\"|[^\"])*\"[^\"\-]*)*)--.*', re.MULTILINE)
+VHDL_REMOVE_COMMENT_RE = re.compile(r'^([^\"\-]*(?:\"(?:\"\"|[^\"])*\"[^\"\-]*)*)(--.*)', re.MULTILINE)
 
 
 def _comment_repl(match):
@@ -996,7 +996,7 @@ def _comment_repl(match):
     Replace comment with equal amount of whitespace to make
     lexical position unaffected
     """
-    return match.group(1)
+    return match.group(1) + " "*len(match.group(2))
 
 
 def remove_comments(code):

--- a/vunit/vhdl_parser.py
+++ b/vunit/vhdl_parser.py
@@ -988,7 +988,7 @@ class VHDLReference(object):
         return self.name_within == "all"
 
 
-VHDL_REMOVE_COMMENT_RE = re.compile(r'--[^\n]*')
+VHDL_REMOVE_COMMENT_RE = re.compile(r'^([^\"\-]*(?:\"[^\"]*\"[^\"\-]*)*)--.*')
 
 
 def _comment_repl(match):
@@ -996,8 +996,7 @@ def _comment_repl(match):
     Replace comment with equal amount of whitespace to make
     lexical position unaffected
     """
-    text = match.group(0)
-    return " " * len(text)
+    return match.group(1)
 
 
 def remove_comments(code):


### PR DESCRIPTION
Changed regex for matching comments to not match when the `--` pattern is found in a string. This fixes #529.