### PR TITLE
ci: do not push images from forks

### DIFF
--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -40,6 +40,7 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     - name: docker push
+      if: github.repository == 'VUnit/vunit'
       run: |
         DIMG="vunit/dev:$TAG"
         GHIMG="${DOCKER_REGISTRY}/vunit/$DIMG"


### PR DESCRIPTION
Currently, when workflow 'images' is executed in a fork, pushing docker images to the registry (https://github.com/orgs/VUnit/packages) fails. This is expected, because the `GITHUB_TOKEN` of contributors does not have the required write privileges.

In this PR, a condition is added so that step 'docker push' is executed when `github.repository == 'VUnit/vunit'` only: https://github.com/dbhi/vunit/runs/281572977#step:5:0