### PR TITLE
ci: add GHA workflow 'coverage'

### DIFF
--- a/.github/run.sh
+++ b/.github/run.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env sh
+
+docker run --rm -t \
+  -v $(pwd):/src \
+  -w /src \
+  -e PYTHONPATH=/src \
+  "$IMAGE" \
+  "$@"

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,37 @@
+name: 'coverage'
+
+on:
+  push:
+  schedule:
+    - cron: '0 0 * * 5'
+
+jobs:
+
+  coverage:
+    runs-on: ubuntu-latest
+    env:
+      DOCKER_REGISTRY: docker.pkg.github.com
+      IMAGE: docker.pkg.github.com/vunit/vunit/dev:llvm
+    steps:
+    - uses: actions/checkout@v1
+    - run: git submodule update --init --recursive
+    - uses: actions/setup-python@v1
+      with:
+        python-version: 3.7
+    - name: Docker login
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        echo "$GITHUB_TOKEN" | docker login -u vunit-gha --password-stdin "$DOCKER_REGISTRY"
+        docker pull $IMAGE
+        docker logout "$DOCKER_REGISTRY"
+    - name: Run coverage
+      run: |
+        ./.github/run.sh tox -e coverage
+        ./.github/run.sh coverage html --directory=htmlcov
+    - name: Report coverage
+      run: ./.github/run.sh coverage report -m --skip-covered
+    - uses: actions/upload-artifact@master
+      with:
+        name: VUnit_coverage
+        path: htmlcov

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{36,37,38}-fmt, py{36,37,38}-{unit}, py{36,37,38}-{lint,docs}, py{36,37,38}-{acceptance,vcomponents}-{activehdl,ghdl,modelsim,rivierapro}
+envlist = py{36,37,38}-fmt, py{36,37,38}-{unit}, py{36,37,38}-{lint,docs}, py{36,37,38}-{acceptance,vcomponents}-{activehdl,ghdl,modelsim,rivierapro}, py{36,37,38}-coverage
 skip_missing_interpreters = True
 
 [testenv]
@@ -12,6 +12,10 @@ deps=
     lint: pycodestyle
     lint: pylint
     lint: mypy
+    coverage: coverage
+    coverage: pycodestyle
+    coverage: pylint
+    coverage: mypy
     docs: docutils
     docs: sphinx
     docs: sphinx-argparse
@@ -30,3 +34,4 @@ commands=
     docs:        {envpython} tools/build_docs.py {envtmpdir}/docsbuild {posargs}
     acceptance:  {envpython} -m pytest -v -ra tests/acceptance {posargs}
     vcomponents: {envpython} vunit/vhdl/verification_components/run.py --clean
+    coverage:    {envpython} -m coverage run --branch --source vunit/ -m unittest discover tests/


### PR DESCRIPTION
This PR adds a GitHub Actions workflow to run `coverage` once a week, or whenever a branch is pushed to this repo; but not for PRs. The report is shown in the log of the job, and the HTML report is uploaded as an artifact of the job. See, for example, https://github.com/1138-4EB/vunit/commit/e84b1cf1c5681b03bcb79f935c8028084ed94aa5/checks?check_suite_id=334299964

In the future, GHA will be hopefully enhanced to support displaying the results: actions/upload-artifact#14. Alternatively, it'd be possible to automatically add the HTML report to vunit.github.io or vunit.github.io/vunit. 