### PR TITLE
update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,13 +4,13 @@
 *.o
 *.so
 *.egg-info
-.vscode
 .devcontainer
+.tox
+.vscode
 docs/_build
 docs/examples.rst
 docs/release_notes.rst
-.tox
-vunit/test/acceptance/*_out
-vunit/test/unit/test_report_output.txt
 env/
+tests/acceptance/*_out
+tests/unit/test_report_output.txt
 venv/

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,5 @@ env/
 tests/acceptance/*_out
 tests/unit/test_report_output.txt
 venv/
+vunit/vhdl/check/test/tb_check_equal.vhd
+vunit/vhdl/check/test/tb_check_match.vhd

--- a/tests/acceptance/test_artificial.py
+++ b/tests/acceptance/test_artificial.py
@@ -26,7 +26,7 @@ class TestVunitArtificial(unittest.TestCase):
 
     def setUp(self):
         # Spaces in path intentional to verify that it is supported
-        self.output_path = join(dirname(__file__), "artificial out")
+        self.output_path = join(dirname(__file__), "artificial_out")
         self.report_file = join(self.output_path, "xunit.xml")
         self.artificial_run_vhdl = join(
             dirname(__file__), "artificial", "vhdl", "run.py"


### PR DESCRIPTION
Some minor fixes to `.gitignore`, plus ensuring that all temporal output directories end in `*_out`.