### PR TITLE
ci: add GHA workflow 'push'

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -7,9 +7,6 @@ environment:
     # For Python versions available on Appveyor, see
     # https://www.appveyor.com/docs/windows-images-software/#python
 
-    - BUILD_NAME: py36-unit
-      PYTHON: "C:\\Python36"
-
     - BUILD_NAME: py38-unit
       PYTHON: "C:\\Python38"
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,47 @@
+name: 'docs'
+
+on: [ push, pull_request ]
+
+env:
+  # https://github.com/tox-dev/tox/issues/1468
+  PY_COLORS: 1
+
+jobs:
+
+  docs:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+      with:
+        submodules: recursive
+    - uses: actions/setup-python@v1
+      with:
+        python-version: 3.7
+    - name: install dependencies
+      run: |
+        pip install -U pip --progress-bar off
+        pip install -U virtualenv tox --progress-bar off
+    - name: build docs
+      run: tox -e py37-docs
+    - name: 'publish site to gh-pages'
+      if: github.event_name != 'pull_request' && github.repository == 'VUnit/vunit'
+      env:
+        GH_DEPKEY: ${{ secrets.VUNIT_GITHUB_IO_DEPLOY_KEY }}
+      run: |
+        cd .tox/py37-docs/tmp/docsbuild/
+        touch .nojekyll
+
+        git init
+        git add .
+        git config --local user.email "push@gha"
+        git config --local user.name "GHA"
+        git commit -a -m "update ${{ github.sha }}"
+
+        git remote add origin git@github.com:VUnit/VUnit.github.io
+
+        eval `ssh-agent -t 60 -s`
+        echo "$GH_DEPKEY" | ssh-add -
+        mkdir -p ~/.ssh/
+        ssh-keyscan github.com >> ~/.ssh/known_hosts
+        git push -u origin +master
+        ssh-agent -k

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -1,0 +1,110 @@
+name: 'push'
+
+on: [ push, pull_request ]
+
+env:
+  DOCKER_REGISTRY: docker.pkg.github.com
+  # https://github.com/tox-dev/tox/issues/1468
+  PY_COLORS: 1
+
+jobs:
+
+  fmt:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - uses: actions/setup-python@v1
+      with:
+        python-version: 3.7
+    - name: install dependencies
+      run: |
+        pip install -U pip --progress-bar off
+        pip install -U virtualenv tox --progress-bar off
+    - name: run 'black'
+      run: tox -e py37-fmt -- --check
+
+  lin:
+    strategy:
+      fail-fast: false
+      max-parallel: 2
+      matrix:
+        task: [
+          37-lint,
+          36-unit,
+          37-unit,
+        ]
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - uses: actions/setup-python@v1
+      with:
+        python-version: 3.7
+    - name: install dependencies
+      run: |
+        pip install -U pip --progress-bar off
+        pip install -U virtualenv tox --progress-bar off
+    - name: run job
+      run: |
+        tox -e py${{ matrix.task }} -- --color=yes
+
+  docker:
+    strategy:
+      fail-fast: false
+      max-parallel: 2
+      matrix:
+        task: [
+          {do: 38-acceptance,  tag: llvm},
+          {do: 38-vcomponents, tag: mcode},
+        ]
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+      with:
+        submodules: recursive
+    - name: docker login
+      run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login -u vunit-gha --password-stdin "$DOCKER_REGISTRY"
+    - name: run job
+      run: |
+        docker run --rm -tv $(pwd):/src -w /src "$DOCKER_REGISTRY"/vunit/vunit/dev:${{ matrix.task.tag }} tox -e py${{ matrix.task.do }}-ghdl
+    - name: docker logout
+      run: docker logout "$DOCKER_REGISTRY"
+      if: always()
+
+  win:
+    strategy:
+      fail-fast: false
+      max-parallel: 4
+      matrix:
+        task: [
+          37-acceptance-ghdl,
+          37-vcomponents-ghdl,
+          37-lint,
+          36-unit,
+          37-unit,
+        ]
+    runs-on: windows-latest
+    steps:
+    - uses: actions/checkout@v1
+    - name: git submodule update
+      run: git submodule update --init --recursive
+      if: (endsWith( matrix.task, '-lint' ) || endsWith( matrix.task, '-unit' )) == false
+    - uses: actions/setup-python@v1
+      with:
+        python-version: 3.7
+    - name: install dependencies
+      run: |
+        pip install -U pip --progress-bar off
+        pip install -U virtualenv tox --progress-bar off
+    - name: install GHDL
+      if: endsWith( matrix.task, '-ghdl' )
+      shell: bash
+      run: |
+        curl -fsSL -o ghdl.zip https://github.com/ghdl/ghdl/releases/download/v0.36/ghdl-0.36-mingw32-mcode.zip
+        7z x ghdl.zip "-o../ghdl" -y
+        mv ../ghdl/GHDL/0.36-mingw32-mcode/ ../ghdl-v0.36
+        rm -rf ../ghdl ghdl.zip
+    - name: run job
+      shell: bash
+      run: |
+        export PATH=$PATH:$(pwd)/../ghdl-v0.36/bin
+        tox -e py${{ matrix.task }} -- --color=yes

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: python
+python: '3.8'
 install: pip install tox
-script: tox -e $BUILD_NAME
+script: PY_COLORS=1 tox -e $BUILD_NAME
 
 stages:
   - test
@@ -22,45 +23,19 @@ matrix:
       - BUILD_NAME=py38-vcomponents-ghdl
       - DOCKER_IMAGE=mcode
 
-
   - env: BUILD_NAME=py38-fmt
-    python: '3.8'
-    script: tox -e $BUILD_NAME -- --check
+    script: PY_COLORS=1 tox -e $BUILD_NAME -- --check
 
+  - env: BUILD_NAME="py38-lint -- --color=yes"
 
-  - env: BUILD_NAME=py38-lint
-    dist: xenial
-    python: '3.8'
-
-
-  - env: BUILD_NAME=py36-unit
-    python: '3.6'
-  - env: BUILD_NAME=py38-unit
-    dist: xenial
-    python: '3.8'
-
+  - env: BUILD_NAME="py38-unit -- --color=yes"
 
   - env: BUILD_NAME=py38-docs
-    python: '3.8'
     before_script: git fetch --unshallow --tags
-    after_success: touch .tox/${BUILD_NAME}/tmp/docsbuild/.nojekyll
-    deploy:
-      provider: pages
-      repo: VUnit/VUnit.github.io
-      target_branch: master
-      local_dir: .tox/${BUILD_NAME}/tmp/docsbuild/
-      # This environment variable is set to an OAuth token in travis vunit settings
-      github_token: $GITHUB_PAGES_TOKEN
-      skip_cleanup: true
-      on:
-        repo: VUnit/vunit
-        branch: master
-
 
   # Deploy to PyPI whenever the package version has changed
   # When a package version has not changed a new upload will not be triggered
   - stage: deploy
-    python: '3.8'
     if: tag IS present
     script:
       - git fetch --unshallow --tags

--- a/tox.ini
+++ b/tox.ini
@@ -25,8 +25,8 @@ setenv=
 
 commands=
     fmt:         {envpython} -m black ./ --exclude 'vunit\/vhdl\/JSON-for-VHDL|\.eggs|\.git|\.hg|\.mypy_cache|\.nox|\.tox|\.venv|_build|buck-out|build|dist' {posargs}
-    unit:        {envpython} -m pytest -v tests/unit
-    lint:        {envpython} -m pytest -v tests/lint
+    unit:        {envpython} -m pytest -v -ra tests/unit {posargs}
+    lint:        {envpython} -m pytest -v -ra tests/lint {posargs}
     docs:        {envpython} tools/build_docs.py {envtmpdir}/docsbuild
-    acceptance:  {envpython} -m pytest -v tests/acceptance
+    acceptance:  {envpython} -m pytest -v -ra tests/acceptance {posargs}
     vcomponents: {envpython} vunit/vhdl/verification_components/run.py --clean


### PR DESCRIPTION
As commented in https://github.com/VUnit/vunit/pull/536#issuecomment-560049757, this PR is a subset of #536:

- Travis:
  - All non-py38 jobs are removed.
  - The docs are built, but the site is not updated.
  - Releases to PyPI are still handled by Travis.
  - Colouring is fixed.
- Appveyor:
  - All non-py38 jobs are removed.
- GitHub Actions:
  - A workflow named 'push' is added, which is executed after each push or pull request. It includes:
    - `ubuntu-latest`: py37-fmt, 37-lint, 36-unit, 37-unit.
    - docker images: py38-acceptance-ghdl, py38-vcomponents-ghdl.
    - `windows-latest`: `37-acceptance-ghdl`, `37-vcomponents-ghdl`, `37-lint`, `36-unit`, `37-unit`.
  - A workflow named 'docs' is added, where `py37-docs` is executed and the site is updated.
