### PR TITLE
fix docs egs

### DIFF
--- a/examples/verilog/uart/run.py
+++ b/examples/verilog/uart/run.py
@@ -15,16 +15,14 @@ usage on a typical module.
 from os.path import join, dirname
 from vunit.verilog import VUnit
 
+vu = VUnit.from_argv()
 
-if __name__ == '__main__':
-    ui = VUnit.from_argv()
+src_path = join(dirname(__file__), "src")
 
-    src_path = join(dirname(__file__), "src")
+uart_lib = vu.add_library("uart_lib")
+uart_lib.add_source_files(join(src_path, "*.sv"))
 
-    uart_lib = ui.add_library("uart_lib")
-    uart_lib.add_source_files(join(src_path, "*.sv"))
+tb_uart_lib = vu.add_library("tb_uart_lib")
+tb_uart_lib.add_source_files(join(src_path, "test", "*.sv"))
 
-    tb_uart_lib = ui.add_library("tb_uart_lib")
-    tb_uart_lib.add_source_files(join(src_path, "test", "*.sv"))
-
-    ui.main()
+vu.main()

--- a/examples/verilog/uart/run.py
+++ b/examples/verilog/uart/run.py
@@ -15,15 +15,16 @@ usage on a typical module.
 from os.path import join, dirname
 from vunit.verilog import VUnit
 
-ui = VUnit.from_argv()
-
-src_path = join(dirname(__file__), "src")
-
-uart_lib = ui.add_library("uart_lib")
-uart_lib.add_source_files(join(src_path, "*.sv"))
-
-tb_uart_lib = ui.add_library("tb_uart_lib")
-tb_uart_lib.add_source_files(join(src_path, "test", "*.sv"))
 
 if __name__ == '__main__':
+    ui = VUnit.from_argv()
+
+    src_path = join(dirname(__file__), "src")
+
+    uart_lib = ui.add_library("uart_lib")
+    uart_lib.add_source_files(join(src_path, "*.sv"))
+
+    tb_uart_lib = ui.add_library("tb_uart_lib")
+    tb_uart_lib.add_source_files(join(src_path, "test", "*.sv"))
+
     ui.main()

--- a/examples/verilog/user_guide/run.py
+++ b/examples/verilog/user_guide/run.py
@@ -17,9 +17,8 @@ from vunit.verilog import VUnit
 
 root = dirname(__file__)
 
-if __name__ == '__main__':
-    ui = VUnit.from_argv()
-    lib = ui.add_library("lib")
-    lib.add_source_files(join(root, "*.sv"))
+vu = VUnit.from_argv()
+lib = vu.add_library("lib")
+lib.add_source_files(join(root, "*.sv"))
 
-    ui.main()
+vu.main()

--- a/examples/verilog/user_guide/run.py
+++ b/examples/verilog/user_guide/run.py
@@ -17,9 +17,9 @@ from vunit.verilog import VUnit
 
 root = dirname(__file__)
 
-ui = VUnit.from_argv()
-lib = ui.add_library("lib")
-lib.add_source_files(join(root, "*.sv"))
-
 if __name__ == '__main__':
+    ui = VUnit.from_argv()
+    lib = ui.add_library("lib")
+    lib.add_source_files(join(root, "*.sv"))
+
     ui.main()

--- a/examples/verilog/verilog_ams/run.py
+++ b/examples/verilog/verilog_ams/run.py
@@ -9,10 +9,9 @@ from vunit.verilog import VUnit
 
 root = dirname(__file__)
 
-if __name__ == '__main__':
-    ui = VUnit.from_argv()
-    lib = ui.add_library("lib")
-    lib.add_source_files(join(root, "*.sv"))
-    lib.add_source_files(join(root, "*.vams")).set_compile_option("modelsim.vlog_flags", ["-ams"])
+vu = VUnit.from_argv()
+lib = vu.add_library("lib")
+lib.add_source_files(join(root, "*.sv"))
+lib.add_source_files(join(root, "*.vams")).set_compile_option("modelsim.vlog_flags", ["-ams"])
 
-    ui.main()
+vu.main()

--- a/examples/verilog/verilog_ams/run.py
+++ b/examples/verilog/verilog_ams/run.py
@@ -9,10 +9,10 @@ from vunit.verilog import VUnit
 
 root = dirname(__file__)
 
-ui = VUnit.from_argv()
-lib = ui.add_library("lib")
-lib.add_source_files(join(root, "*.sv"))
-lib.add_source_files(join(root, "*.vams")).set_compile_option("modelsim.vlog_flags", ["-ams"])
-
 if __name__ == '__main__':
+    ui = VUnit.from_argv()
+    lib = ui.add_library("lib")
+    lib.add_source_files(join(root, "*.sv"))
+    lib.add_source_files(join(root, "*.vams")).set_compile_option("modelsim.vlog_flags", ["-ams"])
+
     ui.main()

--- a/examples/vhdl/array/run.py
+++ b/examples/vhdl/array/run.py
@@ -18,12 +18,15 @@ from vunit import VUnit
 
 root = dirname(__file__)
 
-if __name__ == '__main__':
-    ui = VUnit.from_argv()
-    ui.add_osvvm()
-    ui.add_array_util()
-    lib = ui.add_library("lib")
-    lib.add_source_files(join(root, "src", "*.vhd"))
-    lib.add_source_files(join(root, "src", "test", "*.vhd"))
+vu = VUnit.from_argv()
+vu.add_osvvm()
+vu.add_array_util()
 
-    ui.main()
+src_path = join(dirname(__file__), 'src')
+
+vu.add_library('lib').add_source_files([
+    join(src_path, '*.vhd'),
+    join(src_path, 'test', '*.vhd')
+])
+
+vu.main()

--- a/examples/vhdl/array/run.py
+++ b/examples/vhdl/array/run.py
@@ -18,12 +18,12 @@ from vunit import VUnit
 
 root = dirname(__file__)
 
-ui = VUnit.from_argv()
-ui.add_osvvm()
-ui.add_array_util()
-lib = ui.add_library("lib")
-lib.add_source_files(join(root, "src", "*.vhd"))
-lib.add_source_files(join(root, "src", "test", "*.vhd"))
-
 if __name__ == '__main__':
+    ui = VUnit.from_argv()
+    ui.add_osvvm()
+    ui.add_array_util()
+    lib = ui.add_library("lib")
+    lib.add_source_files(join(root, "src", "*.vhd"))
+    lib.add_source_files(join(root, "src", "test", "*.vhd"))
+
     ui.main()

--- a/examples/vhdl/array_axis_vcs/run.py
+++ b/examples/vhdl/array_axis_vcs/run.py
@@ -23,17 +23,17 @@ from vunit import VUnit
 
 root = dirname(__file__)
 
-vu = VUnit.from_argv()
-
-vu.add_osvvm()
-vu.add_array_util()
-vu.add_verification_components()
-
-lib = vu.add_library("lib")
-lib.add_source_files(join(root, "src/*.vhd"))
-lib.add_source_files(join(root, "src/**/*.vhd"))
-
-# vu.set_sim_option('modelsim.init_files.after_load',['runall_addwave.do'])
-
 if __name__ == '__main__':
+    vu = VUnit.from_argv()
+
+    vu.add_osvvm()
+    vu.add_array_util()
+    vu.add_verification_components()
+
+    lib = vu.add_library("lib")
+    lib.add_source_files(join(root, "src/*.vhd"))
+    lib.add_source_files(join(root, "src/**/*.vhd"))
+
+    # vu.set_sim_option('modelsim.init_files.after_load',['runall_addwave.do'])
+
     vu.main()

--- a/examples/vhdl/array_axis_vcs/run.py
+++ b/examples/vhdl/array_axis_vcs/run.py
@@ -21,19 +21,19 @@ in subsection :ref:`Stream <stream_vci>` and in
 from os.path import join, dirname
 from vunit import VUnit
 
-root = dirname(__file__)
+vu = VUnit.from_argv()
 
-if __name__ == '__main__':
-    vu = VUnit.from_argv()
+vu.add_osvvm()
+vu.add_array_util()
+vu.add_verification_components()
 
-    vu.add_osvvm()
-    vu.add_array_util()
-    vu.add_verification_components()
+src_path = join(dirname(__file__), "src")
 
-    lib = vu.add_library("lib")
-    lib.add_source_files(join(root, "src/*.vhd"))
-    lib.add_source_files(join(root, "src/**/*.vhd"))
+vu.add_library("lib").add_source_files([
+    join(src_path, "*.vhd"),
+    join(src_path, "**", "*.vhd")
+])
 
-    # vu.set_sim_option('modelsim.init_files.after_load',['runall_addwave.do'])
+# vu.set_sim_option('modelsim.init_files.after_load',['runall_addwave.do'])
 
-    vu.main()
+vu.main()

--- a/examples/vhdl/axi_dma/run.py
+++ b/examples/vhdl/axi_dma/run.py
@@ -18,15 +18,15 @@ via AXI-lite.
 from os.path import join, dirname
 from vunit import VUnit
 
-if __name__ == '__main__':
-    ui = VUnit.from_argv()
-    ui.add_osvvm()
-    ui.add_verification_components()
+vu = VUnit.from_argv()
+vu.add_osvvm()
+vu.add_verification_components()
 
-    src_path = join(dirname(__file__), "src")
+src_path = join(dirname(__file__), "src")
 
-    axi_dma_lib = ui.add_library("axi_dma_lib")
-    axi_dma_lib.add_source_files(join(src_path, "*.vhd"))
-    axi_dma_lib.add_source_files(join(src_path, "test", "*.vhd"))
+vu.add_library("axi_dma_lib").add_source_files([
+    join(src_path, "*.vhd"),
+    join(src_path, "test", "*.vhd")
+])
 
-    ui.main()
+vu.main()

--- a/examples/vhdl/axi_dma/run.py
+++ b/examples/vhdl/axi_dma/run.py
@@ -18,15 +18,15 @@ via AXI-lite.
 from os.path import join, dirname
 from vunit import VUnit
 
-ui = VUnit.from_argv()
-ui.add_osvvm()
-ui.add_verification_components()
-
-src_path = join(dirname(__file__), "src")
-
-axi_dma_lib = ui.add_library("axi_dma_lib")
-axi_dma_lib.add_source_files(join(src_path, "*.vhd"))
-axi_dma_lib.add_source_files(join(src_path, "test", "*.vhd"))
-
 if __name__ == '__main__':
+    ui = VUnit.from_argv()
+    ui.add_osvvm()
+    ui.add_verification_components()
+
+    src_path = join(dirname(__file__), "src")
+
+    axi_dma_lib = ui.add_library("axi_dma_lib")
+    axi_dma_lib.add_source_files(join(src_path, "*.vhd"))
+    axi_dma_lib.add_source_files(join(src_path, "test", "*.vhd"))
+
     ui.main()

--- a/examples/vhdl/check/run.py
+++ b/examples/vhdl/check/run.py
@@ -14,18 +14,18 @@ Demonstrates the VUnit check library.
 from os.path import join, dirname
 from vunit import VUnit
 
-ui = VUnit.from_argv()
-
-# Enable location preprocessing but exclude all but check_false to make the example less bloated
-ui.enable_location_preprocessing(
-    exclude_subprograms=['debug', 'info', 'check', 'check_failed', 'check_true', 'check_implication',
-                         'check_stable', 'check_equal', 'check_not_unknown', 'check_zero_one_hot',
-                         'check_one_hot', 'check_next', 'check_sequence', 'check_relation'])
-
-ui.enable_check_preprocessing()
-
-lib = ui.add_library("lib")
-lib.add_source_files(join(dirname(__file__), "tb_example.vhd"))
-
 if __name__ == '__main__':
+    ui = VUnit.from_argv()
+
+    # Enable location preprocessing but exclude all but check_false to make the example less bloated
+    ui.enable_location_preprocessing(
+        exclude_subprograms=['debug', 'info', 'check', 'check_failed', 'check_true', 'check_implication',
+                             'check_stable', 'check_equal', 'check_not_unknown', 'check_zero_one_hot',
+                             'check_one_hot', 'check_next', 'check_sequence', 'check_relation'])
+
+    ui.enable_check_preprocessing()
+
+    lib = ui.add_library("lib")
+    lib.add_source_files(join(dirname(__file__), "tb_example.vhd"))
+
     ui.main()

--- a/examples/vhdl/check/run.py
+++ b/examples/vhdl/check/run.py
@@ -14,18 +14,16 @@ Demonstrates the VUnit check library.
 from os.path import join, dirname
 from vunit import VUnit
 
-if __name__ == '__main__':
-    ui = VUnit.from_argv()
+vu = VUnit.from_argv()
 
-    # Enable location preprocessing but exclude all but check_false to make the example less bloated
-    ui.enable_location_preprocessing(
-        exclude_subprograms=['debug', 'info', 'check', 'check_failed', 'check_true', 'check_implication',
-                             'check_stable', 'check_equal', 'check_not_unknown', 'check_zero_one_hot',
-                             'check_one_hot', 'check_next', 'check_sequence', 'check_relation'])
+# Enable location preprocessing but exclude all but check_false to make the example less bloated
+vu.enable_location_preprocessing(
+    exclude_subprograms=['debug', 'info', 'check', 'check_failed', 'check_true', 'check_implication',
+                         'check_stable', 'check_equal', 'check_not_unknown', 'check_zero_one_hot',
+                         'check_one_hot', 'check_next', 'check_sequence', 'check_relation'])
 
-    ui.enable_check_preprocessing()
+vu.enable_check_preprocessing()
 
-    lib = ui.add_library("lib")
-    lib.add_source_files(join(dirname(__file__), "tb_example.vhd"))
+vu.add_library("lib").add_source_files(join(dirname(__file__), "tb_example.vhd"))
 
-    ui.main()
+vu.main()

--- a/examples/vhdl/com/run.py
+++ b/examples/vhdl/com/run.py
@@ -16,16 +16,16 @@ can be found in the :ref:`com user guide <com_user_guide>`.
 from os.path import join, dirname
 from vunit import VUnit
 
-prj = VUnit.from_argv()
-prj.add_com()
-prj.add_verification_components()
-prj.add_osvvm()
-
-lib = prj.add_library('lib')
-lib.add_source_files(join(dirname(__file__), 'src', '*.vhd'))
-
-tb_lib = prj.add_library('tb_lib')
-tb_lib.add_source_files(join(dirname(__file__), 'test', '*.vhd'))
-
 if __name__ == '__main__':
+    prj = VUnit.from_argv()
+    prj.add_com()
+    prj.add_verification_components()
+    prj.add_osvvm()
+
+    lib = prj.add_library('lib')
+    lib.add_source_files(join(dirname(__file__), 'src', '*.vhd'))
+
+    tb_lib = prj.add_library('tb_lib')
+    tb_lib.add_source_files(join(dirname(__file__), 'test', '*.vhd'))
+
     prj.main()

--- a/examples/vhdl/com/run.py
+++ b/examples/vhdl/com/run.py
@@ -16,16 +16,12 @@ can be found in the :ref:`com user guide <com_user_guide>`.
 from os.path import join, dirname
 from vunit import VUnit
 
-if __name__ == '__main__':
-    prj = VUnit.from_argv()
-    prj.add_com()
-    prj.add_verification_components()
-    prj.add_osvvm()
+vu = VUnit.from_argv()
+vu.add_com()
+vu.add_verification_components()
+vu.add_osvvm()
 
-    lib = prj.add_library('lib')
-    lib.add_source_files(join(dirname(__file__), 'src', '*.vhd'))
+vu.add_library('lib').add_source_files(join(dirname(__file__), 'src', '*.vhd'))
+vu.add_library('tb_lib').add_source_files(join(dirname(__file__), 'test', '*.vhd'))
 
-    tb_lib = prj.add_library('tb_lib')
-    tb_lib.add_source_files(join(dirname(__file__), 'test', '*.vhd'))
-
-    prj.main()
+vu.main()

--- a/examples/vhdl/composite_generics/run.py
+++ b/examples/vhdl/composite_generics/run.py
@@ -14,24 +14,24 @@ See `Enable Your Simulator to Handle Complex Top-Level Generics <https://vunit.g
 from os.path import join, dirname
 from vunit import VUnit
 
-prj = VUnit.from_argv()
-
-tb_lib = prj.add_library('tb_lib')
-tb_lib.add_source_files(join(dirname(__file__), 'test', '*.vhd'))
-
-testbench = tb_lib.test_bench("tb_composite_generics")
-test_1 = testbench.test("Test 1")
-
-
-def encode(tb_cfg):
-    return ", ".join(["%s:%s" % (key, str(tb_cfg[key])) for key in tb_cfg])
-
-
-vga_tb_cfg = dict(image_width=640, image_height=480, dump_debug_data=False)
-test_1.add_config(name='VGA', generics=dict(encoded_tb_cfg=encode(vga_tb_cfg)))
-
-tiny_tb_cfg = dict(image_width=4, image_height=3, dump_debug_data=True)
-test_1.add_config(name='tiny', generics=dict(encoded_tb_cfg=encode(tiny_tb_cfg)))
-
 if __name__ == '__main__':
+    prj = VUnit.from_argv()
+
+    tb_lib = prj.add_library('tb_lib')
+    tb_lib.add_source_files(join(dirname(__file__), 'test', '*.vhd'))
+
+    testbench = tb_lib.test_bench("tb_composite_generics")
+    test_1 = testbench.test("Test 1")
+
+
+    def encode(tb_cfg):
+        return ", ".join(["%s:%s" % (key, str(tb_cfg[key])) for key in tb_cfg])
+
+
+    vga_tb_cfg = dict(image_width=640, image_height=480, dump_debug_data=False)
+    test_1.add_config(name='VGA', generics=dict(encoded_tb_cfg=encode(vga_tb_cfg)))
+
+    tiny_tb_cfg = dict(image_width=4, image_height=3, dump_debug_data=True)
+    test_1.add_config(name='tiny', generics=dict(encoded_tb_cfg=encode(tiny_tb_cfg)))
+
     prj.main()

--- a/examples/vhdl/composite_generics/run.py
+++ b/examples/vhdl/composite_generics/run.py
@@ -14,24 +14,22 @@ See `Enable Your Simulator to Handle Complex Top-Level Generics <https://vunit.g
 from os.path import join, dirname
 from vunit import VUnit
 
-if __name__ == '__main__':
-    prj = VUnit.from_argv()
 
-    tb_lib = prj.add_library('tb_lib')
-    tb_lib.add_source_files(join(dirname(__file__), 'test', '*.vhd'))
-
-    testbench = tb_lib.test_bench("tb_composite_generics")
-    test_1 = testbench.test("Test 1")
+def encode(tb_cfg):
+    return ", ".join(["%s:%s" % (key, str(tb_cfg[key])) for key in tb_cfg])
 
 
-    def encode(tb_cfg):
-        return ", ".join(["%s:%s" % (key, str(tb_cfg[key])) for key in tb_cfg])
+vu = VUnit.from_argv()
 
+tb_lib = vu.add_library('tb_lib')
+tb_lib.add_source_files(join(dirname(__file__), 'test', '*.vhd'))
 
-    vga_tb_cfg = dict(image_width=640, image_height=480, dump_debug_data=False)
-    test_1.add_config(name='VGA', generics=dict(encoded_tb_cfg=encode(vga_tb_cfg)))
+test_1 = tb_lib.test_bench("tb_composite_generics").test("Test 1")
 
-    tiny_tb_cfg = dict(image_width=4, image_height=3, dump_debug_data=True)
-    test_1.add_config(name='tiny', generics=dict(encoded_tb_cfg=encode(tiny_tb_cfg)))
+vga_tb_cfg = dict(image_width=640, image_height=480, dump_debug_data=False)
+test_1.add_config(name='VGA', generics=dict(encoded_tb_cfg=encode(vga_tb_cfg)))
 
-    prj.main()
+tiny_tb_cfg = dict(image_width=4, image_height=3, dump_debug_data=True)
+test_1.add_config(name='tiny', generics=dict(encoded_tb_cfg=encode(tiny_tb_cfg)))
+
+vu.main()

--- a/examples/vhdl/coverage/run.py
+++ b/examples/vhdl/coverage/run.py
@@ -7,20 +7,20 @@
 from os.path import join, dirname
 from vunit import VUnit
 
-root = dirname(__file__)
 
-if __name__ == '__main__':
-    ui = VUnit.from_argv()
-    lib = ui.add_library("lib")
-    lib.add_source_files(join(root, "*.vhd"))
+def post_run(results):
+    results.merge_coverage(file_name="coverage_data")
 
-    lib.set_compile_option("rivierapro.vcom_flags", ["-coverage", "bs"])
-    lib.set_compile_option("rivierapro.vlog_flags", ["-coverage", "bs"])
-    lib.set_compile_option("modelsim.vcom_flags", ["+cover=bs"])
-    lib.set_compile_option("modelsim.vlog_flags", ["+cover=bs"])
-    lib.set_sim_option("enable_coverage", True)
 
-    def post_run(results):
-        results.merge_coverage(file_name="coverage_data")
+vu = VUnit.from_argv()
 
-    ui.main(post_run=post_run)
+lib = vu.add_library("lib")
+lib.add_source_files(join(dirname(__file__), "*.vhd"))
+
+lib.set_compile_option("rivierapro.vcom_flags", ["-coverage", "bs"])
+lib.set_compile_option("rivierapro.vlog_flags", ["-coverage", "bs"])
+lib.set_compile_option("modelsim.vcom_flags", ["+cover=bs"])
+lib.set_compile_option("modelsim.vlog_flags", ["+cover=bs"])
+lib.set_sim_option("enable_coverage", True)
+
+vu.main(post_run=post_run)

--- a/examples/vhdl/coverage/run.py
+++ b/examples/vhdl/coverage/run.py
@@ -9,18 +9,18 @@ from vunit import VUnit
 
 root = dirname(__file__)
 
-ui = VUnit.from_argv()
-lib = ui.add_library("lib")
-lib.add_source_files(join(root, "*.vhd"))
-
-lib.set_compile_option("rivierapro.vcom_flags", ["-coverage", "bs"])
-lib.set_compile_option("rivierapro.vlog_flags", ["-coverage", "bs"])
-lib.set_compile_option("modelsim.vcom_flags", ["+cover=bs"])
-lib.set_compile_option("modelsim.vlog_flags", ["+cover=bs"])
-lib.set_sim_option("enable_coverage", True)
-
-def post_run(results):
-    results.merge_coverage(file_name="coverage_data")
-
 if __name__ == '__main__':
+    ui = VUnit.from_argv()
+    lib = ui.add_library("lib")
+    lib.add_source_files(join(root, "*.vhd"))
+
+    lib.set_compile_option("rivierapro.vcom_flags", ["-coverage", "bs"])
+    lib.set_compile_option("rivierapro.vlog_flags", ["-coverage", "bs"])
+    lib.set_compile_option("modelsim.vcom_flags", ["+cover=bs"])
+    lib.set_compile_option("modelsim.vlog_flags", ["+cover=bs"])
+    lib.set_sim_option("enable_coverage", True)
+
+    def post_run(results):
+        results.merge_coverage(file_name="coverage_data")
+
     ui.main(post_run=post_run)

--- a/examples/vhdl/generate_tests/run.py
+++ b/examples/vhdl/generate_tests/run.py
@@ -54,32 +54,33 @@ def generate_tests(obj, signs, data_widths):
         config_name = "data_width=%i,sign=%s" % (data_width, sign)
 
         # Add the configuration with a post check function to verify the output
-        obj.add_config(name=config_name,
-                       generics=dict(
-                           data_width=data_width,
-                           sign=sign),
-                       post_check=make_post_check(data_width, sign))
+        obj.add_config(
+            name=config_name,
+            generics=dict(
+                data_width=data_width,
+                sign=sign),
+            post_check=make_post_check(data_width, sign)
+        )
 
 
 test_path = join(dirname(__file__), "test")
 
-if __name__ == '__main__':
-    ui = VUnit.from_argv()
-    lib = ui.add_library("lib")
-    lib.add_source_files(join(test_path, "*.vhd"))
+vu = VUnit.from_argv()
+lib = vu.add_library("lib")
+lib.add_source_files(join(test_path, "*.vhd"))
 
-    tb_generated = lib.test_bench("tb_generated")
+tb_generated = lib.test_bench("tb_generated")
 
-    # Just set a generic for all configurations within the test bench
-    tb_generated.set_generic("message", "set-for-entity")
+# Just set a generic for all configurations within the test bench
+tb_generated.set_generic("message", "set-for-entity")
 
-    for test in tb_generated.get_tests():
-        if test.name == "Test 2":
-            # Test 2 should only be run with signed width of 16
-            generate_tests(test, [True], [16])
-            test.set_generic("message", "set-for-test")
-        else:
-            # Run all other tests with signed/unsigned and data width in range [1,5[
-            generate_tests(test, [False, True], range(1, 5))
+for test in tb_generated.get_tests():
+    if test.name == "Test 2":
+        # Test 2 should only be run with signed width of 16
+        generate_tests(test, [True], [16])
+        test.set_generic("message", "set-for-test")
+    else:
+        # Run all other tests with signed/unsigned and data width in range [1,5[
+        generate_tests(test, [False, True], range(1, 5))
 
-    ui.main()
+vu.main()

--- a/examples/vhdl/generate_tests/run.py
+++ b/examples/vhdl/generate_tests/run.py
@@ -63,23 +63,23 @@ def generate_tests(obj, signs, data_widths):
 
 test_path = join(dirname(__file__), "test")
 
-ui = VUnit.from_argv()
-lib = ui.add_library("lib")
-lib.add_source_files(join(test_path, "*.vhd"))
-
-tb_generated = lib.test_bench("tb_generated")
-
-# Just set a generic for all configurations within the test bench
-tb_generated.set_generic("message", "set-for-entity")
-
-for test in tb_generated.get_tests():
-    if test.name == "Test 2":
-        # Test 2 should only be run with signed width of 16
-        generate_tests(test, [True], [16])
-        test.set_generic("message", "set-for-test")
-    else:
-        # Run all other tests with signed/unsigned and data width in range [1,5[
-        generate_tests(test, [False, True], range(1, 5))
-
 if __name__ == '__main__':
+    ui = VUnit.from_argv()
+    lib = ui.add_library("lib")
+    lib.add_source_files(join(test_path, "*.vhd"))
+
+    tb_generated = lib.test_bench("tb_generated")
+
+    # Just set a generic for all configurations within the test bench
+    tb_generated.set_generic("message", "set-for-entity")
+
+    for test in tb_generated.get_tests():
+        if test.name == "Test 2":
+            # Test 2 should only be run with signed width of 16
+            generate_tests(test, [True], [16])
+            test.set_generic("message", "set-for-test")
+        else:
+            # Run all other tests with signed/unsigned and data width in range [1,5[
+            generate_tests(test, [False, True], range(1, 5))
+
     ui.main()

--- a/examples/vhdl/json4vhdl/run.py
+++ b/examples/vhdl/json4vhdl/run.py
@@ -18,16 +18,13 @@ from vunit import VUnit, read_json, encode_json
 
 root = dirname(__file__)
 
-if __name__ == '__main__':
-    vu = VUnit.from_argv()
+vu = VUnit.from_argv()
+vu.add_json4vhdl()
 
-    vu.add_json4vhdl()
+vu.add_library("test").add_source_files(join(root, "src/test/*.vhd"))
 
-    lib = vu.add_library("test")
-    lib.add_source_files(join(root, "src/test/*.vhd"))
+tb_cfg = read_json(join(root, "src/test/data/data.json"))
+tb_cfg["dump_debug_data"]=False
+vu.set_generic("tb_cfg", encode_json(tb_cfg))
 
-    tb_cfg = read_json(join(root, "src/test/data/data.json"))
-    tb_cfg["dump_debug_data"]=False
-    vu.set_generic("tb_cfg", encode_json(tb_cfg))
-
-    vu.main()
+vu.main()

--- a/examples/vhdl/json4vhdl/run.py
+++ b/examples/vhdl/json4vhdl/run.py
@@ -18,16 +18,16 @@ from vunit import VUnit, read_json, encode_json
 
 root = dirname(__file__)
 
-vu = VUnit.from_argv()
-
-vu.add_json4vhdl()
-
-lib = vu.add_library("test")
-lib.add_source_files(join(root, "src/test/*.vhd"))
-
-tb_cfg = read_json(join(root, "src/test/data/data.json"))
-tb_cfg["dump_debug_data"]=False
-vu.set_generic("tb_cfg", encode_json(tb_cfg))
-
 if __name__ == '__main__':
+    vu = VUnit.from_argv()
+
+    vu.add_json4vhdl()
+
+    lib = vu.add_library("test")
+    lib.add_source_files(join(root, "src/test/*.vhd"))
+
+    tb_cfg = read_json(join(root, "src/test/data/data.json"))
+    tb_cfg["dump_debug_data"]=False
+    vu.set_generic("tb_cfg", encode_json(tb_cfg))
+
     vu.main()

--- a/examples/vhdl/logging/run.py
+++ b/examples/vhdl/logging/run.py
@@ -14,9 +14,9 @@ Demonstrates VUnit's support for logging.
 from os.path import join, dirname
 from vunit import VUnit
 
-ui = VUnit.from_argv()
-lib = ui.add_library("lib")
-lib.add_source_files(join(dirname(__file__), "*.vhd"))
-
 if __name__ == '__main__':
+    ui = VUnit.from_argv()
+    lib = ui.add_library("lib")
+    lib.add_source_files(join(dirname(__file__), "*.vhd"))
+
     ui.main()

--- a/examples/vhdl/logging/run.py
+++ b/examples/vhdl/logging/run.py
@@ -14,9 +14,7 @@ Demonstrates VUnit's support for logging.
 from os.path import join, dirname
 from vunit import VUnit
 
-if __name__ == '__main__':
-    ui = VUnit.from_argv()
-    lib = ui.add_library("lib")
-    lib.add_source_files(join(dirname(__file__), "*.vhd"))
+vu = VUnit.from_argv()
+vu.add_library("lib").add_source_files(join(dirname(__file__), "*.vhd"))
 
-    ui.main()
+vu.main()

--- a/examples/vhdl/run/run.py
+++ b/examples/vhdl/run/run.py
@@ -16,11 +16,11 @@ from vunit import VUnit
 
 root = dirname(__file__)
 
-ui = VUnit.from_argv()
-lib = ui.add_library("lib")
-lib.add_source_files(join(root, "*.vhd"))
-tb_with_lower_level_control = lib.entity("tb_with_lower_level_control")
-tb_with_lower_level_control.scan_tests_from_file(join(root, "test_control.vhd"))
-
 if __name__ == '__main__':
+    ui = VUnit.from_argv()
+    lib = ui.add_library("lib")
+    lib.add_source_files(join(root, "*.vhd"))
+    tb_with_lower_level_control = lib.entity("tb_with_lower_level_control")
+    tb_with_lower_level_control.scan_tests_from_file(join(root, "test_control.vhd"))
+
     ui.main()

--- a/examples/vhdl/run/run.py
+++ b/examples/vhdl/run/run.py
@@ -16,11 +16,11 @@ from vunit import VUnit
 
 root = dirname(__file__)
 
-if __name__ == '__main__':
-    ui = VUnit.from_argv()
-    lib = ui.add_library("lib")
-    lib.add_source_files(join(root, "*.vhd"))
-    tb_with_lower_level_control = lib.entity("tb_with_lower_level_control")
-    tb_with_lower_level_control.scan_tests_from_file(join(root, "test_control.vhd"))
+vu = VUnit.from_argv()
 
-    ui.main()
+lib = vu.add_library("lib")
+lib.add_source_files(join(root, "*.vhd"))
+tb_with_lower_level_control = lib.entity("tb_with_lower_level_control")
+tb_with_lower_level_control.scan_tests_from_file(join(root, "test_control.vhd"))
+
+vu.main()

--- a/examples/vhdl/third_party_integration/run.py
+++ b/examples/vhdl/third_party_integration/run.py
@@ -8,10 +8,11 @@ from os.path import join, dirname
 from vunit import VUnit
 
 root = dirname(__file__)
-ui = VUnit.from_argv()
-
-lib = ui.add_library("lib")
-lib.add_source_files(join(root, 'test', '*.vhd'))
 
 if __name__ == '__main__':
+    ui = VUnit.from_argv()
+
+    lib = ui.add_library("lib")
+    lib.add_source_files(join(root, 'test', '*.vhd'))
+
     ui.main()

--- a/examples/vhdl/third_party_integration/run.py
+++ b/examples/vhdl/third_party_integration/run.py
@@ -7,12 +7,6 @@
 from os.path import join, dirname
 from vunit import VUnit
 
-root = dirname(__file__)
-
-if __name__ == '__main__':
-    ui = VUnit.from_argv()
-
-    lib = ui.add_library("lib")
-    lib.add_source_files(join(root, 'test', '*.vhd'))
-
-    ui.main()
+vu = VUnit.from_argv()
+vu.add_library("lib").add_source_files(join(dirname(__file__), 'test', '*.vhd'))
+vu.main()

--- a/examples/vhdl/uart/run.py
+++ b/examples/vhdl/uart/run.py
@@ -15,17 +15,13 @@ typical module.
 from os.path import join, dirname
 from vunit import VUnit
 
-if __name__ == '__main__':
-    ui = VUnit.from_argv()
-    ui.add_osvvm()
-    ui.add_verification_components()
+vu = VUnit.from_argv()
+vu.add_osvvm()
+vu.add_verification_components()
 
-    src_path = join(dirname(__file__), "src")
+src_path = join(dirname(__file__), "src")
 
-    uart_lib = ui.add_library("uart_lib")
-    uart_lib.add_source_files(join(src_path, "*.vhd"))
+vu.add_library("uart_lib").add_source_files(join(src_path, "*.vhd"))
+vu.add_library("tb_uart_lib").add_source_files(join(src_path, "test", "*.vhd"))
 
-    tb_uart_lib = ui.add_library("tb_uart_lib")
-    tb_uart_lib.add_source_files(join(src_path, "test", "*.vhd"))
-
-    ui.main()
+vu.main()

--- a/examples/vhdl/uart/run.py
+++ b/examples/vhdl/uart/run.py
@@ -15,17 +15,17 @@ typical module.
 from os.path import join, dirname
 from vunit import VUnit
 
-ui = VUnit.from_argv()
-ui.add_osvvm()
-ui.add_verification_components()
-
-src_path = join(dirname(__file__), "src")
-
-uart_lib = ui.add_library("uart_lib")
-uart_lib.add_source_files(join(src_path, "*.vhd"))
-
-tb_uart_lib = ui.add_library("tb_uart_lib")
-tb_uart_lib.add_source_files(join(src_path, "test", "*.vhd"))
-
 if __name__ == '__main__':
+    ui = VUnit.from_argv()
+    ui.add_osvvm()
+    ui.add_verification_components()
+
+    src_path = join(dirname(__file__), "src")
+
+    uart_lib = ui.add_library("uart_lib")
+    uart_lib.add_source_files(join(src_path, "*.vhd"))
+
+    tb_uart_lib = ui.add_library("tb_uart_lib")
+    tb_uart_lib.add_source_files(join(src_path, "test", "*.vhd"))
+
     ui.main()

--- a/examples/vhdl/user_guide/run.py
+++ b/examples/vhdl/user_guide/run.py
@@ -15,11 +15,6 @@ The most minimal VUnit VHDL project covering the basics of the
 from os.path import join, dirname
 from vunit import VUnit
 
-root = dirname(__file__)
-
-if __name__ == '__main__':
-    ui = VUnit.from_argv()
-    lib = ui.add_library("lib")
-    lib.add_source_files(join(root, "*.vhd"))
-
-    ui.main()
+vu = VUnit.from_argv()
+vu.add_library("lib").add_source_files(join(dirname(__file__), "*.vhd"))
+vu.main()

--- a/examples/vhdl/user_guide/run.py
+++ b/examples/vhdl/user_guide/run.py
@@ -17,9 +17,9 @@ from vunit import VUnit
 
 root = dirname(__file__)
 
-ui = VUnit.from_argv()
-lib = ui.add_library("lib")
-lib.add_source_files(join(root, "*.vhd"))
-
 if __name__ == '__main__':
+    ui = VUnit.from_argv()
+    lib = ui.add_library("lib")
+    lib.add_source_files(join(root, "*.vhd"))
+
     ui.main()

--- a/examples/vhdl/vivado/run.py
+++ b/examples/vhdl/vivado/run.py
@@ -17,20 +17,17 @@ from vunit import VUnit
 from vivado_util import add_vivado_ip
 
 root = dirname(__file__)
+src_path = join(root, "src")
 
-if __name__ == '__main__':
-    ui = VUnit.from_argv()
+vu = VUnit.from_argv()
 
-    src_path = join(root, "src")
+vu.add_library("lib").add_source_files(join(src_path, "*.vhd"))
+vu.add_library("tb_lib").add_source_files(join(src_path, "test", "*.vhd"))
 
-    lib = ui.add_library("lib")
-    lib.add_source_files(join(src_path, "*.vhd"))
+add_vivado_ip(
+    vu,
+    output_path=join(root, "vivado_libs"),
+    project_file=join(root, "myproject", "myproject.xpr")
+)
 
-    tb_lib = ui.add_library("tb_lib")
-    tb_lib.add_source_files(join(src_path, "test", "*.vhd"))
-
-    add_vivado_ip(ui,
-                  output_path=join(root, "vivado_libs"),
-                  project_file=join(root, "myproject", "myproject.xpr"))
-
-    ui.main()
+vu.main()

--- a/examples/vhdl/vivado/run.py
+++ b/examples/vhdl/vivado/run.py
@@ -16,18 +16,19 @@ from os.path import join, dirname
 from vunit import VUnit
 from vivado_util import add_vivado_ip
 
-ui = VUnit.from_argv()
-
 root = dirname(__file__)
-src_path = join(root, "src")
-
-lib = ui.add_library("lib")
-lib.add_source_files(join(src_path, "*.vhd"))
-
-tb_lib = ui.add_library("tb_lib")
-tb_lib.add_source_files(join(src_path, "test", "*.vhd"))
 
 if __name__ == '__main__':
+    ui = VUnit.from_argv()
+
+    src_path = join(root, "src")
+
+    lib = ui.add_library("lib")
+    lib.add_source_files(join(src_path, "*.vhd"))
+
+    tb_lib = ui.add_library("tb_lib")
+    tb_lib.add_source_files(join(src_path, "test", "*.vhd"))
+
     add_vivado_ip(ui,
                   output_path=join(root, "vivado_libs"),
                   project_file=join(root, "myproject", "myproject.xpr"))

--- a/tools/docs_utils.py
+++ b/tools/docs_utils.py
@@ -8,9 +8,11 @@
 Helper functions to generate examples.rst from docstrings in run.py files
 """
 
+from __future__ import print_function
+
 import sys
 import inspect
-from os.path import join, dirname, isdir
+from os.path import basename, dirname, isdir, isfile, join
 from os import listdir
 
 
@@ -38,16 +40,23 @@ def examples():
         for item in listdir(join(eg_path, subdir)):
             loc = join(eg_path, subdir, item)
             if isdir(loc):
-                egs_fptr.write(_get_eg_doc(
+                _data = _get_eg_doc(
                     loc,
                     'https://github.com/VUnit/vunit/tree/master/examples/%s/%s' % (subdir, item)
-                ))
+                )
+                if _data:
+                    egs_fptr.write(_data)
 
 
 def _get_eg_doc(location, ref):
     """
     Reads the docstring from a run.py file and rewrites the title to make it a ref
     """
+    if not isfile(join(location, 'run.py')):
+        print("Example subdir '" + basename(location) + "' does not contain a 'run.py' file. Skipping...")
+        return None
+
+    print("Extracting docs from '" + basename(location) + "'...")
     sys.path.append(location)
     import run  # pylint: disable=import-error
     vc_doc = inspect.getdoc(run)


### PR DESCRIPTION
This PR ensures that `VUnit.from_argv()` is not executed when `run.py` scripts are sourced to generate the docs (examples). Moreover, function `docs_utils` is fixed to ignore subdirs of `examples/**/` that do not have a `run-py` file.