### PR TITLE
add possibility to configure random stalls for axi_stream

### DIFF
--- a/vunit/vhdl/verification_components/run.py
+++ b/vunit/vhdl/verification_components/run.py
@@ -134,9 +134,9 @@ for max_waits in [0, 8]:
 
 tb_axi_stream = lib.test_bench("tb_axi_stream")
 for test in tb_axi_stream.get_tests("test random stall on master"):
-    test.add_config(name="stall_master", generics=dict(g_stall_master=1))
+    test.add_config(name="stall_master", generics=dict(g_stall_master=30))
 
 for test in tb_axi_stream.get_tests("test random stall on slave"):
-    test.add_config(name="stall_slave", generics=dict(g_stall_slave=1))
+    test.add_config(name="stall_slave", generics=dict(g_stall_slave=30))
 
 ui.main()

--- a/vunit/vhdl/verification_components/run.py
+++ b/vunit/vhdl/verification_components/run.py
@@ -16,6 +16,7 @@ ui.add_verification_components()
 lib = ui.library("vunit_lib")
 lib.add_source_files(join(root, "test", "*.vhd"))
 
+
 def encode(tb_cfg):
     return ",".join(["%s:%s" % (key, str(tb_cfg[key])) for key in tb_cfg])
 
@@ -137,4 +138,5 @@ for test in tb_axi_stream.get_tests("test random stall on master"):
 
 for test in tb_axi_stream.get_tests("test random stall on slave"):
     test.add_config(name="stall_slave", generics=dict(g_stall_slave=1))
+
 ui.main()

--- a/vunit/vhdl/verification_components/run.py
+++ b/vunit/vhdl/verification_components/run.py
@@ -132,8 +132,12 @@ for max_waits in [0, 8]:
         name="max_waits=%d" % max_waits, generics=dict(max_waits=max_waits)
     )
 
-tb_axi_stream.test("test random stall on master").add_config(name="stall_master", generics=dict(g_stall_percentage_master=30))
+tb_axi_stream.test("test random stall on master").add_config(
+    name="stall_master", generics=dict(g_stall_percentage_master=30)
+)
 
-tb_axi_stream.test("test random stall on slave").add_config(name="stall_slave", generics=dict(g_stall_percentage_slave=30))
+tb_axi_stream.test("test random stall on slave").add_config(
+    name="stall_slave", generics=dict(g_stall_percentage_slave=30)
+)
 
 ui.main()

--- a/vunit/vhdl/verification_components/run.py
+++ b/vunit/vhdl/verification_components/run.py
@@ -132,11 +132,8 @@ for max_waits in [0, 8]:
         name="max_waits=%d" % max_waits, generics=dict(max_waits=max_waits)
     )
 
-tb_axi_stream = lib.test_bench("tb_axi_stream")
-for test in tb_axi_stream.get_tests("test random stall on master"):
-    test.add_config(name="stall_master", generics=dict(g_stall_percentage_master=30))
+tb_axi_stream.test("test random stall on master").add_config(name="stall_master", generics=dict(g_stall_percentage_master=30))
 
-for test in tb_axi_stream.get_tests("test random stall on slave"):
-    test.add_config(name="stall_slave", generics=dict(g_stall_percentage_slave=30))
+tb_axi_stream.test("test random stall on slave").add_config(name="stall_slave", generics=dict(g_stall_percentage_slave=30))
 
 ui.main()

--- a/vunit/vhdl/verification_components/run.py
+++ b/vunit/vhdl/verification_components/run.py
@@ -16,7 +16,6 @@ ui.add_verification_components()
 lib = ui.library("vunit_lib")
 lib.add_source_files(join(root, "test", "*.vhd"))
 
-
 def encode(tb_cfg):
     return ",".join(["%s:%s" % (key, str(tb_cfg[key])) for key in tb_cfg])
 
@@ -132,5 +131,10 @@ for max_waits in [0, 8]:
         name="max_waits=%d" % max_waits, generics=dict(max_waits=max_waits)
     )
 
+tb_axi_stream = lib.test_bench("tb_axi_stream")
+for test in tb_axi_stream.get_tests("test random stall on master"):
+    test.add_config(name="stall_master", generics=dict(g_stall_master=1))
 
+for test in tb_axi_stream.get_tests("test random stall on slave"):
+    test.add_config(name="stall_slave", generics=dict(g_stall_slave=1))
 ui.main()

--- a/vunit/vhdl/verification_components/run.py
+++ b/vunit/vhdl/verification_components/run.py
@@ -132,11 +132,11 @@ for max_waits in [0, 8]:
         name="max_waits=%d" % max_waits, generics=dict(max_waits=max_waits)
     )
 
-tb_axi_stream.test("test random stall on master").add_config(
+TB_AXI_STREAM.test("test random stall on master").add_config(
     name="stall_master", generics=dict(g_stall_percentage_master=30)
 )
 
-tb_axi_stream.test("test random stall on slave").add_config(
+TB_AXI_STREAM.test("test random stall on slave").add_config(
     name="stall_slave", generics=dict(g_stall_percentage_slave=30)
 )
 

--- a/vunit/vhdl/verification_components/run.py
+++ b/vunit/vhdl/verification_components/run.py
@@ -134,9 +134,9 @@ for max_waits in [0, 8]:
 
 tb_axi_stream = lib.test_bench("tb_axi_stream")
 for test in tb_axi_stream.get_tests("test random stall on master"):
-    test.add_config(name="stall_master", generics=dict(g_stall_master=30))
+    test.add_config(name="stall_master", generics=dict(g_stall_percentage_master=30))
 
 for test in tb_axi_stream.get_tests("test random stall on slave"):
-    test.add_config(name="stall_slave", generics=dict(g_stall_slave=30))
+    test.add_config(name="stall_slave", generics=dict(g_stall_percentage_slave=30))
 
 ui.main()

--- a/vunit/vhdl/verification_components/src/axi_stream_master.vhd
+++ b/vunit/vhdl/verification_components/src/axi_stream_master.vhd
@@ -46,6 +46,22 @@ architecture a of axi_stream_master is
   constant message_queue           : queue_t    := new_queue;
   signal   notify_bus_process_done : std_logic  := '0';
 
+  procedure drive_invalid_output(signal l_tdata : out std_logic_vector(data_length(master)-1 downto 0);
+                                 signal l_tkeep : out std_logic_vector(data_length(master)/8-1 downto 0);
+                                 signal l_tstrb : out std_logic_vector(data_length(master)/8-1 downto 0);
+                                 signal l_tid   : out std_logic_vector(id_length(master)-1 downto 0);
+                                 signal l_tdest : out std_logic_vector(dest_length(master)-1 downto 0);
+                                 signal l_tuser : out std_logic_vector(user_length(master)-1 downto 0))
+  is
+  begin
+    l_tdata <= (others => drive_invalid_val);
+    l_tkeep <= (others => drive_invalid_val);
+    l_tstrb <= (others => drive_invalid_val);
+    l_tid   <= (others => drive_invalid_val);
+    l_tdest <= (others => drive_invalid_val);
+    l_tuser <= (others => drive_invalid_val_user);
+  end procedure;
+
 begin
 
   main : process
@@ -78,12 +94,7 @@ begin
     rnd.InitSeed(rnd'instance_name);
     loop
       if drive_invalid then
-        tdata <= (others => drive_invalid_val);
-        tkeep <= (others => drive_invalid_val);
-        tstrb <= (others => drive_invalid_val);
-        tid   <= (others => drive_invalid_val);
-        tdest <= (others => drive_invalid_val);
-        tuser <= (others => drive_invalid_val_user);
+        drive_invalid_output(tdata, tkeep, tstrb, tid, tdest, tuser);
       end if;
 
       -- Wait for messages to arrive on the queue, posted by the process above
@@ -103,13 +114,7 @@ begin
           elsif msg_type = notify_request_msg then
             -- Ignore this message, but expect it
           elsif msg_type = stream_push_msg or msg_type = push_axi_stream_msg then
-
-            tdata <= (others => drive_invalid_val);
-            tkeep <= (others => drive_invalid_val);
-            tstrb <= (others => drive_invalid_val);
-            tid   <= (others => drive_invalid_val);
-            tdest <= (others => drive_invalid_val);
-            tuser <= (others => drive_invalid_val_user);
+            drive_invalid_output(tdata, tkeep, tstrb, tid, tdest, tuser);
             -- stall according to probability configuration
             probability_stall_axi_stream(aclk, master, rnd);
 

--- a/vunit/vhdl/verification_components/src/axi_stream_master.vhd
+++ b/vunit/vhdl/verification_components/src/axi_stream_master.vhd
@@ -15,7 +15,7 @@ use work.queue_pkg.all;
 use work.sync_pkg.all;
 
 library osvvm;
-use osvvm.RandomPkg.all;
+use osvvm.RandomPkg.RandomPType;
 
 entity axi_stream_master is
   generic (

--- a/vunit/vhdl/verification_components/src/axi_stream_master.vhd
+++ b/vunit/vhdl/verification_components/src/axi_stream_master.vhd
@@ -11,6 +11,7 @@ context work.vunit_context;
 context work.com_context;
 use work.stream_master_pkg.all;
 use work.axi_stream_pkg.all;
+use work.axi_stream_private_pkg.all;
 use work.queue_pkg.all;
 use work.sync_pkg.all;
 

--- a/vunit/vhdl/verification_components/src/axi_stream_pkg.vhd
+++ b/vunit/vhdl/verification_components/src/axi_stream_pkg.vhd
@@ -17,9 +17,6 @@ context work.vunit_context;
 context work.com_context;
 context work.data_types_context;
 
-library osvvm;
-use osvvm.RandomPkg.RandomPType;
-
 package axi_stream_pkg is
 
   type stall_config_t is record
@@ -277,24 +274,6 @@ package axi_stream_pkg is
       tuser    : std_logic_vector := "";
       msg      : string           := "";
       blocking : boolean          := true
-    );
-
-  procedure probability_stall_axi_stream(
-      signal aclk : in std_logic;
-      axi_stream  : in axi_stream_slave_t;
-      rnd         : inout RandomPType
-    );
-
-  procedure probability_stall_axi_stream(
-      signal aclk : in std_logic;
-      axi_stream  : in axi_stream_master_t;
-      rnd         : inout RandomPType
-    );
-
-  procedure probability_stall_axi_stream(
-      signal aclk  : in std_logic;
-      stall_config : in stall_config_t;
-      rnd          : inout RandomPType
     );
 
   type axi_stream_transaction_t is record
@@ -820,35 +799,5 @@ package body axi_stream_pkg is
       pop_axi_stream_transaction(msg, axi_transaction);
     end if;
   end;
-
-  procedure probability_stall_axi_stream(
-    signal aclk : in std_logic;
-    axi_stream  : in axi_stream_master_t;
-    rnd         : inout RandomPType) is
-  begin
-    probability_stall_axi_stream(aclk, axi_stream.p_stall_config, rnd);
-  end procedure;
-
-  procedure probability_stall_axi_stream(
-    signal aclk : in std_logic;
-    axi_stream  : in axi_stream_slave_t;
-    rnd         : inout RandomPType) is
-  begin
-    probability_stall_axi_stream(aclk, axi_stream.p_stall_config, rnd);
-  end procedure;
-
-  procedure probability_stall_axi_stream(
-    signal aclk  : in std_logic;
-    stall_config : in stall_config_t;
-    rnd          : inout RandomPType) is
-    variable num_stall_cycles : natural := 0;
-  begin
-    if rnd.Uniform(0.0, 1.0) < stall_config.stall_probability then
-      num_stall_cycles := rnd.FavorSmall(stall_config.min_stall_cycles, stall_config.max_stall_cycles);
-    end if;
-    for stall in 0 to num_stall_cycles-1 loop
-       wait until rising_edge(aclk);
-    end loop;
-  end procedure;
 
 end package body;

--- a/vunit/vhdl/verification_components/src/axi_stream_pkg.vhd
+++ b/vunit/vhdl/verification_components/src/axi_stream_pkg.vhd
@@ -18,7 +18,7 @@ context work.com_context;
 context work.data_types_context;
 
 library osvvm;
-use osvvm.RandomPkg.all;
+use osvvm.RandomPkg.RandomPType;
 
 package axi_stream_pkg is
 

--- a/vunit/vhdl/verification_components/src/axi_stream_pkg.vhd
+++ b/vunit/vhdl/verification_components/src/axi_stream_pkg.vhd
@@ -301,6 +301,12 @@ package axi_stream_pkg is
     variable msg             : inout msg_t;
     variable axi_transaction : out axi_stream_transaction_t);
 
+  function new_stall_config(
+    stall_probability : real range 0.0 to 1.0;
+    min_stall_cycles  : natural;
+    max_stall_cycles  : natural
+  ) return stall_config_t;
+
 end package;
 
 package body axi_stream_pkg is
@@ -798,6 +804,19 @@ package body axi_stream_pkg is
 
       pop_axi_stream_transaction(msg, axi_transaction);
     end if;
+  end;
+
+  function new_stall_config(
+    stall_probability : real range 0.0 to 1.0;
+    min_stall_cycles  : natural;
+    max_stall_cycles  : natural) return stall_config_t is
+      variable stall_config : stall_config_t;
+  begin
+    stall_config := (
+      stall_probability => stall_probability,
+      min_stall_cycles  => min_stall_cycles,
+      max_stall_cycles  => max_stall_cycles);
+    return stall_config;
   end;
 
 end package body;

--- a/vunit/vhdl/verification_components/src/axi_stream_pkg.vhd
+++ b/vunit/vhdl/verification_components/src/axi_stream_pkg.vhd
@@ -403,7 +403,7 @@ package body axi_stream_pkg is
     p_actor            := actor when actor /= null_actor else new_actor;
     p_protocol_checker := get_valid_protocol_checker(data_length, id_length, dest_length, user_length, logger, actor, protocol_checker, "slave");
 
-    return (p_actor      => new_actor,
+    return (p_actor      => p_actor,
       p_data_length      => data_length,
       p_id_length        => id_length,
       p_dest_length      => dest_length,

--- a/vunit/vhdl/verification_components/src/axi_stream_private_pkg.vhd
+++ b/vunit/vhdl/verification_components/src/axi_stream_private_pkg.vhd
@@ -2,7 +2,7 @@
 -- License, v. 2.0. If a copy of the MPL was not distributed with this file,
 -- You can obtain one at http://mozilla.org/MPL/2.0/.
 --
--- Copyright (c) 2014-2019, Lars Asplund lars.anders.asplund@gmail.com
+-- Copyright (c) 2014-2020, Lars Asplund lars.anders.asplund@gmail.com
 
 library ieee;
 use ieee.std_logic_1164.all;

--- a/vunit/vhdl/verification_components/src/axi_stream_private_pkg.vhd
+++ b/vunit/vhdl/verification_components/src/axi_stream_private_pkg.vhd
@@ -1,0 +1,68 @@
+-- This Source Code Form is subject to the terms of the Mozilla Public
+-- License, v. 2.0. If a copy of the MPL was not distributed with this file,
+-- You can obtain one at http://mozilla.org/MPL/2.0/.
+--
+-- Copyright (c) 2014-2019, Lars Asplund lars.anders.asplund@gmail.com
+
+library ieee;
+use ieee.std_logic_1164.all;
+
+library osvvm;
+use osvvm.RandomPkg.RandomPType;
+
+use work.axi_stream_pkg.all;
+
+package axi_stream_private_pkg is
+  procedure probability_stall_axi_stream(
+      signal aclk : in std_logic;
+      axi_stream  : in axi_stream_slave_t;
+      rnd         : inout RandomPType
+    );
+
+  procedure probability_stall_axi_stream(
+      signal aclk : in std_logic;
+      axi_stream  : in axi_stream_master_t;
+      rnd         : inout RandomPType
+    );
+
+  procedure probability_stall_axi_stream(
+      signal aclk  : in std_logic;
+      stall_config : in stall_config_t;
+      rnd          : inout RandomPType
+    );
+
+end package;
+
+package body axi_stream_private_pkg is
+
+  procedure probability_stall_axi_stream(
+    signal aclk : in std_logic;
+    axi_stream  : in axi_stream_master_t;
+    rnd         : inout RandomPType) is
+  begin
+    probability_stall_axi_stream(aclk, axi_stream.p_stall_config, rnd);
+  end procedure;
+
+  procedure probability_stall_axi_stream(
+    signal aclk : in std_logic;
+    axi_stream  : in axi_stream_slave_t;
+    rnd         : inout RandomPType) is
+  begin
+    probability_stall_axi_stream(aclk, axi_stream.p_stall_config, rnd);
+  end procedure;
+
+  procedure probability_stall_axi_stream(
+    signal aclk  : in std_logic;
+    stall_config : in stall_config_t;
+    rnd          : inout RandomPType) is
+    variable num_stall_cycles : natural := 0;
+  begin
+    if rnd.Uniform(0.0, 1.0) < stall_config.stall_probability then
+      num_stall_cycles := rnd.FavorSmall(stall_config.min_stall_cycles, stall_config.max_stall_cycles);
+    end if;
+    for stall in 0 to num_stall_cycles-1 loop
+       wait until rising_edge(aclk);
+    end loop;
+  end procedure;
+
+end package body;

--- a/vunit/vhdl/verification_components/src/axi_stream_slave.vhd
+++ b/vunit/vhdl/verification_components/src/axi_stream_slave.vhd
@@ -11,6 +11,7 @@ context work.vunit_context;
 context work.com_context;
 use work.stream_slave_pkg.all;
 use work.axi_stream_pkg.all;
+use work.axi_stream_private_pkg.all;
 use work.sync_pkg.all;
 use work.string_ptr_pkg.all;
 

--- a/vunit/vhdl/verification_components/src/axi_stream_slave.vhd
+++ b/vunit/vhdl/verification_components/src/axi_stream_slave.vhd
@@ -15,7 +15,7 @@ use work.sync_pkg.all;
 use work.string_ptr_pkg.all;
 
 library osvvm;
-use osvvm.RandomPkg.all;
+use osvvm.RandomPkg.RandomPType;
 
 entity axi_stream_slave is
   generic (

--- a/vunit/vhdl/verification_components/src/axi_stream_slave.vhd
+++ b/vunit/vhdl/verification_components/src/axi_stream_slave.vhd
@@ -38,9 +38,9 @@ end entity;
 
 architecture a of axi_stream_slave is
 
-  constant        notify_request_msg      : msg_type_t := new_msg_type("notify request");
-  constant        message_queue           : queue_t    := new_queue;
-  signal          notify_bus_process_done : std_logic  := '0';
+  constant notify_request_msg      : msg_type_t := new_msg_type("notify request");
+  constant message_queue           : queue_t    := new_queue;
+  signal   notify_bus_process_done : std_logic  := '0';
 
 begin
 

--- a/vunit/vhdl/verification_components/test/tb_axi_stream.vhd
+++ b/vunit/vhdl/verification_components/test/tb_axi_stream.vhd
@@ -502,7 +502,7 @@ begin
       for i in 0 to 100 loop
         reference := pop(reference_queue);
         await_pop_stream_reply(net, reference, data);
-      -- check_equal(data, to_unsigned(i + 1, data'length), result("for await pop stream data"));
+        check_equal(data, to_unsigned(i + 1, data'length), result("for await pop stream data"));
       end loop;
       info("There have been " & integer'image(tvalid_stall_events) & " tvalid stall events");
       info("Min stall length was " & integer'image(tvalid_min_stall_length));
@@ -527,7 +527,7 @@ begin
       for i in 0 to 100 loop
         reference := pop(reference_queue);
         await_pop_stream_reply(net, reference, data);
-      -- check_equal(data, to_unsigned(i + 1, data'length), result("for await pop stream data"));
+        check_equal(data, to_unsigned(i + 1, data'length), result("for await pop stream data"));
       end loop;
       info("There have been " & integer'image(tready_stall_events) & " tready stall events");
       info("Min stall length was " & integer'image(tready_min_stall_length));

--- a/vunit/vhdl/verification_components/test/tb_axi_stream.vhd
+++ b/vunit/vhdl/verification_components/test/tb_axi_stream.vhd
@@ -17,13 +17,14 @@ use work.stream_slave_pkg.all;
 use work.sync_pkg.all;
 
 entity tb_axi_stream is
-  generic(runner_cfg : string;
-      	  g_id_length    : natural := 8;
-          g_dest_length  : natural := 8;
-          g_user_length  : natural := 8;
-          g_stall_percentage_master : natural range 0 to 100 := 0;
-          g_stall_percentage_slave  : natural range 0 to 100 := 0
-        );
+  generic(
+    runner_cfg    : string;
+    g_id_length   : natural := 8;
+    g_dest_length : natural := 8;
+    g_user_length : natural := 8;
+    g_stall_percentage_master : natural range 0 to 100 := 0;
+    g_stall_percentage_slave  : natural range 0 to 100 := 0
+  );
 end entity;
 
 architecture a of tb_axi_stream is
@@ -610,7 +611,7 @@ begin
       tid      => tid,
       tdest    => tdest,
       tuser    => tuser
-      );
+    );
 
   statistics : process(aclk)
   begin

--- a/vunit/vhdl/verification_components/test/tb_axi_stream.vhd
+++ b/vunit/vhdl/verification_components/test/tb_axi_stream.vhd
@@ -21,16 +21,15 @@ entity tb_axi_stream is
       	  g_id_length    : natural := 8;
           g_dest_length  : natural := 8;
           g_user_length  : natural := 8;
-          g_stall_master : natural := 0;
-          g_stall_slave  : natural := 0
+          g_stall_master : natural range 0 to 100 := 0; -- as in 0 to 100%
+          g_stall_slave  : natural range 0 to 100 := 0  -- as in 0 to 100%
         );
 end entity;
 
 architecture a of tb_axi_stream is
 
-  constant stall_config : real_vector(0 to 1) := (0.0, 0.3);
-  constant master_stall_config : stall_config_t := (stall_probability => stall_config(g_stall_master), min_stall_cycles => 5, max_stall_cycles => 15);
-  constant slave_stall_config  : stall_config_t := (stall_probability => stall_config(g_stall_slave), min_stall_cycles => 5, max_stall_cycles => 15);
+  constant master_stall_config : stall_config_t := (stall_probability => real(g_stall_master)/100.0, min_stall_cycles => 5, max_stall_cycles => 15);
+  constant slave_stall_config  : stall_config_t := (stall_probability => real(g_stall_slave)/100.0, min_stall_cycles => 5, max_stall_cycles => 15);
 
   constant master_axi_stream : axi_stream_master_t := new_axi_stream_master(
     data_length => 8, id_length => g_id_length, dest_length => g_dest_length, user_length => g_user_length,

--- a/vunit/vhdl/verification_components/test/tb_axi_stream.vhd
+++ b/vunit/vhdl/verification_components/test/tb_axi_stream.vhd
@@ -522,12 +522,13 @@ begin
         await_pop_stream_reply(net, reference, data);
       -- check_equal(data, to_unsigned(i + 1, data'length), result("for await pop stream data"));
       end loop;
-      info("There have been " & integer'image(tvalid_stall_events) & " tvalid stall events"); 
+      info("There have been " & integer'image(tvalid_stall_events) & " tvalid stall events");
       info("Min stall length was " & integer'image(tvalid_min_stall_length));
       info("Max stall length was " & integer'image(tvalid_max_stall_length));
       check((tvalid_stall_events < 40) and (tvalid_stall_events > 20), "Checking that the tvalid stall probability lies within reasonable boundaries");
       check((tvalid_min_stall_length >= 5) and (tvalid_max_stall_length <=15), "Checking that the minimal and maximal stall lenghts are in expected boundaries");
-      
+      check_equal(tready_stall_events, 0, "Checking that there are zero tready stall events");
+
     elsif run("test random stall on slave") then
       wait until rising_edge(aclk);
       for i in 0 to 100 loop
@@ -546,11 +547,13 @@ begin
         await_pop_stream_reply(net, reference, data);
       -- check_equal(data, to_unsigned(i + 1, data'length), result("for await pop stream data"));
       end loop;
-      info("There have been " & integer'image(tready_stall_events) & " tready stall events"); 
+      info("There have been " & integer'image(tready_stall_events) & " tready stall events");
       info("Min stall length was " & integer'image(tready_min_stall_length));
       info("Max stall length was " & integer'image(tready_max_stall_length));
       check((tready_stall_events < 40) and (tready_stall_events > 20), "Checking that the tready stall probability lies within reasonable boundaries");
       check((tready_min_stall_length >= 5) and (tready_max_stall_length <=15), "Checking that the minimal and maximal stall lenghts are in expected boundaries");
+      check_equal(tvalid_stall_events, 0, "Checking that there are zero tvalid stall events");
+
     end if;
     test_runner_cleanup(runner);
   end process;

--- a/vunit/vhdl/verification_components/test/tb_axi_stream.vhd
+++ b/vunit/vhdl/verification_components/test/tb_axi_stream.vhd
@@ -28,8 +28,8 @@ end entity;
 
 architecture a of tb_axi_stream is
 
-  constant master_stall_config : stall_config_t := (stall_probability => real(g_stall_percentage_master)/100.0, min_stall_cycles => 5, max_stall_cycles => 15);
-  constant slave_stall_config  : stall_config_t := (stall_probability => real(g_stall_percentage_slave)/100.0, min_stall_cycles => 5, max_stall_cycles => 15);
+  constant master_stall_config : stall_config_t := new_stall_config(stall_probability => real(g_stall_percentage_master)/100.0, min_stall_cycles => 5, max_stall_cycles => 15);
+  constant slave_stall_config  : stall_config_t := new_stall_config(stall_probability => real(g_stall_percentage_slave)/100.0, min_stall_cycles => 5, max_stall_cycles => 15);
 
   constant master_axi_stream : axi_stream_master_t := new_axi_stream_master(
     data_length => 8, id_length => g_id_length, dest_length => g_dest_length, user_length => g_user_length,

--- a/vunit/vhdl/verification_components/test/tb_axi_stream.vhd
+++ b/vunit/vhdl/verification_components/test/tb_axi_stream.vhd
@@ -29,27 +29,9 @@ end entity;
 
 architecture a of tb_axi_stream is
 
-  impure function master_stall_config return stall_config_t is
-    variable stall_config : stall_config_t;
-  begin
-    if (g_stall_master > 0) then
-      stall_config := (stall_probability => 0.3, min_stall_cycles => 5, max_stall_cycles => 15);
-    else
-      stall_config := null_stall_config;
-    end if;
-    return stall_config;
-  end;
-
-  impure function slave_stall_config return stall_config_t is
-    variable stall_config : stall_config_t;
-  begin
-    if (g_stall_slave > 0) then
-      stall_config := (stall_probability => 0.3, min_stall_cycles => 5, max_stall_cycles => 15);
-    else
-      stall_config := null_stall_config;
-    end if;
-    return stall_config;
-  end;
+  constant stall_config : real_vector(0 to 1) := (0.0, 0.3);
+  constant master_stall_config : stall_config_t := (stall_probability => stall_config(g_stall_master), min_stall_cycles => 5, max_stall_cycles => 15);
+  constant slave_stall_config  : stall_config_t := (stall_probability => stall_config(g_stall_slave), min_stall_cycles => 5, max_stall_cycles => 15);
 
   constant master_axi_stream : axi_stream_master_t := new_axi_stream_master(
     data_length => 8, id_length => g_id_length, dest_length => g_dest_length, user_length => g_user_length,

--- a/vunit/vhdl/verification_components/test/tb_axi_stream.vhd
+++ b/vunit/vhdl/verification_components/test/tb_axi_stream.vhd
@@ -652,7 +652,7 @@ begin
       if tready and axis_stall_stats.ready.start and (not axis_stall_stats.ready.prev) then
         axis_stall_stats.ready.length <= 0;
         axis_stall_stats.ready.min <= minimum(axis_stall_stats.ready.length, axis_stall_stats.ready.min);
-        axis_stall_stats.ready.max <= maximum(axis_stall_Stats.ready.length, axis_stall_stats.ready.max);
+        axis_stall_stats.ready.max <= maximum(axis_stall_stats.ready.length, axis_stall_stats.ready.max);
       end if;
 
     end if;

--- a/vunit/vhdl/verification_components/test/tb_axi_stream.vhd
+++ b/vunit/vhdl/verification_components/test/tb_axi_stream.vhd
@@ -17,14 +17,13 @@ use work.stream_slave_pkg.all;
 use work.sync_pkg.all;
 
 entity tb_axi_stream is
-  generic(
-    runner_cfg    : string;
-    g_id_length   : natural  := 8;
-    g_dest_length : natural  := 8;
-    g_user_length : natural  := 8;
-    g_stall_master : natural := 0;
-    g_stall_slave : natural  := 0
-  );
+  generic(runner_cfg : string;
+      	  g_id_length    : natural := 8;
+          g_dest_length  : natural := 8;
+          g_user_length  : natural := 8;
+          g_stall_master : natural := 0;
+          g_stall_slave  : natural := 0
+        );
 end entity;
 
 architecture a of tb_axi_stream is

--- a/vunit/vhdl/verification_components/test/tb_axi_stream.vhd
+++ b/vunit/vhdl/verification_components/test/tb_axi_stream.vhd
@@ -21,15 +21,15 @@ entity tb_axi_stream is
       	  g_id_length    : natural := 8;
           g_dest_length  : natural := 8;
           g_user_length  : natural := 8;
-          g_stall_master : natural range 0 to 100 := 0; -- as in 0 to 100%
-          g_stall_slave  : natural range 0 to 100 := 0  -- as in 0 to 100%
+          g_stall_percentage_master : natural range 0 to 100 := 0;
+          g_stall_percentage_slave  : natural range 0 to 100 := 0
         );
 end entity;
 
 architecture a of tb_axi_stream is
 
-  constant master_stall_config : stall_config_t := (stall_probability => real(g_stall_master)/100.0, min_stall_cycles => 5, max_stall_cycles => 15);
-  constant slave_stall_config  : stall_config_t := (stall_probability => real(g_stall_slave)/100.0, min_stall_cycles => 5, max_stall_cycles => 15);
+  constant master_stall_config : stall_config_t := (stall_probability => real(g_stall_percentage_master)/100.0, min_stall_cycles => 5, max_stall_cycles => 15);
+  constant slave_stall_config  : stall_config_t := (stall_probability => real(g_stall_percentage_slave)/100.0, min_stall_cycles => 5, max_stall_cycles => 15);
 
   constant master_axi_stream : axi_stream_master_t := new_axi_stream_master(
     data_length => 8, id_length => g_id_length, dest_length => g_dest_length, user_length => g_user_length,

--- a/vunit/vhdl/verification_components/test/tb_axi_stream.vhd
+++ b/vunit/vhdl/verification_components/test/tb_axi_stream.vhd
@@ -28,8 +28,10 @@ end entity;
 
 architecture a of tb_axi_stream is
 
-  constant master_stall_config : stall_config_t := new_stall_config(stall_probability => real(g_stall_percentage_master)/100.0, min_stall_cycles => 5, max_stall_cycles => 15);
-  constant slave_stall_config  : stall_config_t := new_stall_config(stall_probability => real(g_stall_percentage_slave)/100.0, min_stall_cycles => 5, max_stall_cycles => 15);
+  constant min_stall_cycles : natural := 5;
+  constant max_stall_cycles : natural := 15;
+  constant master_stall_config : stall_config_t := new_stall_config(stall_probability => real(g_stall_percentage_master)/100.0, min_stall_cycles => min_stall_cycles, max_stall_cycles => max_stall_cycles);
+  constant slave_stall_config  : stall_config_t := new_stall_config(stall_probability => real(g_stall_percentage_slave)/100.0 , min_stall_cycles => min_stall_cycles, max_stall_cycles => max_stall_cycles);
 
   constant master_axi_stream : axi_stream_master_t := new_axi_stream_master(
     data_length => 8, id_length => g_id_length, dest_length => g_dest_length, user_length => g_user_length,
@@ -509,12 +511,12 @@ begin
       info("Min stall length was " & to_string(axis_stall_stats.valid.min));
       info("Max stall length was " & to_string(axis_stall_stats.valid.max));
       if running_test_case = "test random stall on master" then
-        check((axis_stall_stats.valid.events < 40) and (axis_stall_stats.valid.events > 20), "Checking that the tvalid stall probability lies within reasonable boundaries");
-        check((axis_stall_stats.valid.min >= 5) and (axis_stall_stats.valid.max <= 15), "Checking that the minimal and maximal stall lenghts are in expected boundaries");
+        check((axis_stall_stats.valid.events < (g_stall_percentage_master+10)) and (axis_stall_stats.valid.events > (g_stall_percentage_master-10)), "Checking that the tvalid stall probability lies within reasonable boundaries");
+        check((axis_stall_stats.valid.min >= min_stall_cycles) and (axis_stall_stats.valid.max <= max_stall_cycles), "Checking that the minimal and maximal stall lenghts are in expected boundaries");
         check_equal(axis_stall_stats.ready.events, 0, "Checking that there are zero tready stall events");
       else
-        check((axis_stall_stats.ready.events < 40) and (axis_stall_stats.ready.events > 20), "Checking that the tready stall probability lies within reasonable boundaries");
-        check((axis_stall_stats.ready.min >= 5) and (axis_stall_stats.ready.max <= 15), "Checking that the minimal and maximal stall lenghts are in expected boundaries");
+        check((axis_stall_stats.ready.events < (g_stall_percentage_slave+10)) and (axis_stall_stats.ready.events > (g_stall_percentage_slave-10)), "Checking that the tready stall probability lies within reasonable boundaries");
+        check((axis_stall_stats.ready.min >= min_stall_cycles) and (axis_stall_stats.ready.max <= max_stall_cycles), "Checking that the minimal and maximal stall lenghts are in expected boundaries");
         check_equal(axis_stall_stats.valid.events, 0, "Checking that there are zero tvalid stall events");
       end if;
 

--- a/vunit/vhdl/verification_components/test/tb_axi_stream.vhd
+++ b/vunit/vhdl/verification_components/test/tb_axi_stream.vhd
@@ -635,23 +635,23 @@ begin
       tready_prev <= tready;
       -------------------------------------------------------------------------
       -- TVALID and TREADY stall events counters
-      if tvalid = '1' and tready = '0' and tready_prev = '1' then
+      if tvalid and (not tready) and tready_prev then
         tready_stall_events <= tready_stall_events + 1;
       end if;
-      if tready = '1' and tvalid = '0' and tvalid_prev = '1' then
+      if (not tvalid) and tready and tvalid_prev then
         tvalid_stall_events <= tvalid_stall_events + 1;
       end if;
 
       -------------------------------------------------------------------------
       -- TVALID Minmal and Maximal Stall lengths
-      if tvalid = '1' then
+      if tvalid then
         tvalid_start <= '1';
       end if;
 
-      if tvalid = '0' and tvalid_start = '1' then
+      if (not tvalid) and tvalid_start then
         tvalid_stall_length <= tvalid_stall_length + 1;
       end if;
-      if tvalid = '1' and tvalid_prev = '0' and tvalid_start = '1' then
+      if tvalid and tvalid_start and (not tvalid_prev) then
         tvalid_stall_length <= 0;
         if tvalid_stall_length < tvalid_min_stall_length then
           tvalid_min_stall_length <= tvalid_stall_length;
@@ -662,14 +662,14 @@ begin
       end if;
       -------------------------------------------------------------------------
       -- TREADY Minmal and Maximal Stall lengths
-      if tready = '1' then
+      if tready then
         tready_start <= '1';
       end if;
 
-      if tready = '0' and tready_start = '1' then
+      if (not tready) and tready_start then
         tready_stall_length <= tready_stall_length + 1;
       end if;
-      if tready = '1' and tready_prev = '0' and tready_start = '1' then
+      if tready and tready_start and (not tready_prev) then
         tready_stall_length <= 0;
         if tready_stall_length < tready_min_stall_length then
           tready_min_stall_length <= tready_stall_length;

--- a/vunit/vhdl/verification_components/test/tb_axi_stream.vhd
+++ b/vunit/vhdl/verification_components/test/tb_axi_stream.vhd
@@ -637,12 +637,8 @@ begin
       end if;
       if tvalid and axis_stall_stats.valid.start and (not axis_stall_stats.valid.prev) then
         axis_stall_stats.valid.length <= 0;
-        if axis_stall_stats.valid.length < axis_stall_stats.valid.min then
-          axis_stall_stats.valid.min <= axis_stall_stats.valid.length;
-        end if;
-        if axis_stall_stats.valid.length > axis_stall_stats.valid.min then
-          axis_stall_stats.valid.max <= axis_stall_stats.valid.length;
-        end if;
+        axis_stall_stats.valid.min <= minimum(axis_stall_stats.valid.length, axis_stall_stats.valid.min);
+        axis_stall_stats.valid.max <= maximum(axis_stall_stats.valid.length, axis_stall_stats.valid.max);
       end if;
       -------------------------------------------------------------------------
       -- TREADY Minmal and Maximal Stall lengths
@@ -655,12 +651,8 @@ begin
       end if;
       if tready and axis_stall_stats.ready.start and (not axis_stall_stats.ready.prev) then
         axis_stall_stats.ready.length <= 0;
-        if axis_stall_stats.ready.length < axis_stall_stats.ready.min then
-          axis_stall_stats.ready.min <= axis_stall_stats.ready.length;
-        end if;
-        if axis_stall_stats.ready.length > axis_stall_stats.ready.min then
-          axis_stall_stats.ready.max <= axis_stall_stats.ready.length;
-        end if;
+        axis_stall_stats.ready.min <= minimum(axis_stall_stats.ready.length, axis_stall_stats.ready.min);
+        axis_stall_stats.ready.max <= maximum(axis_stall_Stats.ready.length, axis_stall_stats.ready.max);
       end if;
 
     end if;


### PR DESCRIPTION
At creation of axi_stream_master/slave one can provide a configuration which tells
how often a stall should occur, and if it occurs what the
minimal/maximal stall length of such a stall shall be.