### PR TITLE
ci: add GHA workflow 'images.yml'

### DIFF
--- a/.github/images.sh
+++ b/.github/images.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+
+# Stop in case of error
+set -e
+
+docker build \
+  --build-arg IMAGE="python:$PYVER-slim-buster" \
+  --build-arg LLVM_VER=7 \
+  --build-arg GNAT_VER=8 \
+  --target vunit \
+  -t "vunit/dev:${TAG}" \
+  - <<-EOF
+$(curl -fsSL https://raw.githubusercontent.com/ghdl/docker/master/dockerfiles/run_debian)
+
+FROM $TGT AS vunit
+COPY --from=ghdl/pkg:buster-$PKG / /test
+
+RUN tar xzf \$(ls /test/ghdl-*) -C /usr/local/ \\
+ && rm -rf /test \
+ && pip install tox colorama
+EOF

--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -1,0 +1,44 @@
+name: 'images'
+
+on:
+  push:
+    paths:
+      - '.github/workflows/images.yml'
+      - '.github/images.sh'
+  schedule:
+    - cron: '0 0 * * 5'
+
+env:
+  DOCKER_BUILDKIT: '1'
+
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+      max-parallel: 3
+      matrix:
+        task: [
+          { tag: llvm,    pyver: 3, tgt: llvm,  pkg: llvm-7 },
+          { tag: mcode,   pyver: 3, tgt: mcode, pkg: mcode  },
+          { tag: mcode-2, pyver: 2, tgt: mcode, pkg: mcode  },
+        ]
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - name: Run job
+      env:
+        TAG:   ${{ matrix.task.tag }}
+        PYVER: ${{ matrix.task.pyver }}
+        TGT:   ${{ matrix.task.tgt }}
+        PKG:   ${{ matrix.task.pkg }}
+      run: |
+        ./.github/images.sh
+    - name: Deploy to hub.docker.com
+      env:
+        DOCKER_USER: ${{ secrets.DOCKER_USER }}
+        DOCKER_PASS: ${{ secrets.DOCKER_PASS }}
+        TAG: ${{ matrix.task.tag }}
+      run: |
+        echo "$DOCKER_PASS" | docker login -u "$DOCKER_USER" --password-stdin
+        docker push vunit/dev:$TAG
+        docker logout

--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -23,9 +23,11 @@ jobs:
           { tag: mcode-2, pyver: 2, tgt: mcode, pkg: mcode  },
         ]
     runs-on: ubuntu-latest
+    env:
+      DOCKER_REGISTRY: docker.pkg.github.com
     steps:
     - uses: actions/checkout@v1
-    - name: Run job
+    - name: build image
       env:
         TAG:   ${{ matrix.task.tag }}
         PYVER: ${{ matrix.task.pyver }}
@@ -33,12 +35,18 @@ jobs:
         PKG:   ${{ matrix.task.pkg }}
       run: |
         ./.github/images.sh
-    - name: Deploy to hub.docker.com
+    - name: docker login
+      run: echo "$GITHUB_TOKEN" | docker login -u vunit-gha --password-stdin "$DOCKER_REGISTRY"
       env:
-        DOCKER_USER: ${{ secrets.DOCKER_USER }}
-        DOCKER_PASS: ${{ secrets.DOCKER_PASS }}
-        TAG: ${{ matrix.task.tag }}
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    - name: docker push
       run: |
-        echo "$DOCKER_PASS" | docker login -u "$DOCKER_USER" --password-stdin
-        docker push vunit/dev:$TAG
-        docker logout
+        DIMG="vunit/dev:$TAG"
+        GHIMG="${DOCKER_REGISTRY}/vunit/$DIMG"
+        docker tag "$DIMG" "$GHIMG"
+        docker push "$GHIMG"
+      env:
+        TAG: ${{ matrix.task.tag }}
+    - name: docker logout
+      run: docker logout "$DOCKER_REGISTRY"
+      if: always()


### PR DESCRIPTION
This is a subset of the changes in #536, that can be merged independently.

Unlike Travis or AppVeyor, GHA allows to have multiple 'workflows', which are triggered independently. Hence, we don't need [VUnit/docker](https://github.com/VUnit/docker). In this PR, [VUnit/docker/blob/master/.travis.yml](https://github.com/VUnit/docker/blob/master/.travis.yml) is integrated as `.github/workflows/images.yml` and a helper script `.github/images.sh`. The workflow is executed either when any of those files is modified, or weekly (00:00 UTC on Friday).

- [x] <strike>`DOCKER_USER` and `DOCKER_PASS` secrets need to be configured in this repo.</strike> Pushing to https://github.com/orgs/VUnit/packages?package_type=Docker with the GITHUB_TOKEN provided in Actions needs to be tested.
- [ ] When this PR is merged, VUnit/docker can be archived.

Example execution: https://github.com/1138-4EB/vunit/commit/0212ceecfdd05cf6c9be14f436813db610800de2/checks?check_suite_id=272997645
