### PR TITLE
string_ptr: allow to set the initialization value for new_string_ptr, reallocate, resize

### DIFF
--- a/vunit/vhdl/data_types/src/string_ptr_pkg-body-200x.vhd
+++ b/vunit/vhdl/data_types/src/string_ptr_pkg-body-200x.vhd
@@ -7,7 +7,8 @@
 package body string_ptr_pkg is
   type string_ptr_storage_t is protected
     impure function new_string_ptr (
-      length : natural := 0
+      length : natural := 0;
+      value  : val_t   := val_t'low
     ) return natural;
 
     procedure deallocate (
@@ -31,7 +32,8 @@ package body string_ptr_pkg is
 
     procedure reallocate (
       ref    : natural;
-      length : natural
+      length : natural;
+      value  : val_t := val_t'low
     );
 
     procedure reallocate (
@@ -42,7 +44,8 @@ package body string_ptr_pkg is
     procedure resize (
       ref    : natural;
       length : natural;
-      drop   : natural := 0
+      drop   : natural := 0;
+      value  : val_t   := val_t'low
     );
 
     impure function to_string (
@@ -55,7 +58,8 @@ package body string_ptr_pkg is
     variable ptrs : vava_t := null;
 
     impure function new_string_ptr (
-      length : natural := 0
+      length : natural := 0;
+      value  : val_t   := val_t'low
     ) return natural is
       variable old_ptrs : string_access_vector_access_t;
     begin
@@ -71,7 +75,7 @@ package body string_ptr_pkg is
         end loop;
         deallocate(old_ptrs);
       end if;
-      ptrs(current_index) := new string'(1 to length => val_t'low);
+      ptrs(current_index) := new string'(1 to length => value);
       current_index := current_index + 1;
       return current_index-1;
     end;
@@ -106,12 +110,13 @@ package body string_ptr_pkg is
 
     procedure reallocate (
       ref    : natural;
-      length : natural
+      length : natural;
+      value  : val_t := val_t'low
     ) is
       variable old_ptr, new_ptr : string_access_t;
     begin
       deallocate(ptrs(ref));
-      ptrs(ref) := new string'(1 to length => val_t'low);
+      ptrs(ref) := new string'(1 to length => value);
     end;
 
     procedure reallocate (
@@ -128,12 +133,13 @@ package body string_ptr_pkg is
     procedure resize (
       ref    : natural;
       length : natural;
-      drop   : natural := 0
+      drop   : natural := 0;
+      value  : val_t   := val_t'low
     ) is
       variable old_ptr, new_ptr : string_access_t;
       variable min_length : natural := length;
     begin
-      new_ptr := new string'(1 to length => val_t'low);
+      new_ptr := new string'(1 to length => value);
       old_ptr := ptrs(ref);
       if min_length > old_ptr'length - drop then
         min_length := old_ptr'length - drop;
@@ -169,9 +175,10 @@ package body string_ptr_pkg is
   end;
 
   impure function new_string_ptr (
-    length : natural := 0
+    length : natural := 0;
+    value  : val_t   := val_t'low
   ) return ptr_t is begin
-    return (ref => string_ptr_storage.new_string_ptr(length));
+    return (ref => string_ptr_storage.new_string_ptr(length, value));
   end;
 
   impure function new_string_ptr (
@@ -216,9 +223,10 @@ package body string_ptr_pkg is
 
   procedure reallocate (
     ptr : ptr_t;
-    length : natural
+    length : natural;
+    value  : val_t := val_t'low
   ) is begin
-    string_ptr_storage.reallocate(ptr.ref, length);
+    string_ptr_storage.reallocate(ptr.ref, length, value);
   end;
 
   procedure reallocate (
@@ -231,9 +239,10 @@ package body string_ptr_pkg is
   procedure resize (
     ptr    : ptr_t;
     length : natural;
-    drop   : natural := 0
+    drop   : natural := 0;
+    value  : val_t   := val_t'low
   ) is begin
-    string_ptr_storage.resize(ptr.ref, length, drop);
+    string_ptr_storage.resize(ptr.ref, length, drop, value);
   end;
 
   impure function to_string (

--- a/vunit/vhdl/data_types/src/string_ptr_pkg-body-93.vhd
+++ b/vunit/vhdl/data_types/src/string_ptr_pkg-body-93.vhd
@@ -9,7 +9,8 @@ package body string_ptr_pkg is
   shared variable ptrs : vava_t := null;
 
   impure function new_string_ptr (
-    length : natural := 0
+    length : natural := 0;
+    value  : val_t   := val_t'low
   ) return ptr_t is
     variable old_ptrs : vava_t;
     variable retval : ptr_t := (ref => current_index);
@@ -26,7 +27,7 @@ package body string_ptr_pkg is
       end loop;
       deallocate(old_ptrs);
     end if;
-    ptrs(current_index) := new string'(1 to length => val_t'low);
+    ptrs(current_index) := new string'(1 to length => value);
     current_index := current_index + 1;
     return retval;
   end;
@@ -61,12 +62,13 @@ package body string_ptr_pkg is
 
   procedure reallocate (
     ptr    : ptr_t;
-    length : natural
+    length : natural;
+    value  : val_t := val_t'low
   ) is
     variable old_ptr, new_ptr : string_access_t;
   begin
     deallocate(ptrs(ptr.ref));
-    ptrs(ptr.ref) := new string'(1 to length => val_t'low);
+    ptrs(ptr.ref) := new string'(1 to length => value);
   end;
 
   procedure reallocate (
@@ -83,12 +85,13 @@ package body string_ptr_pkg is
   procedure resize (
     ptr    : ptr_t;
     length : natural;
-    drop   : natural := 0
+    drop   : natural := 0;
+    value  : val_t   := val_t'low
   ) is
     variable old_ptr, new_ptr : string_access_t;
     variable min_length : natural := length;
   begin
-    new_ptr := new string'(1 to length => val_t'low);
+    new_ptr := new string'(1 to length => value);
     old_ptr := ptrs(ptr.ref);
     if min_length > old_ptr'length - drop then
       min_length := old_ptr'length - drop;

--- a/vunit/vhdl/data_types/src/string_ptr_pkg.vhd
+++ b/vunit/vhdl/data_types/src/string_ptr_pkg.vhd
@@ -36,7 +36,8 @@ package string_ptr_pkg is
   ) return ptr_t;
 
   impure function new_string_ptr (
-    length : natural := 0
+    length : natural := 0;
+    value  : val_t   := val_t'low
   ) return ptr_t;
 
   impure function new_string_ptr (
@@ -64,7 +65,8 @@ package string_ptr_pkg is
 
   procedure reallocate (
     ptr    : ptr_t;
-    length : natural
+    length : natural;
+    value  : val_t := val_t'low
   );
 
   procedure reallocate (
@@ -75,7 +77,8 @@ package string_ptr_pkg is
   procedure resize (
     ptr    : ptr_t;
     length : natural;
-    drop   : natural := 0
+    drop   : natural := 0;
+    value  : val_t := val_t'low
   );
 
   impure function to_string (


### PR DESCRIPTION
Currently, new_string_ptr, reallocate and resize procedures for string_ptr use `val_t'low` to initialize empty/unused position of the new vector. This PR allows to provide the value to be used as an option. To preserve backwards compatibility, `val_t'low` is the default of `value`.

Note that this feature is already implemented in integer_vector_ptr: https://github.com/VUnit/vunit/blob/master/vunit/vhdl/data_types/src/integer_vector_ptr_pkg.vhd#L64-L75