### PR TITLE
test_verilog_tokenizer: fix test_tokenizes_keywords

### DIFF
--- a/vunit/test/unit/test_verilog_tokenizer.py
+++ b/vunit/test/unit/test_verilog_tokenizer.py
@@ -117,17 +117,17 @@ there"''',
 
     def test_tokenizes_keywords(self):
         self.check("module",
-                   [MODULE(value='')])
+                   [MODULE(value='module')])
         self.check("endmodule",
-                   [ENDMODULE(value='')])
+                   [ENDMODULE(value='endmodule')])
         self.check("package",
-                   [PACKAGE(value='')])
+                   [PACKAGE(value='package')])
         self.check("endpackage",
-                   [ENDPACKAGE(value='')])
+                   [ENDPACKAGE(value='endpackage')])
         self.check("parameter",
-                   [PARAMETER(value='')])
+                   [PARAMETER(value='parameter')])
         self.check("import",
-                   [IMPORT(value='')])
+                   [IMPORT(value='import')])
 
     def test_has_location_information(self):
         self.check("`define foo", [


### PR DESCRIPTION
In this PR the `test_tokenizes_keywords` is fixed. It needs to adapted to the changes introduced in https://github.com/VUnit/vunit/commit/27c31f8228e8aecb0474f20ef1340d4573a09c8c.