### PR TITLE
Use integer_array_t instead of array_t

### DIFF
--- a/examples/vhdl/array/run.py
+++ b/examples/vhdl/array/run.py
@@ -8,9 +8,9 @@
 Array
 -----
 
-Demonstrates the ``array_t`` data type of ``array_pkg.vhd`` which
-can be used to handle dynamically sized 1D, 2D and 3D data as well
-as storing and loading it from csv and raw files.
+Demonstrates the ``integer_array_t`` data type, which can be used to
+handle dynamically sized 1D, 2D and 3D data as well as storing and
+loading it from csv and raw files.
 """
 
 from os.path import join, dirname
@@ -20,12 +20,14 @@ root = dirname(__file__)
 
 vu = VUnit.from_argv()
 vu.add_osvvm()
-vu.add_array_util()
 
 src_path = join(dirname(__file__), "src")
 
 vu.add_library("lib").add_source_files(
     [join(src_path, "*.vhd"), join(src_path, "test", "*.vhd")]
 )
+
+vu.set_compile_option("ghdl.flags", ["-frelaxed"])
+vu.set_sim_option("ghdl.elab_flags", ["-frelaxed"])
 
 vu.main()

--- a/examples/vhdl/array/src/test/tb_sobel_x.vhd
+++ b/examples/vhdl/array/src/test/tb_sobel_x.vhd
@@ -10,59 +10,76 @@ use ieee.numeric_std.all;
 
 library vunit_lib;
 context vunit_lib.vunit_context;
-use vunit_lib.array_pkg.all;
-
 
 library osvvm;
-use osvvm.RandomPkg.all;
+use osvvm.RandomPkg.RandomPType;
 
 entity tb_sobel_x is
   generic (
     runner_cfg : string;
-    tb_path : string);
+    tb_path    : string
+  );
 end entity;
 
 architecture tb of tb_sobel_x is
-  signal clk : std_logic := '0';
-  signal input_tvalid : std_logic := '0';
-  signal input_tlast : std_logic := '0';
-  signal input_tdata : unsigned(14-1 downto 0) := (others => '0');
-  signal output_tvalid : std_logic;
-  signal output_tlast : std_logic;
-  signal output_tdata : signed(input_tdata'length downto 0);
 
-  shared variable image : array_t;
-  shared variable reference_image : array_t;
+  signal clk           : std_logic := '0';
+  signal input_tvalid  : std_logic := '0';
+  signal input_tlast   : std_logic := '0';
+  signal input_tdata   : unsigned(13 downto 0) := (others => '0');
+  signal output_tvalid : std_logic;
+  signal output_tlast  : std_logic;
+  signal output_tdata  : signed(input_tdata'length downto 0);
+
+  shared variable image, ref_image : integer_array_t;
   signal start, data_check_done, stimuli_done : boolean := false;
+
 begin
 
   main : process
-    procedure sobel_x(variable image : inout array_t;
-                      variable result : inout array_t) is
+    impure function sobel_x (
+      constant image : integer_array_t
+    ) return integer_array_t is
+      variable result: integer_array_t := new_2d(
+        width     => width(image),
+        height    => height(image),
+        bit_width => bit_width(image)+1,
+        is_signed => true
+      );
     begin
-      result.init_2d(width => image.width,
-                     height => image.height,
-                     bit_width => image.bit_width+1,
-                     is_signed => true);
-
-      for y in 0 to image.height-1 loop
-        for x in 0 to image.width-1 loop
-          result.set(x => x, y => y,
-                     value => (image.get(minimum(x+1, image.width-1),y) -
-                               image.get(maximum(x-1, 0), y)));
+      for y in 0 to height(image)-1 loop
+        for x in 0 to width(image)-1 loop
+          set(
+            result,
+            x => x,
+            y => y,
+            value => (
+              get(image, minimum(x+1, width(image)-1),y)
+              - get(image, maximum(x-1, 0), y)
+            )
+          );
         end loop;
       end loop;
-
-    end procedure;
+    return result;
+    end;
 
     variable rnd : RandomPType;
 
-    procedure randomize(variable arr : inout array_t) is
+    impure function randomize (
+      constant width, height, bit_width: natural
+    ) return integer_array_t is
+      variable image: integer_array_t := new_2d(
+        width     => width,
+        height    => height,
+        bit_width => bit_width,
+        is_signed => false
+      );
     begin
-      for idx in 0 to arr.length-1 loop
-        arr.set(idx, value => rnd.RandInt(arr.lower_limit, arr.upper_limit));
+      for idx in 0 to length(image)-1 loop
+        set(image, idx, value => rnd.RandInt(lower_limit(image), upper_limit(image)));
       end loop;
-    end procedure;
+      return image;
+    end;
 
     procedure run_test is
     begin
@@ -71,18 +88,17 @@ begin
       wait until rising_edge(clk);
       start <= false;
 
-      wait until (stimuli_done and
-                  data_check_done and
-                  rising_edge(clk));
+      wait until (
+        stimuli_done and
+        data_check_done and
+        rising_edge(clk)
+      );
     end procedure;
 
     procedure test_random_image(width, height : natural) is
     begin
-      image.init_2d(width => width, height => height,
-                    bit_width => input_tdata'length,
-                    is_signed => false);
-      randomize(image);
-      sobel_x(image, result => reference_image);
+      image := randomize(width, height, input_tdata'length);
+      ref_image := sobel_x(image);
       run_test;
     end procedure;
 
@@ -96,8 +112,8 @@ begin
         test_random_image(16, 1);
         test_random_image(1, 1);
       elsif run("test_input_file_against_output_file") then
-        image.load_csv(tb_path & "input.csv");
-        reference_image.load_csv(tb_path & "output.csv");
+        image := load_csv(tb_path & "input.csv");
+        ref_image := load_csv(tb_path & "output.csv");
         run_test;
       end if;
     end loop;
@@ -110,20 +126,22 @@ begin
     wait until start and rising_edge(clk);
     stimuli_done <= false;
 
-    report ("Sending image of size " &
-            to_string(image.width) & "x" &
-            to_string(image.height));
+    report (
+      "Sending image of size " &
+      to_string(width(image)) & "x" &
+      to_string(height(image))
+    );
 
-    for y in 0 to image.height-1 loop
-      for x in 0 to image.width-1 loop
+    for y in 0 to height(image)-1 loop
+      for x in 0 to width(image)-1 loop
         wait until rising_edge(clk);
         input_tvalid <= '1';
-        if x = image.width-1 then
+        if x = width(image)-1 then
           input_tlast <= '1';
         else
           input_tlast <= '0';
         end if;
-        input_tdata <= to_unsigned(image.get(x,y), input_tdata'length);
+        input_tdata <= to_unsigned(get(image, x, y), input_tdata'length);
       end loop;
     end loop;
 
@@ -137,17 +155,19 @@ begin
   begin
     wait until start and rising_edge(clk);
     data_check_done <= false;
-    for y in 0 to reference_image.height-1 loop
-      for x in 0 to reference_image.width-1 loop
+    for y in 0 to height(ref_image)-1 loop
+      for x in 0 to width(ref_image)-1 loop
         wait until output_tvalid = '1' and rising_edge(clk);
-        check_equal(output_tlast, x = reference_image.width-1);
-        check_equal(output_tdata, reference_image.get(x, y),
+        check_equal(output_tlast, x = width(ref_image)-1);
+        check_equal(output_tdata, get(ref_image, x, y),
                     "x=" & to_string(x) & " y=" & to_string(y));
       end loop;
     end loop;
-    report ("Done checking image of size " &
-            to_string(reference_image.width) & "x" &
-            to_string(reference_image.height));
+    report (
+      "Done checking image of size " &
+      to_string(width(ref_image)) & "x" &
+      to_string(height(ref_image))
+    );
     data_check_done <= true;
   end process;
 
@@ -155,7 +175,8 @@ begin
 
   dut : entity work.sobel_x
     generic map (
-      data_width => input_tdata'length)
+      data_width => input_tdata'length
+    )
     port map (
       clk           => clk,
       input_tvalid  => input_tvalid,
@@ -163,6 +184,7 @@ begin
       input_tdata   => input_tdata,
       output_tvalid => output_tvalid,
       output_tlast  => output_tlast,
-      output_tdata  => output_tdata);
+      output_tdata  => output_tdata
+    );
 
 end architecture;

--- a/examples/vhdl/array_axis_vcs/run.py
+++ b/examples/vhdl/array_axis_vcs/run.py
@@ -8,11 +8,9 @@
 Array and AXI4 Stream Verification Components
 ---------------------------------------------
 
-Demonstrates ``array_t``, ``axi_stream_master_t`` and ``axi_stream_slave_t``
-data types of ``array_pkg.vhd``, ``stream_master_pkg`` and ``stream_slave_pkg``,
-respectively. Also, ``push_axi_stream`` of ``axi_stream_pkg`` is used. A CSV file
-is read, the content is sent in a row-major order to an AXI Stream buffer (FIFO)
-and it is received back to be saved in a different file. Further information can
+Shows how to use ``integer_array_t``, ``axi_stream_master_t`` and ``axi_stream_slave_t``.
+A CSV file is read, the content is sent in a row-major order to an AXI Stream buffer
+(FIFO) and it is received back to be saved in a different file. Further information can
 be found in the :ref:`verification component library user guide <vc_library>`,
 in subsection :ref:`Stream <stream_vci>` and in
 :vunit_file:`vhdl/verification_components/test/tb_axi_stream.vhd <vunit/vhdl/verification_components/test/tb_axi_stream.vhd>`.
@@ -22,9 +20,6 @@ from os.path import join, dirname
 from vunit import VUnit
 
 vu = VUnit.from_argv()
-
-vu.add_osvvm()
-vu.add_array_util()
 vu.add_verification_components()
 
 src_path = join(dirname(__file__), "src")

--- a/examples/vhdl/array_axis_vcs/src/test/tb_axis_loop.vhd
+++ b/examples/vhdl/array_axis_vcs/src/test/tb_axis_loop.vhd
@@ -17,7 +17,6 @@ context ieee.ieee_std_context;
 library vunit_lib;
 context vunit_lib.vunit_context;
 context vunit_lib.vc_context;
-use vunit_lib.array_pkg.all;
 
 entity tb_axis_loop is
   generic (
@@ -32,13 +31,13 @@ architecture tb of tb_axis_loop is
 
   -- Simulation constants
 
-  constant clk_period : time := 20 ns;
+  constant clk_period : time    := 20 ns;
   constant data_width : natural := 32;
 
   -- AXI4Stream Verification Components
 
   constant master_axi_stream : axi_stream_master_t := new_axi_stream_master(data_length => data_width);
-  constant slave_axi_stream : axi_stream_slave_t := new_axi_stream_slave(data_length => data_width);
+  constant slave_axi_stream  : axi_stream_slave_t  := new_axi_stream_slave(data_length => data_width);
 
   -- Signals to/from the UUT from/to the verification components
 
@@ -48,7 +47,8 @@ architecture tb of tb_axis_loop is
   -- tb signals and variables
 
   signal clk, rst, rstn : std_logic := '0';
-  shared variable m_I, m_O : array_t;
+  constant m_I : integer_array_t := load_csv(tb_path & csv_i);
+  constant m_O : integer_array_t := new_2d(width(m_I), height(m_I), data_width, true);
   signal start, done, saved : boolean := false;
 
 begin
@@ -85,15 +85,13 @@ begin
     done <= false;
     wait until rising_edge(clk);
 
-    m_I.load_csv(tb_path & csv_i);
+    info("Sending m_I of size " & to_string(height(m_I)) & "x" & to_string(width(m_I)) & " to UUT...");
 
-    info("Sending m_I of size " & to_string(m_I.height) & "x" & to_string(m_I.width) & " to UUT...");
-
-    for y in 0 to m_I.height-1 loop
-      for x in 0 to m_I.width-1 loop
+    for y in 0 to height(m_I)-1 loop
+      for x in 0 to width(m_I)-1 loop
         wait until rising_edge(clk);
-        if x = m_I.width-1 then last := '1'; else last := '0'; end if;
-        push_axi_stream(net, master_axi_stream, std_logic_vector(to_signed(m_I.get(x,y), data_width)) , tlast => last);
+        if x = width(m_I)-1 then last := '1'; else last := '0'; end if;
+        push_axi_stream(net, master_axi_stream, std_logic_vector(to_signed(get(m_I, x, y), data_width)) , tlast => last);
       end loop;
     end loop;
 
@@ -111,24 +109,22 @@ begin
     saved <= false;
     wait for 50*clk_period;
 
-    m_O.init_2d(m_I.width, m_I.height, o'length, true);
+    info("Receiving m_O of size " & to_string(height(m_O)) & "x" & to_string(width(m_O)) & " from UUT...");
 
-    info("Receiving m_O of size " & to_string(m_O.height) & "x" & to_string(m_O.width) & " from UUT...");
-
-    for y in 0 to m_O.height-1 loop
-      for x in 0 to m_O.width-1 loop
+    for y in 0 to height(m_O)-1 loop
+      for x in 0 to width(m_O)-1 loop
         pop_axi_stream(net, slave_axi_stream, tdata => o, tlast => last);
-        if (x = m_O.width-1) and (last='0') then
+        if (x = width(m_O)-1) and (last='0') then
           error("Something went wrong. Last misaligned!");
         end if;
-        m_O.set(x,y,to_integer(signed(o)));
+        set(m_O, x, y, to_integer(signed(o)));
       end loop;
     end loop;
 
     info("m_O read!");
 
     wait until rising_edge(clk);
-    m_O.save_csv(tb_path & csv_o);
+    save_csv(m_O, tb_path & csv_o);
 
     info("m_O saved!");
 
@@ -140,23 +136,27 @@ begin
 
   vunit_axism: entity vunit_lib.axi_stream_master
   generic map (
-    master => master_axi_stream)
+    master => master_axi_stream
+  )
   port map (
     aclk   => clk,
     tvalid => m_valid,
     tready => m_ready,
     tdata  => m_data,
-    tlast  => m_last);
+    tlast  => m_last
+  );
 
   vunit_axiss: entity vunit_lib.axi_stream_slave
   generic map (
-    slave => slave_axi_stream)
+    slave => slave_axi_stream
+  )
   port map (
     aclk   => clk,
     tvalid => s_valid,
     tready => s_ready,
     tdata  => s_data,
-    tlast  => s_last);
+    tlast  => s_last
+  );
 
 --
 

--- a/vunit/builtins.py
+++ b/vunit/builtins.py
@@ -10,6 +10,7 @@ Functions to add builtin VHDL code to a project for compilation
 
 from os.path import join, abspath, dirname, basename
 from glob import glob
+from warnings import warn
 from vunit.vhdl_standard import VHDL
 from vunit.sim_if.common import simulator_check
 
@@ -127,6 +128,12 @@ class Builtins(object):
         """
         if not self._vhdl_standard >= VHDL.STD_2008:
             raise RuntimeError("Array util only supports vhdl 2008 and later")
+
+        arr_deprecation_note = (
+            "'array_t' is deprecated and it will removed in future releases;"
+            "use 'integer_array_t' instead"
+        )
+        warn(arr_deprecation_note, Warning)
 
         self._vunit_lib.add_source_files(join(VHDL_PATH, "array", "src", "*.vhd"))
 


### PR DESCRIPTION
In this PR, examples 'array' and 'array_axis_vcs' are modified to use `integer_array_t` instead of `array_t`. Also, a deprecation warning is added, which is shown when `add_array_util()` is used.

This PR is expected to be merged in the next release, and the following removal branch should be merged in future releases: https://github.com/1138-4EB/vunit/compare/array_t...1138-4EB:rm-array_pkg?expand=1

Ref https://github.com/1138-4EB/vunit/commit/9020d6ed6802d70a7f8561734eab29f67e044489#r36134178