### PR TITLE
post_run: add report data to 'Results' object/class

### DIFF
--- a/docs/py/vunit.rst
+++ b/docs/py/vunit.rst
@@ -36,6 +36,10 @@ Results
 
 .. autoclass:: vunit.ui.results.Results()
 
+.. autoclass:: vunit.ui.results.Report()
+
+.. autoclass:: vunit.ui.results.TestResult()
+
 .. |compile_option| replace::
    The name of the compile option (See :ref:`Compilation options <compile_options>`)
 

--- a/vunit/test/report.py
+++ b/vunit/test/report.py
@@ -14,6 +14,7 @@ from sys import version_info
 import os
 import socket
 import re
+from os.path import dirname
 from vunit.color_printer import COLOR_PRINTER
 from vunit.ostools import read_file
 
@@ -322,3 +323,13 @@ class TestResult(object):
             skipped = ElementTree.SubElement(test, "skipped")
             skipped.attrib["message"] = "Skipped"
         return test
+
+    def to_dict(self):
+        """
+        Convert a subset of the test result to a dictionary
+        """
+        return {
+            "status": self._status.name,
+            "time": self.time,
+            "path": dirname(self._output_file_name),
+        }

--- a/vunit/ui/__init__.py
+++ b/vunit/ui/__init__.py
@@ -38,7 +38,7 @@ from ..test.bench_list import TestBenchList
 from ..test.report import TestReport
 from ..test.runner import TestRunner
 
-from .common import LOGGER, select_vhdl_standard, check_not_empty
+from .common import LOGGER, TEST_OUTPUT_PATH, select_vhdl_standard, check_not_empty
 from .source import SourceFile, SourceFileList
 from .library import Library
 from .results import Results
@@ -769,7 +769,7 @@ avoid location preprocessing of other functions sharing name with a VUnit log or
         report.print_str()
 
         if post_run is not None:
-            post_run(results=Results(simulator_if))
+            post_run(results=Results(self._output_path, simulator_if, report))
 
         del simulator_if
 
@@ -929,7 +929,7 @@ avoid location preprocessing of other functions sharing name with a VUnit log or
 
         runner = TestRunner(
             report,
-            join(self._output_path, "test_output"),
+            join(self._output_path, TEST_OUTPUT_PATH),
             verbosity=verbosity,
             num_threads=self._args.num_threads,
             fail_fast=self._args.fail_fast,

--- a/vunit/ui/common.py
+++ b/vunit/ui/common.py
@@ -15,6 +15,8 @@ from ..vhdl_standard import VHDL
 
 LOGGER = getLogger(__name__)
 
+TEST_OUTPUT_PATH = "test_output"
+
 
 def select_vhdl_standard(vhdl_standard=None):
     """

--- a/vunit/ui/results.py
+++ b/vunit/ui/results.py
@@ -8,14 +8,19 @@
 UI class Results
 """
 
+from os.path import join, basename, normpath
+from .common import TEST_OUTPUT_PATH
+
 
 class Results(object):
     """
-    Gives access to results after running tests.
+    Gives access to results after running tests
     """
 
-    def __init__(self, simulator_if):
+    def __init__(self, output_path, simulator_if, report):
+        self._output_path = output_path
         self._simulator_if = simulator_if
+        self._report = report
 
     def merge_coverage(self, file_name, args=None):
         """
@@ -24,5 +29,84 @@ class Results(object):
         :param file_name: The resulting coverage file name.
         :param args: The tool arguments for the merge command. Should be a list of strings.
         """
-
         self._simulator_if.merge_coverage(file_name=file_name, args=args)
+
+    def get_report(self):
+        """
+        Get a report (dictionary) of tests: status, time and output path
+
+        :returns: A :class:`Report` object
+        """
+        report = Report(self._output_path)
+        for (
+            test
+        ) in self._report._test_results_in_order():  # pylint: disable=protected-access
+            obj = test.to_dict()
+            report.tests.update(
+                {
+                    test.name: TestResult(
+                        join(self._output_path, TEST_OUTPUT_PATH),
+                        obj["status"],
+                        obj["time"],
+                        obj["path"],
+                    )
+                }
+            )
+        return report
+
+
+class Report(object):
+    """
+    Gives access to test results and paths after running tests
+
+    :data output_path: Absolute path to the output path (see :ref:`cli`)
+    :data tests: Dictionary of :class:`TestResult` objects
+    """
+
+    def __init__(self, output_path):
+        self.output_path = output_path
+        self.tests = {}
+
+
+class TestResult(object):
+    """
+    Gives access to a subset of the results of a test
+
+    :data status: Result status (passed, failed or skipped)
+    :data time: Simulation time
+    :data path: Absolute path of the test output
+
+    :example:
+
+    .. code-block:: python
+
+       def post_func(results):
+           report = results.get_report()
+           print(report.output_path)
+           for key, test in report.tests.items():
+               print(key)
+               print(test.status)
+               print(test.time)
+               print(test.path)
+               print(test.relpath)
+
+       vu.main(post_run=post_func)
+    """
+
+    def __init__(self, test_output_path, status, time, path):
+        self._test_output_path = test_output_path
+        self.status = status
+        self.time = time
+        self.path = path
+
+    @property
+    def relpath(self):
+        """
+        If the path is a subdir to the default TEST_OUTPUT_PATH, return the subdir only
+        """
+        base = basename(self.path)
+        return (
+            base
+            if normpath(join(self._test_output_path, base)) == normpath(self.path)
+            else self.path
+        )


### PR DESCRIPTION
Close #445
Close #478
Close #574

In this PR, parameters `output_path` and `report` are passed from `main` to the `Results` object built and passed to `post_run` callbacks. Instead of exposing the `TestReport` object, as suggested in #445, a subset of info is extracted for each test: name, status, time and path. The path is relative to `join(output_path, 'test_output')`.

Usage example:

```py
def post_func(results):
    print(results.output_path)
    for key, val in results.get_report().items():
        print(key , val)

vu.main(post_run=post_func)
```

@felixn, you can build the path to each test log as follows: `join(results.output_path, 'test_output', val.path, 'output.txt')`. Alternatively: `join(results.output_path, 'test_output', results.get_report().items()[<test_name>], 'output.txt')`.

/cc @richjyoung