### PR TITLE
Add get_simulator_name() to ui

### DIFF
--- a/tests/unit/test_ui.py
+++ b/tests/unit/test_ui.py
@@ -1193,6 +1193,10 @@ end architecture;
             sorted(expected, key=lambda x: x.name),
         )
 
+    def test_get_simulator_name(self):
+        ui = self._create_ui()
+        self.assertEqual(ui.get_simulator_name(), "mock")
+
     def _create_ui(self, *args):
         """ Create an instance of the VUnit public interface class """
         with mock.patch(

--- a/vunit/ui/__init__.py
+++ b/vunit/ui/__init__.py
@@ -1049,3 +1049,13 @@ avoid location preprocessing of other functions sharing name with a VUnit log or
                 for source_file in source_files
             ]
         )
+
+    def get_simulator_name(self):
+        """
+        Get the name of the simulator used.
+
+        Will return None if no simulator was found.
+        """
+        if self._simulator_class is None:
+            return None
+        return self._simulator_class.name


### PR DESCRIPTION
In my `run.py` I want to do different things depending on what simulator the user is running. That might be things like using different locations for precompiled simlib, not adding some sources when using ghdl, etc.

This PR is a suggestion for a simple interface that solves my use case. Feel free to provide feedback.