### PR TITLE
add_submodule method to import vunit projects

### DIFF
--- a/examples/vhdl/submodule/run.py
+++ b/examples/vhdl/submodule/run.py
@@ -1,0 +1,34 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+# Copyright (c) 2014-2019, Lars Asplund lars.anders.asplund@gmail.com
+
+"""
+Submodule support
+-------------
+This script shows how to import smaller submodules in a bigger design. 
+
+The submodules contains a own run.py script in which the sources are defined.
+With 'add_submodule' you can add the complete project into your top design.
+Usecase could be a CPU design which uses some periphery which is managed in 
+seperate projects.
+"""
+
+from os.path import join, dirname
+from vunit import VUnit
+
+root = dirname(__file__)
+
+vu = VUnit.from_argv()
+
+vu.add_json4vhdl()
+
+lib = vu.add_library("lib")
+lib.add_source_files(join(root, "src/*.vhd"))
+lib.add_source_files(join(root, "tb/*.vhd"))
+
+vu.add_submodule('src/adder/run.py')
+
+if __name__ == '__main__':
+    vu.main()

--- a/examples/vhdl/submodule/src/adder/run.py
+++ b/examples/vhdl/submodule/src/adder/run.py
@@ -1,0 +1,29 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+# Copyright (c) 2014-2019, Lars Asplund lars.anders.asplund@gmail.com
+
+"""
+Submodule support
+-------------
+
+This is only a small example and shows how a complete vunit design can be 
+imported at once. Intended use case could be a seperately managed periphery
+which gets imported in a bigger top design like a CPU or complete vhdl librarys.
+"""
+
+from os.path import join, dirname
+from vunit import VUnit
+
+root = dirname(__file__)
+
+vu = VUnit.from_argv()
+
+vu.add_json4vhdl()
+
+lib = vu.add_library("adder")
+lib.add_source_files(join(root, "src/*.vhd"))
+
+if __name__ == '__main__':
+    vu.main()

--- a/examples/vhdl/submodule/src/adder/src/adder.vhd
+++ b/examples/vhdl/submodule/src/adder/src/adder.vhd
@@ -1,0 +1,30 @@
+-- This Source Code Form is subject to the terms of the Mozilla Public
+-- License, v. 2.0. If a copy of the MPL was not distributed with this file,
+-- You can obtain one at http://mozilla.org/MPL/2.0/.
+--
+-- Copyright (c) 2014-2019, Lars Asplund lars.anders.asplund@gmail.com
+
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.numeric_std.all;
+
+entity adder is
+  generic (
+      BITS : positive);
+  port(
+    clk : in std_logic;
+    op_a : in unsigned(BITS - 1 downto 0);
+    op_b : in unsigned(BITS - 1 downto 0);
+    sum : out unsigned(BITS - 1 downto 0)
+  );
+end entity;
+
+architecture arch of adder is
+begin
+  main : process(clk)
+  begin
+    if rising_edge(clk) then
+        sum <= op_a + op_b;
+    end if;
+  end process;
+end architecture;

--- a/examples/vhdl/submodule/src/top.vhd
+++ b/examples/vhdl/submodule/src/top.vhd
@@ -1,0 +1,38 @@
+-- This Source Code Form is subject to the terms of the Mozilla Public
+-- License, v. 2.0. If a copy of the MPL was not distributed with this file,
+-- You can obtain one at http://mozilla.org/MPL/2.0/.
+--
+-- Copyright (c) 2014-2019, Lars Asplund lars.anders.asplund@gmail.com
+
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.numeric_std.all;
+
+library adder;
+
+entity top is
+  generic (
+      BITS : positive);
+  port(
+    clk : in std_logic;
+    op_a : in unsigned(BITS - 1 downto 0);
+    op_b : in unsigned(BITS - 1 downto 0);
+    sum : out unsigned(BITS - 1 downto 0)
+  );
+end entity;
+
+architecture arch of top is
+begin
+
+  adder_inst: entity adder.adder
+    generic map(
+      BITS => BITS
+    )
+    port map(
+      clk => clk,
+      op_a => op_a,
+      op_b => op_b,
+      sum => sum
+    );
+
+end architecture;

--- a/examples/vhdl/submodule/tb/top_tb.vhd
+++ b/examples/vhdl/submodule/tb/top_tb.vhd
@@ -1,0 +1,55 @@
+-- This Source Code Form is subject to the terms of the Mozilla Public
+-- License, v. 2.0. If a copy of the MPL was not distributed with this file,
+-- You can obtain one at http://mozilla.org/MPL/2.0/.
+--
+-- Copyright (c) 2014-2019, Lars Asplund lars.anders.asplund@gmail.com
+
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.numeric_std.all;
+
+library vunit_lib;
+context vunit_lib.vunit_context;
+
+entity top_tb is
+  generic (
+    RUNNER_CFG	: string);
+end entity;
+
+architecture arch of top_tb is
+  signal clk : std_logic := '0';
+
+  constant BITS : natural := 8;
+  signal in_a, in_b, add_out : unsigned(BITS - 1 downto 0);
+
+begin
+  clk <= not clk after 1 ns;
+
+
+  main: process
+  begin
+    test_runner_setup(runner, runner_cfg);
+    while test_suite loop
+      if run("test") then
+        in_a <= to_unsigned(10, in_a);
+        in_b <= to_unsigned(15, in_b);
+        wait for 3 ns;
+        check(add_out = in_a + in_b, "Addition failed");
+      end if;
+    end loop;
+    test_runner_cleanup(runner);
+    wait;
+  end process;
+
+  top_module: entity work.top
+  generic map(
+    BITS => BITS
+  )
+  port map(
+    clk => clk,
+    op_a => in_a,
+    op_b => in_b,
+    sum => add_out
+  );
+  
+end architecture;

--- a/vunit/project.py
+++ b/vunit/project.py
@@ -139,11 +139,6 @@ class Project(object):  # pylint: disable=too-many-instance-attributes
 
         return old_source_file
 
-    def remove_source_file(self, file_name, library_name):
-        library = self._libraries[library_name]
-        sourcefile = library.remove_source_file(file_name)
-        self._source_files_in_order.remove(sourcefile)
-
     def add_manual_dependency(self, source_file, depends_on):
         """
         Add manual dependency where 'source_file' depends_on 'depends_on'
@@ -554,14 +549,6 @@ class Library(object):  # pylint: disable=too-many-instance-attributes
         Get source file with file name or raise KeyError
         """
         return self._source_files[file_name]
-
-    def remove_source_file(self, file_name):
-        """
-        Remove source file with file name from library or raise KeyError
-        """
-        print("Try to remove ", file_name, "from ", self.name)
-        print("Removing ", self._source_files[file_name])
-        return self._source_files.pop(file_name)
 
     @property
     def is_external(self):

--- a/vunit/project.py
+++ b/vunit/project.py
@@ -139,6 +139,11 @@ class Project(object):  # pylint: disable=too-many-instance-attributes
 
         return old_source_file
 
+    def remove_source_file(self, file_name, library_name):
+        library = self._libraries[library_name]
+        sourcefile = library.remove_source_file(file_name)
+        self._source_files_in_order.remove(sourcefile)
+
     def add_manual_dependency(self, source_file, depends_on):
         """
         Add manual dependency where 'source_file' depends_on 'depends_on'
@@ -549,6 +554,14 @@ class Library(object):  # pylint: disable=too-many-instance-attributes
         Get source file with file name or raise KeyError
         """
         return self._source_files[file_name]
+
+    def remove_source_file(self, file_name):
+        """
+        Remove source file with file name from library or raise KeyError
+        """
+        print("Try to remove ", file_name, "from ", self.name)
+        print("Removing ", self._source_files[file_name])
+        return self._source_files.pop(file_name)
 
     @property
     def is_external(self):

--- a/vunit/ui.py
+++ b/vunit/ui.py
@@ -288,6 +288,13 @@ class VUnit(object):  # pylint: disable=too-many-instance-attributes, too-many-p
 
        from vunit import VUnit
     """
+    _instance = None
+    _initialized = False
+    def __new__(cls, *args, **kwargs):
+        if not cls._instance:
+            cls._instance = super(VUnit, cls).__new__(cls)
+        
+        return cls._instance
 
     @classmethod
     def from_argv(cls, argv=None, compile_builtins=True, vhdl_standard=None):
@@ -325,6 +332,9 @@ class VUnit(object):  # pylint: disable=too-many-instance-attributes, too-many-p
         return cls(args, compile_builtins=compile_builtins, vhdl_standard=vhdl_standard)
 
     def __init__(self, args, compile_builtins=True, vhdl_standard=None):
+        if self._initialized != False:
+            return
+
         self._args = args
         self._configure_logging(args.log_level)
         self._output_path = abspath(args.output_path)
@@ -373,6 +383,8 @@ class VUnit(object):  # pylint: disable=too-many-instance-attributes, too-many-p
         self._builtins = Builtins(self, self._vhdl_standard, simulator_class)
         if compile_builtins:
             self.add_builtins()
+
+        self._initialized = True
 
     def _create_database(self):
         """

--- a/vunit/ui.py
+++ b/vunit/ui.py
@@ -1167,6 +1167,7 @@ avoid location preprocessing of other functions sharing name with a VUnit log or
         :param import_testbenches : If set, the submodules testbenches are imported, otherwise not.
         """
 
+        f = open(module) # raises FileNotFoundError if the module is not available
         rootpath = os.getcwd()
         path = os.path.abspath(os.path.dirname(module))
         sys.path.insert(0, path)

--- a/vunit/ui.py
+++ b/vunit/ui.py
@@ -1160,6 +1160,12 @@ avoid location preprocessing of other functions sharing name with a VUnit log or
                                for source_file in source_files])
 
     def add_submodule(self, module, import_testbenches = False):
+        """
+        Add a complete vunit build script to the design at once. 
+        
+        :param module: Path to the submodule's run.py file
+        :param import_testbenches : If set, the submodules testbenches are imported, otherwise not.
+        """
 
         rootpath = os.getcwd()
         path = os.path.abspath(os.path.dirname(module))


### PR DESCRIPTION
This PR enable vunit to import separate managed vunit projects at once. 

The vunit class creating has been modified therefore and acts now as a singleton. So every further vunit call returns the same instance, so the project's source files get _merged_ together.

Typical use cases are a top level design like a CPU which imports several peripheries as a submodule. Each periphery is managed separately as vunit project. When importing the module there's no need to track the source files (changes) of the top project anymore. 
Another use case would be libraries. So instead of importing several files from a vhdl library only a run.py from the library gets imported.

I opened an issue a while ago, #353 but it is already closed. I needed the feature anyway so i decided to give it a try.

Testers are welcome to try the new feature. 

