### PR TITLE
Save GHDL args to JSON file

### DIFF
--- a/tests/unit/test_ghdl_interface.py
+++ b/tests/unit/test_ghdl_interface.py
@@ -228,7 +228,7 @@ warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE."""
 
         self.assertEqual(
             simif._get_command(  # pylint: disable=protected-access
-                config, join("output_path", "ghdl"), True
+                config, join("output_path", "ghdl"), True, True, None
             ),
             [
                 join("prefix", "ghdl"),

--- a/vunit/sim_if/ghdl.py
+++ b/vunit/sim_if/ghdl.py
@@ -234,7 +234,7 @@ class GHDLInterface(SimulatorInterface):
         cmd += [source_file.name]
         return cmd
 
-    def _get_command(self, config, output_path, ghdl_e):
+    def _get_command(self, config, output_path, elaborate_only, ghdl_e, wave_file):
         """
         Return GHDL simulation command
         """
@@ -251,24 +251,32 @@ class GHDLInterface(SimulatorInterface):
             "--workdir=%s" % self._project.get_library(config.library_name).directory
         ]
         cmd += ["-P%s" % lib.directory for lib in self._project.get_libraries()]
+
+        bin_path = join(
+            output_path, "%s-%s" % (config.entity_name, config.architecture_name)
+        )
         if self._has_output_flag():
-            cmd += [
-                "-o",
-                join(
-                    output_path,
-                    "%s-%s" % (config.entity_name, config.architecture_name),
-                ),
-            ]
+            cmd += ["-o", bin_path]
         cmd += config.sim_options.get("ghdl.elab_flags", [])
         cmd += [config.entity_name, config.architecture_name]
 
+        sim = config.sim_options.get("ghdl.sim_flags", [])
+        for name, value in config.generics.items():
+            sim += ["-g%s=%s" % (name, value)]
+        sim += ["--assert-level=%s" % config.vhdl_assert_stop_level]
+        if config.sim_options.get("disable_ieee_warnings", False):
+            sim += ["--ieee-asserts=disable"]
+
+        if wave_file:
+            if self._gtkwave_fmt == "ghw":
+                sim += ["--wave=%s" % wave_file]
+            elif self._gtkwave_fmt == "vcd":
+                sim += ["--vcd=%s" % wave_file]
+
         if not ghdl_e:
-            cmd += config.sim_options.get("ghdl.sim_flags", [])
-            for name, value in config.generics.items():
-                cmd += ["-g%s=%s" % (name, value)]
-            cmd += ["--assert-level=%s" % config.vhdl_assert_stop_level]
-            if config.sim_options.get("disable_ieee_warnings", False):
-                cmd += ["--ieee-asserts=disable"]
+            cmd += sim
+            if elaborate_only:
+                cmd += ["--no-run"]
 
         return cmd
 
@@ -286,24 +294,16 @@ class GHDLInterface(SimulatorInterface):
 
         ghdl_e = elaborate_only and config.sim_options.get("ghdl.elab_e", False)
 
-        cmd = self._get_command(config, script_path, ghdl_e)
-
-        if elaborate_only and not ghdl_e:
-            cmd += ["--no-run"]
-
-        if self._gtkwave_fmt is not None and not ghdl_e:
+        if self._gtkwave_fmt is not None:
             data_file_name = join(script_path, "wave.%s" % self._gtkwave_fmt)
-
             if exists(data_file_name):
                 os.remove(data_file_name)
-
-            if self._gtkwave_fmt == "ghw":
-                cmd += ["--wave=%s" % data_file_name]
-            elif self._gtkwave_fmt == "vcd":
-                cmd += ["--vcd=%s" % data_file_name]
-
         else:
             data_file_name = None
+
+        cmd = self._get_command(
+            config, script_path, elaborate_only, ghdl_e, data_file_name
+        )
 
         status = True
         try:

--- a/vunit/sim_if/ghdl.py
+++ b/vunit/sim_if/ghdl.py
@@ -13,6 +13,7 @@ import os
 import logging
 import subprocess
 import shlex
+from json import dump
 from sys import stdout  # To avoid output catched in non-verbose mode
 from warnings import warn
 from ..exceptions import CompileError
@@ -277,6 +278,13 @@ class GHDLInterface(SimulatorInterface):
             cmd += sim
             if elaborate_only:
                 cmd += ["--no-run"]
+        else:
+            try:
+                os.makedirs(output_path, mode=0o777)
+            except OSError:
+                pass
+            with open(join(output_path, "args.json"), "w") as fname:
+                dump({"build": cmd, "sim": sim}, fname)
 
         return cmd
 


### PR DESCRIPTION
Close #579

In the first commit of this PR, ghdl_interface is refactored to:

- Accumulate compilation and simulation arguments in separate variables.
- Manipulate/generate all the arguments in `_get_command`, not in `simulate`.

In the second commit, runtime arguments (`cmd` and `sim`) are saved to a `args.JSON` file when `ghdl_e` is used.