### PR TITLE
Compile only required subset

### DIFF
--- a/vunit/project.py
+++ b/vunit/project.py
@@ -9,24 +9,18 @@
 """
 Functionality to represent and operate on a HDL code project
 """
-
-
-from os.path import join, basename, dirname, splitext, isdir, exists
-from copy import copy
-import traceback
+from os.path import join, basename, dirname, isdir, exists
 import logging
 from collections import OrderedDict
 from vunit.hashing import hash_string
 from vunit.dependency_graph import (DependencyGraph,
                                     CircularDependencyException)
-from vunit.vhdl_parser import VHDLParser, VHDLReference
-from vunit.cached import file_content_hash
+from vunit.vhdl_parser import VHDLParser
 from vunit.parsing.verilog.parser import VerilogParser
-from vunit.parsing.encodings import HDL_FILE_ENCODING
 from vunit.exceptions import CompileError
-from vunit.simulator_factory import SIMULATOR_FACTORY
-from vunit.design_unit import DesignUnit, VHDLDesignUnit, Entity, Module
 from vunit import ostools
+from vunit.source_file import (VERILOG_FILE_TYPES, VerilogSourceFile, VHDLSourceFile)
+
 LOGGER = logging.getLogger(__name__)
 
 
@@ -407,8 +401,10 @@ class Project(object):  # pylint: disable=too-many-instance-attributes
         target files.
         :param target_files: A list of SourceFiles
         """
+
         if target_files is None:
             target_files = self.get_source_files_in_order()
+
         dependency_graph = self.create_dependency_graph(implementation_dependencies)
         affected_files = self._get_affected_files(set(target_files), dependency_graph.get_dependencies)
         compile_order = self._get_compile_order(dependency_graph)
@@ -506,6 +502,7 @@ class Project(object):  # pylint: disable=too-many-instance-attributes
         new_content_hash = source_file.content_hash
         ostools.write_file(self._hash_file_name_of(source_file), new_content_hash)
         LOGGER.debug('Wrote %s content_hash=%s', source_file.name, new_content_hash)
+
 
 def _get_sorted_files(files, compile_order):
     """
@@ -690,323 +687,3 @@ class Library(object):  # pylint: disable=too-many-instance-attributes
 
     def __hash__(self):
         return hash(self.name)
-
-
-class SourceFile(object):
-    """
-    Represents a generic source file
-    """
-
-    def __init__(self, name, library, file_type):
-        self.name = name
-        self.library = library
-        self.file_type = file_type
-        self.design_units = []
-        self._content_hash = None
-        self._compile_options = {}
-
-        # The file name before preprocessing
-        self.original_name = name
-
-    @property
-    def is_vhdl(self):
-        return self.file_type == "vhdl"
-
-    @property
-    def is_system_verilog(self):
-        return self.file_type == "systemverilog"
-
-    @property
-    def is_any_verilog(self):
-        return self.file_type in VERILOG_FILE_TYPES
-
-    def __eq__(self, other):
-        if isinstance(other, type(self)):
-            return self.to_tuple() == other.to_tuple()
-
-        return False
-
-    def to_tuple(self):
-        return (self.name, self.library, self.file_type)
-
-    def __lt__(self, other):
-        return self.to_tuple() < other.to_tuple()
-
-    def __hash__(self):
-        return hash(self.to_tuple())
-
-    def __repr__(self):
-        return "SourceFile(%s, %s)" % (self.name, self.library.name)
-
-    def set_compile_option(self, name, value):
-        """
-        Set compile option
-        """
-        SIMULATOR_FACTORY.check_compile_option(name, value)
-        self._compile_options[name] = copy(value)
-
-    def add_compile_option(self, name, value):
-        """
-        Add compile option
-        """
-        SIMULATOR_FACTORY.check_compile_option(name, value)
-
-        if name not in self._compile_options:
-            self._compile_options[name] = copy(value)
-        else:
-            self._compile_options[name] += value
-
-    @property
-    def compile_options(self):
-        return self._compile_options
-
-    def get_compile_option(self, name):
-        """
-        Return a copy of the compile option list
-        """
-        SIMULATOR_FACTORY.check_compile_option_name(name)
-
-        if name not in self._compile_options:
-            self._compile_options[name] = []
-
-        return copy(self._compile_options[name])
-
-    def _compile_options_hash(self):
-        """
-        Compute hash of compile options
-
-        Needs to be updated if there are nested dictionaries
-        """
-        return hash_string(repr(sorted(self._compile_options.items())))
-
-    @property
-    def content_hash(self):
-        """
-        Compute hash of contents and compile options
-        """
-        return hash_string(self._content_hash + self._compile_options_hash())
-
-
-class VerilogSourceFile(SourceFile):
-    """
-    Represents a Verilog source file
-    """
-    def __init__(self,  # pylint: disable=too-many-arguments
-                 file_type, name, library, verilog_parser, database, include_dirs=None, defines=None, no_parse=False):
-        SourceFile.__init__(self, name, library, file_type)
-        self.package_dependencies = []
-        self.module_dependencies = []
-        self.include_dirs = include_dirs if include_dirs is not None else []
-        self.defines = defines.copy() if defines is not None else {}
-        self._content_hash = file_content_hash(self.name, encoding=HDL_FILE_ENCODING,
-                                               database=database)
-
-        for path in self.include_dirs:
-            self._content_hash = hash_string(self._content_hash + hash_string(path))
-
-        for key, value in sorted(self.defines.items()):
-            self._content_hash = hash_string(self._content_hash + hash_string(key))
-            self._content_hash = hash_string(self._content_hash + hash_string(value))
-
-        if not no_parse:
-            self.parse(verilog_parser, database, include_dirs)
-
-    def parse(self, parser, database, include_dirs):
-        """
-        Parse Verilog code and adding dependencies and design units
-        """
-        try:
-            design_file = parser.parse(self.name, include_dirs, self.defines)
-            for included_file_name in design_file.included_files:
-                self._content_hash = hash_string(self._content_hash
-                                                 + file_content_hash(included_file_name,
-                                                                     encoding=HDL_FILE_ENCODING,
-                                                                     database=database))
-
-            for module in design_file.modules:
-                self.design_units.append(Module(module.name, self, module.parameters))
-
-            for package in design_file.packages:
-                self.design_units.append(DesignUnit(package.name, self, "package"))
-
-            for package_name in design_file.imports:
-                self.package_dependencies.append(package_name)
-
-            for package_name in design_file.package_references:
-                self.package_dependencies.append(package_name)
-
-            for instance_name in design_file.instances:
-                self.module_dependencies.append(instance_name)
-
-        except KeyboardInterrupt:
-            raise KeyboardInterrupt
-        except:  # pylint: disable=bare-except
-            traceback.print_exc()
-            LOGGER.error("Failed to parse %s", self.name)
-
-    def add_to_library(self, library):
-        """
-        Add design units to the library
-        """
-        assert self.library == library
-        library.add_verilog_design_units(self.design_units)
-
-
-class VHDLSourceFile(SourceFile):
-    """
-    Represents a VHDL source file
-    """
-    def __init__(self,  # pylint: disable=too-many-arguments
-                 name, library, vhdl_parser, database, vhdl_standard, no_parse=False):
-        SourceFile.__init__(self, name, library, 'vhdl')
-        self.dependencies = []
-        self.depending_components = []
-        self._vhdl_standard = vhdl_standard
-        check_vhdl_standard(vhdl_standard)
-
-        if not no_parse:
-
-            try:
-                design_file = vhdl_parser.parse(self.name)
-            except KeyboardInterrupt:
-                raise KeyboardInterrupt
-            except:  # pylint: disable=bare-except
-                traceback.print_exc()
-                LOGGER.error("Failed to parse %s", self.name)
-            else:
-                self._add_design_file(design_file)
-
-        self._content_hash = file_content_hash(self.name,
-                                               encoding=HDL_FILE_ENCODING,
-                                               database=database)
-
-    def get_vhdl_standard(self):
-        """
-        Return the VHDL standard used to create this file
-        """
-        return self._vhdl_standard
-
-    def _add_design_file(self, design_file):
-        """
-        Parse VHDL code and adding dependencies and design units
-        """
-        self.design_units = self._find_design_units(design_file)
-        self.dependencies = self._find_dependencies(design_file)
-        self.depending_components = design_file.component_instantiations
-
-        for design_unit in self.design_units:
-            if design_unit.is_primary:
-                LOGGER.debug('Adding primary design unit (%s) %s', design_unit.unit_type, design_unit.name)
-            elif design_unit.unit_type == 'package body':
-                LOGGER.debug('Adding secondary design unit (package body) for package %s',
-                             design_unit.primary_design_unit)
-            else:
-                LOGGER.debug('Adding secondary design unit (%s) %s', design_unit.unit_type, design_unit.name)
-
-        if self.depending_components:
-            LOGGER.debug("The file '%s' has the following components:", self.name)
-            for component in self.depending_components:
-                LOGGER.debug(component)
-        else:
-            LOGGER.debug("The file '%s' has no components", self.name)
-
-    def _find_dependencies(self, design_file):
-        """
-        Return a list of dependencies of this source_file based on the
-        use clause and entity instantiations
-        """
-        # Find dependencies introduced by the use clause
-        result = []
-        for ref in design_file.references:
-            ref = ref.copy()
-
-            if ref.library == "work":
-                # Work means same library as current file
-                ref.library = self.library.name
-
-            result.append(ref)
-
-        for configuration in design_file.configurations:
-            result.append(VHDLReference('entity', self.library.name, configuration.entity, 'all'))
-
-        return result
-
-    def _find_design_units(self, design_file):
-        """
-        Return all design units found in the design_file
-        """
-        result = []
-        for entity in design_file.entities:
-            generic_names = [generic.identifier for generic in entity.generics]
-            result.append(Entity(entity.identifier, self, generic_names))
-
-        for context in design_file.contexts:
-            result.append(VHDLDesignUnit(context.identifier, self, 'context'))
-
-        for package in design_file.packages:
-            result.append(VHDLDesignUnit(package.identifier, self, 'package'))
-
-        for architecture in design_file.architectures:
-            result.append(VHDLDesignUnit(architecture.identifier, self, 'architecture', False, architecture.entity))
-
-        for configuration in design_file.configurations:
-            result.append(VHDLDesignUnit(configuration.identifier, self, 'configuration'))
-
-        for body in design_file.package_bodies:
-            result.append(VHDLDesignUnit(body.identifier,
-                                         self, 'package body', False, body.identifier))
-
-        return result
-
-    @property
-    def content_hash(self):
-        """
-        Compute hash of contents and compile options
-        """
-        return hash_string(self._content_hash + self._compile_options_hash() + hash_string(self._vhdl_standard))
-
-    def add_to_library(self, library):
-        """
-        Add design units to the library
-        """
-        assert self.library == library
-        library.add_vhdl_design_units(self.design_units)
-
-
-# lower case representation of supported extensions
-VHDL_EXTENSIONS = (".vhd", ".vhdl", ".vho")
-VERILOG_EXTENSIONS = (".v", ".vp", ".vams", ".vo")
-SYSTEM_VERILOG_EXTENSIONS = (".sv",)
-VERILOG_FILE_TYPES = ("verilog", "systemverilog")
-FILE_TYPES = ("vhdl", ) + VERILOG_FILE_TYPES
-
-
-def file_type_of(file_name):
-    """
-    Return the file type of file_name based on the file ending
-    """
-    _, ext = splitext(file_name)
-    if ext.lower() in VHDL_EXTENSIONS:
-        return "vhdl"
-
-    if ext.lower() in VERILOG_EXTENSIONS:
-        return "verilog"
-
-    if ext.lower() in SYSTEM_VERILOG_EXTENSIONS:
-        return "systemverilog"
-
-    raise RuntimeError("Unknown file ending '%s' of %s" % (ext, file_name))
-
-
-def check_vhdl_standard(vhdl_standard, from_str=None):
-    """
-    Check the VHDL standard selected is recognized
-    """
-    if from_str is None:
-        from_str = ""
-    else:
-        from_str += " "
-
-    valid_standards = ('93', '2002', '2008')
-    if vhdl_standard not in valid_standards:
-        raise ValueError("Unknown VHDL standard '%s' %snot one of %r" % (vhdl_standard, from_str, valid_standards))

--- a/vunit/project.py
+++ b/vunit/project.py
@@ -410,6 +410,27 @@ class Project(object):  # pylint: disable=too-many-instance-attributes
         compile_order = self._get_compile_order(dependency_graph)
         return _get_sorted_files(affected_files, compile_order)
 
+    def get_minimal_file_set_in_compile_order(self, target_files=None):
+        """
+        Get the minimal set of files to be compiled for a list of target files of type SourceFile
+        param: target_files: List of type SourceFile, if the paramater is None all files are used
+        """
+        ###
+        # First get all files that are required to fullfill the dependencies for the target files
+        dependency_graph = self.create_dependency_graph(True)
+        dependency_files = self._get_affected_files(target_files, dependency_graph.get_dependencies)
+
+        ###
+        # Now the file set is known, but it has to be evaluated which files
+        # realy have to be compiled according to their timestamp.
+        max_file_set_to_be_compiled = self.get_files_in_compile_order(incremental=True, files=dependency_files)
+
+        # get_files_in_compile_order returns more files than actually are in the
+        # list of dependent files. So the list is filtered for only the files
+        # that are required
+        min_file_set_to_be_compiled = [f for f in max_file_set_to_be_compiled if f in dependency_files]
+        return min_file_set_to_be_compiled
+
     def _get_affected_files(self, target_files, get_depend_func):
         """
         Get affected files given a  list of type SourceFile, if the list is None

--- a/vunit/simulator_interface.py
+++ b/vunit/simulator_interface.py
@@ -163,13 +163,14 @@ class SimulatorInterface(object):  # pylint: disable=too-many-public-methods
         Hook for the simulator interface to add simulator specific things to the project
         """
 
-    def compile_project(self, project, printer=NO_COLOR_PRINTER, continue_on_error=False):
+    def compile_project(self, project, printer=NO_COLOR_PRINTER, continue_on_error=False, target_files=None):
         """
         Compile the project
+        param: target_files: Given a list of SourceFiles only these and dependent files are compiled
         """
         self.add_simulator_specific(project)
         self.setup_library_mapping(project)
-        self.compile_source_files(project, printer, continue_on_error)
+        self.compile_source_files(project, printer, continue_on_error, target_files=target_files)
 
     def simulate(self, output_path, test_suite_name, config, elaborate_only):
         """
@@ -214,13 +215,19 @@ class SimulatorInterface(object):  # pylint: disable=too-many-public-methods
 
         return True
 
-    def compile_source_files(self, project, printer=NO_COLOR_PRINTER, continue_on_error=False):
+    def compile_source_files(self, project, printer=NO_COLOR_PRINTER, continue_on_error=False, target_files=None):
         """
         Use compile_source_file_command to compile all source_files
+        param: target_files: Given a list of SourceFiles only these and dependent files are compiled
         """
         dependency_graph = project.create_dependency_graph()
         failures = []
-        source_files = project.get_files_in_compile_order(dependency_graph=dependency_graph)
+
+        if target_files is None:
+            source_files = project.get_files_in_compile_order(dependency_graph=dependency_graph)
+        else:
+            source_files = project.get_minimal_file_set_in_compile_order(target_files)
+
         source_files_to_skip = set()
 
         max_library_name = 0

--- a/vunit/source_file.py
+++ b/vunit/source_file.py
@@ -1,0 +1,340 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+# Copyright (c) 2014-2019, Lars Asplund lars.anders.asplund@gmail.com
+
+"""
+Functionality to represent and operate on VHDL and Verilog source files
+"""
+from os.path import splitext
+import logging
+from copy import copy
+import traceback
+from vunit.simulator_factory import SIMULATOR_FACTORY
+from vunit.hashing import hash_string
+from vunit.vhdl_parser import VHDLReference
+from vunit.cached import file_content_hash
+from vunit.parsing.encodings import HDL_FILE_ENCODING
+from vunit.design_unit import DesignUnit, VHDLDesignUnit, Entity, Module
+LOGGER = logging.getLogger(__name__)
+
+
+class SourceFile(object):
+    """
+    Represents a generic source file
+    """
+
+    def __init__(self, name, library, file_type):
+        self.name = name
+        self.library = library
+        self.file_type = file_type
+        self.design_units = []
+        self._content_hash = None
+        self._compile_options = {}
+
+        # The file name before preprocessing
+        self.original_name = name
+
+    @property
+    def is_vhdl(self):
+        return self.file_type == "vhdl"
+
+    @property
+    def is_system_verilog(self):
+        return self.file_type == "systemverilog"
+
+    @property
+    def is_any_verilog(self):
+        return self.file_type in VERILOG_FILE_TYPES
+
+    def __eq__(self, other):
+        if isinstance(other, type(self)):
+            return self.to_tuple() == other.to_tuple()
+
+        return False
+
+    def to_tuple(self):
+        return (self.name, self.library, self.file_type)
+
+    def __lt__(self, other):
+        return self.to_tuple() < other.to_tuple()
+
+    def __hash__(self):
+        return hash(self.to_tuple())
+
+    def __repr__(self):
+        return "SourceFile(%s, %s)" % (self.name, self.library.name)
+
+    def set_compile_option(self, name, value):
+        """
+        Set compile option
+        """
+        SIMULATOR_FACTORY.check_compile_option(name, value)
+        self._compile_options[name] = copy(value)
+
+    def add_compile_option(self, name, value):
+        """
+        Add compile option
+        """
+        SIMULATOR_FACTORY.check_compile_option(name, value)
+
+        if name not in self._compile_options:
+            self._compile_options[name] = copy(value)
+        else:
+            self._compile_options[name] += value
+
+    @property
+    def compile_options(self):
+        return self._compile_options
+
+    def get_compile_option(self, name):
+        """
+        Return a copy of the compile option list
+        """
+        SIMULATOR_FACTORY.check_compile_option_name(name)
+
+        if name not in self._compile_options:
+            self._compile_options[name] = []
+
+        return copy(self._compile_options[name])
+
+    def _compile_options_hash(self):
+        """
+        Compute hash of compile options
+
+        Needs to be updated if there are nested dictionaries
+        """
+        return hash_string(repr(sorted(self._compile_options.items())))
+
+    @property
+    def content_hash(self):
+        """
+        Compute hash of contents and compile options
+        """
+        return hash_string(self._content_hash + self._compile_options_hash())
+
+
+class VerilogSourceFile(SourceFile):
+    """
+    Represents a Verilog source file
+    """
+    def __init__(self,  # pylint: disable=too-many-arguments
+                 file_type, name, library, verilog_parser, database, include_dirs=None, defines=None, no_parse=False):
+        SourceFile.__init__(self, name, library, file_type)
+        self.package_dependencies = []
+        self.module_dependencies = []
+        self.include_dirs = include_dirs if include_dirs is not None else []
+        self.defines = defines.copy() if defines is not None else {}
+        self._content_hash = file_content_hash(self.name, encoding=HDL_FILE_ENCODING,
+                                               database=database)
+
+        for path in self.include_dirs:
+            self._content_hash = hash_string(self._content_hash + hash_string(path))
+
+        for key, value in sorted(self.defines.items()):
+            self._content_hash = hash_string(self._content_hash + hash_string(key))
+            self._content_hash = hash_string(self._content_hash + hash_string(value))
+
+        if not no_parse:
+            self.parse(verilog_parser, database, include_dirs)
+
+    def parse(self, parser, database, include_dirs):
+        """
+        Parse Verilog code and adding dependencies and design units
+        """
+        try:
+            design_file = parser.parse(self.name, include_dirs, self.defines)
+            for included_file_name in design_file.included_files:
+                self._content_hash = hash_string(self._content_hash
+                                                 + file_content_hash(included_file_name,
+                                                                     encoding=HDL_FILE_ENCODING,
+                                                                     database=database))
+
+            for module in design_file.modules:
+                self.design_units.append(Module(module.name, self, module.parameters))
+
+            for package in design_file.packages:
+                self.design_units.append(DesignUnit(package.name, self, "package"))
+
+            for package_name in design_file.imports:
+                self.package_dependencies.append(package_name)
+
+            for package_name in design_file.package_references:
+                self.package_dependencies.append(package_name)
+
+            for instance_name in design_file.instances:
+                self.module_dependencies.append(instance_name)
+
+        except KeyboardInterrupt:
+            raise KeyboardInterrupt
+        except:  # pylint: disable=bare-except
+            traceback.print_exc()
+            LOGGER.error("Failed to parse %s", self.name)
+
+    def add_to_library(self, library):
+        """
+        Add design units to the library
+        """
+        assert self.library == library
+        library.add_verilog_design_units(self.design_units)
+
+
+class VHDLSourceFile(SourceFile):
+    """
+    Represents a VHDL source file
+    """
+    def __init__(self,  # pylint: disable=too-many-arguments
+                 name, library, vhdl_parser, database, vhdl_standard, no_parse=False):
+        SourceFile.__init__(self, name, library, 'vhdl')
+        self.dependencies = []
+        self.depending_components = []
+        self._vhdl_standard = vhdl_standard
+        check_vhdl_standard(vhdl_standard)
+
+        if not no_parse:
+
+            try:
+                design_file = vhdl_parser.parse(self.name)
+            except KeyboardInterrupt:
+                raise KeyboardInterrupt
+            except:  # pylint: disable=bare-except
+                traceback.print_exc()
+                LOGGER.error("Failed to parse %s", self.name)
+            else:
+                self._add_design_file(design_file)
+
+        self._content_hash = file_content_hash(self.name,
+                                               encoding=HDL_FILE_ENCODING,
+                                               database=database)
+
+    def get_vhdl_standard(self):
+        """
+        Return the VHDL standard used to create this file
+        """
+        return self._vhdl_standard
+
+    def _add_design_file(self, design_file):
+        """
+        Parse VHDL code and adding dependencies and design units
+        """
+        self.design_units = self._find_design_units(design_file)
+        self.dependencies = self._find_dependencies(design_file)
+        self.depending_components = design_file.component_instantiations
+
+        for design_unit in self.design_units:
+            if design_unit.is_primary:
+                LOGGER.debug('Adding primary design unit (%s) %s', design_unit.unit_type, design_unit.name)
+            elif design_unit.unit_type == 'package body':
+                LOGGER.debug('Adding secondary design unit (package body) for package %s',
+                             design_unit.primary_design_unit)
+            else:
+                LOGGER.debug('Adding secondary design unit (%s) %s', design_unit.unit_type, design_unit.name)
+
+        if self.depending_components:
+            LOGGER.debug("The file '%s' has the following components:", self.name)
+            for component in self.depending_components:
+                LOGGER.debug(component)
+        else:
+            LOGGER.debug("The file '%s' has no components", self.name)
+
+    def _find_dependencies(self, design_file):
+        """
+        Return a list of dependencies of this source_file based on the
+        use clause and entity instantiations
+        """
+        # Find dependencies introduced by the use clause
+        result = []
+        for ref in design_file.references:
+            ref = ref.copy()
+
+            if ref.library == "work":
+                # Work means same library as current file
+                ref.library = self.library.name
+
+            result.append(ref)
+
+        for configuration in design_file.configurations:
+            result.append(VHDLReference('entity', self.library.name, configuration.entity, 'all'))
+
+        return result
+
+    def _find_design_units(self, design_file):
+        """
+        Return all design units found in the design_file
+        """
+        result = []
+        for entity in design_file.entities:
+            generic_names = [generic.identifier for generic in entity.generics]
+            result.append(Entity(entity.identifier, self, generic_names))
+
+        for context in design_file.contexts:
+            result.append(VHDLDesignUnit(context.identifier, self, 'context'))
+
+        for package in design_file.packages:
+            result.append(VHDLDesignUnit(package.identifier, self, 'package'))
+
+        for architecture in design_file.architectures:
+            result.append(VHDLDesignUnit(architecture.identifier, self, 'architecture', False, architecture.entity))
+
+        for configuration in design_file.configurations:
+            result.append(VHDLDesignUnit(configuration.identifier, self, 'configuration'))
+
+        for body in design_file.package_bodies:
+            result.append(VHDLDesignUnit(body.identifier,
+                                         self, 'package body', False, body.identifier))
+
+        return result
+
+    @property
+    def content_hash(self):
+        """
+        Compute hash of contents and compile options
+        """
+        return hash_string(self._content_hash + self._compile_options_hash() + hash_string(self._vhdl_standard))
+
+    def add_to_library(self, library):
+        """
+        Add design units to the library
+        """
+        assert self.library == library
+        library.add_vhdl_design_units(self.design_units)
+
+
+# lower case representation of supported extensions
+VHDL_EXTENSIONS = (".vhd", ".vhdl", ".vho")
+VERILOG_EXTENSIONS = (".v", ".vp", ".vams", ".vo")
+SYSTEM_VERILOG_EXTENSIONS = (".sv",)
+VERILOG_FILE_TYPES = ("verilog", "systemverilog")
+FILE_TYPES = ("vhdl", ) + VERILOG_FILE_TYPES
+
+
+def file_type_of(file_name):
+    """
+    Return the file type of file_name based on the file ending
+    """
+    _, ext = splitext(file_name)
+    if ext.lower() in VHDL_EXTENSIONS:
+        return "vhdl"
+
+    if ext.lower() in VERILOG_EXTENSIONS:
+        return "verilog"
+
+    if ext.lower() in SYSTEM_VERILOG_EXTENSIONS:
+        return "systemverilog"
+
+    raise RuntimeError("Unknown file ending '%s' of %s" % (ext, file_name))
+
+
+def check_vhdl_standard(vhdl_standard, from_str=None):
+    """
+    Check the VHDL standard selected is recognized
+    """
+    if from_str is None:
+        from_str = ""
+    else:
+        from_str += " "
+
+    valid_standards = ('93', '2002', '2008')
+    if vhdl_standard not in valid_standards:
+        raise ValueError("Unknown VHDL standard '%s' %snot one of %r" % (vhdl_standard, from_str, valid_standards))

--- a/vunit/test/unit/test_project.py
+++ b/vunit/test/unit/test_project.py
@@ -20,7 +20,8 @@ import itertools
 from vunit.test.mock_2or3 import mock
 from vunit.exceptions import CompileError
 from vunit.ostools import renew_path, write_file
-from vunit.project import Project, file_type_of
+from vunit.project import Project
+from vunit.source_file import file_type_of
 
 
 class TestProject(unittest.TestCase):  # pylint: disable=too-many-public-methods
@@ -110,7 +111,7 @@ end package body;
         self.assert_has_package("file1.vhd", "foo")
         self.assert_has_package_body("file1.vhd", "foo")
 
-    @mock.patch("vunit.project.LOGGER")
+    @mock.patch("vunit.source_file.LOGGER")
     def test_recovers_from_parse_error(self, logger):
         self.project.add_library("lib", "work_path")
         source_file = self.add_source_file("lib", "file.vhd", """\

--- a/vunit/test/unit/test_test_bench.py
+++ b/vunit/test/unit/test_test_bench.py
@@ -453,8 +453,12 @@ if run("Test 2")
             self.assertEqual(set(item
                                  for test_suite in test_suites
                                  for item in test_suite.test_information.items()),
-                             set([("lib.tb_entity.Test 1", Test("Test 1", _file_location(file_name, 'Test 1'))),
-                                  ("lib.tb_entity.Test 2", Test("Test 2", _file_location(file_name, 'Test 2')))]))
+                             set([("lib.tb_entity.Test 1", Test("Test 1",
+                                                                _file_location(file_name, 'Test 1'),
+                                                                file_name)),
+                                  ("lib.tb_entity.Test 2", Test("Test 2",
+                                                                _file_location(file_name, 'Test 2'),
+                                                                file_name))]))
 
     @with_tempdir
     def test_fail_on_unknown_sim_option(self, tempdir):

--- a/vunit/test/unit/test_ui.py
+++ b/vunit/test/unit/test_ui.py
@@ -20,7 +20,7 @@ import re
 from re import MULTILINE
 from shutil import rmtree
 from vunit.ui import VUnit
-from vunit.project import VHDL_EXTENSIONS, VERILOG_EXTENSIONS
+from vunit.source_file import VHDL_EXTENSIONS, VERILOG_EXTENSIONS
 from vunit.test.mock_2or3 import mock
 from vunit.test.common import (set_env,
                                with_tempdir,

--- a/vunit/test_bench.py
+++ b/vunit/test_bench.py
@@ -20,7 +20,7 @@ from vunit.test_list import TestList
 from vunit.vhdl_parser import remove_comments as remove_vhdl_comments
 from vunit.test_suites import IndependentSimTestCase, SameSimTestSuite
 from vunit.parsing.encodings import HDL_FILE_ENCODING
-from vunit.project import file_type_of, VERILOG_FILE_TYPES
+from vunit.source_file import file_type_of, VERILOG_FILE_TYPES
 from vunit.configuration import Configuration, ConfigurationVisitor, DEFAULT_NAME
 
 

--- a/vunit/test_bench.py
+++ b/vunit/test_bench.py
@@ -32,11 +32,11 @@ class TestBench(ConfigurationVisitor):
     A VUnit test bench top level
     """
 
-    def __init__(self, design_unit, database=None):
+    def __init__(self, design_unit, database=None, source_file=None):
         ConfigurationVisitor.__init__(self)
         self.design_unit = design_unit
         self._database = database
-
+        self.source_file = source_file
         self._individual_tests = False
         self._configs = {}
         self._test_cases = []
@@ -281,10 +281,15 @@ class Test(object):
          Implicit tests are those when there are no tests in the test bench, just the test suite
     """
 
-    def __init__(self, name, location):
+    def __init__(self, name, location, file_name):
         self._name = name
         self._location = location
         self._attributes = []
+        self._file_name = file_name
+
+    @property
+    def file_name(self):
+        return self._file_name
 
     @property
     def name(self):
@@ -456,7 +461,7 @@ def _find_tests(code, file_name, line_offsets=None):
         suite_regexp = _RE_VHDL_TEST_SUITE
 
     tests = [Test(name=match.group("name"),
-                  location=FileLocation.from_match(file_name, match, "name", line_offsets))
+                  location=FileLocation.from_match(file_name, match, "name", line_offsets), file_name=file_name)
              for match in regexp.finditer(code)]
 
     _check_duplicate_tests(tests)
@@ -472,7 +477,7 @@ def _find_tests(code, file_name, line_offsets=None):
             location = FileLocation.from_line_offsets(file_name, 0, 0, line_offsets)
 
         tests = [Test(None,
-                      location=location)]
+                      location=location, file_name=file_name)]
 
     return tests
 

--- a/vunit/test_bench_list.py
+++ b/vunit/test_bench_list.py
@@ -34,7 +34,7 @@ class TestBenchList(object):
             if design_unit.is_entity or design_unit.is_module:
                 if tb_filter is None or tb_filter(design_unit):
                     if design_unit.is_module or design_unit.is_entity:
-                        self._add_test_bench(TestBench(design_unit, self._database))
+                        self._add_test_bench(TestBench(design_unit, self._database, source_file))
 
     def _add_test_bench(self, test_bench):
         """

--- a/vunit/test_list.py
+++ b/vunit/test_list.py
@@ -73,6 +73,10 @@ class TestSuiteWrapper(object):
         self._test_case = test_case
 
     @property
+    def file_name(self):
+        return self._test_case.file_name
+
+    @property
     def test_names(self):
         return [self._test_case.name]
 

--- a/vunit/test_suites.py
+++ b/vunit/test_suites.py
@@ -41,6 +41,10 @@ class IndependentSimTestCase(object):
                             test_cases=[test.name])
 
     @property
+    def file_name(self):
+        return self._test.file_name
+
+    @property
     def name(self):
         return self._name
 
@@ -86,6 +90,10 @@ class SameSimTestSuite(object):
                             elaborate_only=elaborate_only,
                             test_suite_name=self._name,
                             test_cases=[test.name for test in tests])
+
+    @property
+    def file_name(self):
+        return self._tests[0].file_name if self._tests else ""
 
     @property
     def test_names(self):

--- a/vunit/ui.py
+++ b/vunit/ui.py
@@ -1032,9 +1032,17 @@ avoid location preprocessing of other functions sharing name with a VUnit log or
         """
         Compile entire project
         """
+        # get test benches
+        if self._args.minimal:
+            test_list = self._create_tests(simulator_if)
+            tb_file_names = set([test_suite.file_name for test_suite in test_list])
+            target_files = [self.get_source_file(file_name).project_source_file for file_name in tb_file_names]
+        else:
+            target_files = None
+
         simulator_if.compile_project(self._project,
                                      continue_on_error=self._args.keep_compiling,
-                                     printer=self._printer)
+                                     printer=self._printer, target_files=target_files)
 
     def _run_test(self, test_cases, report):
         """
@@ -1887,6 +1895,10 @@ class SourceFile(object):
         self._source_file = source_file
         self._project = project
         self._ui = ui
+
+    @property
+    def project_source_file(self):
+        return self._source_file
 
     @property
     def name(self):

--- a/vunit/ui.py
+++ b/vunit/ui.py
@@ -259,11 +259,8 @@ from vunit.simulator_interface import (is_string_not_iterable,
                                        SimulatorInterface)
 from vunit.color_printer import (COLOR_PRINTER,
                                  NO_COLOR_PRINTER)
-from vunit.project import (Project,
-                           file_type_of,
-                           FILE_TYPES,
-                           VERILOG_FILE_TYPES,
-                           check_vhdl_standard)
+from vunit.project import Project
+from vunit.source_file import (file_type_of, FILE_TYPES, VERILOG_FILE_TYPES, check_vhdl_standard)
 from vunit.test_runner import TestRunner
 from vunit.test_report import TestReport
 from vunit.test_bench_list import TestBenchList

--- a/vunit/vunit_cli.py
+++ b/vunit/vunit_cli.py
@@ -110,6 +110,10 @@ def _create_argument_parser(description=None, for_documentation=False):
                         default=False,
                         help='Only compile project without running tests')
 
+    parser.add_argument('-m', '--minimal', action='store_true',
+                        default=False,
+                        help='Only compile files required for the (filtered) test benches')
+
     parser.add_argument('-k', '--keep-compiling', action='store_true',
                         default=False,
                         help='Continue compiling even after errors only skipping files that depend on failed files')


### PR DESCRIPTION
This introduces a new command line switch -m / --minimal 
Using this switch will allow to only compile the files that are required for running a given test bench, or a set of test benches, or a set of filtered test benches.