### PR TITLE
examples/vhdl: use pathlib instead of join and dirname

### DIFF
--- a/examples/vhdl/array/run.py
+++ b/examples/vhdl/array/run.py
@@ -13,18 +13,16 @@ handle dynamically sized 1D, 2D and 3D data as well as storing and
 loading it from csv and raw files.
 """
 
-from os.path import join, dirname
+from pathlib import Path
 from vunit import VUnit
-
-root = dirname(__file__)
 
 vu = VUnit.from_argv()
 vu.add_osvvm()
 
-src_path = join(dirname(__file__), "src")
+src_path = Path(__file__).parent / "src"
 
 vu.add_library("lib").add_source_files(
-    [join(src_path, "*.vhd"), join(src_path, "test", "*.vhd")]
+    [src_path / "*.vhd", src_path / "test" / "*.vhd"]
 )
 
 vu.set_compile_option("ghdl.flags", ["-frelaxed"])

--- a/examples/vhdl/array_axis_vcs/run.py
+++ b/examples/vhdl/array_axis_vcs/run.py
@@ -16,17 +16,15 @@ in subsection :ref:`Stream <stream_vci>` and in
 :vunit_file:`vhdl/verification_components/test/tb_axi_stream.vhd <vunit/vhdl/verification_components/test/tb_axi_stream.vhd>`.
 """
 
-from os.path import join, dirname
+from pathlib import Path
 from vunit import VUnit
 
 vu = VUnit.from_argv()
 vu.add_verification_components()
 
-src_path = join(dirname(__file__), "src")
+src_path = Path(__file__).parent / "src"
 
-vu.add_library("lib").add_source_files(
-    [join(src_path, "*.vhd"), join(src_path, "**", "*.vhd")]
-)
+vu.add_library("lib").add_source_files([src_path / "*.vhd", src_path / "**" / "*.vhd"])
 
 # vu.set_sim_option('modelsim.init_files.after_load',['runall_addwave.do'])
 

--- a/examples/vhdl/axi_dma/run.py
+++ b/examples/vhdl/axi_dma/run.py
@@ -15,17 +15,17 @@ external memory. The AXI DMA also has a control register interface
 via AXI-lite.
 """
 
-from os.path import join, dirname
+from pathlib import Path
 from vunit import VUnit
 
 vu = VUnit.from_argv()
 vu.add_osvvm()
 vu.add_verification_components()
 
-src_path = join(dirname(__file__), "src")
+src_path = Path(__file__).parent / "src"
 
 vu.add_library("axi_dma_lib").add_source_files(
-    [join(src_path, "*.vhd"), join(src_path, "test", "*.vhd")]
+    [src_path / "*.vhd", src_path / "test" / "*.vhd"]
 )
 
 vu.main()

--- a/examples/vhdl/check/run.py
+++ b/examples/vhdl/check/run.py
@@ -11,7 +11,7 @@ Check
 Demonstrates the VUnit check library.
 """
 
-from os.path import join, dirname
+from pathlib import Path
 from vunit import VUnit
 
 vu = VUnit.from_argv()
@@ -38,6 +38,6 @@ vu.enable_location_preprocessing(
 
 vu.enable_check_preprocessing()
 
-vu.add_library("lib").add_source_files(join(dirname(__file__), "tb_example.vhd"))
+vu.add_library("lib").add_source_files(Path(__file__).parent / "tb_example.vhd")
 
 vu.main()

--- a/examples/vhdl/com/run.py
+++ b/examples/vhdl/com/run.py
@@ -13,7 +13,7 @@ to communicate arbitrary objects between processes.  Further reading
 can be found in the :ref:`com user guide <com_user_guide>`.
 """
 
-from os.path import join, dirname
+from pathlib import Path
 from vunit import VUnit
 
 vu = VUnit.from_argv()
@@ -21,7 +21,9 @@ vu.add_com()
 vu.add_verification_components()
 vu.add_osvvm()
 
-vu.add_library("lib").add_source_files(join(dirname(__file__), "src", "*.vhd"))
-vu.add_library("tb_lib").add_source_files(join(dirname(__file__), "test", "*.vhd"))
+root = Path(__file__).parent
+
+vu.add_library("lib").add_source_files(root / "src" / "*.vhd")
+vu.add_library("tb_lib").add_source_files(root / "test" / "*.vhd")
 
 vu.main()

--- a/examples/vhdl/composite_generics/run.py
+++ b/examples/vhdl/composite_generics/run.py
@@ -11,7 +11,7 @@ Composite generics
 See `Enable Your Simulator to Handle Complex Top-Level Generics <https://vunit.github.io/posts/2017_06_03_enable_your_simulator_to_handle_complex_top_level_generics/post.html>`_.
 """
 
-from os.path import join, dirname
+from pathlib import Path
 from vunit import VUnit
 
 
@@ -22,7 +22,7 @@ def encode(tb_cfg):
 vu = VUnit.from_argv()
 
 tb_lib = vu.add_library("tb_lib")
-tb_lib.add_source_files(join(dirname(__file__), "test", "*.vhd"))
+tb_lib.add_source_files(Path(__file__).parent / "test" / "*.vhd")
 
 test_1 = tb_lib.test_bench("tb_composite_generics").test("Test 1")
 

--- a/examples/vhdl/coverage/run.py
+++ b/examples/vhdl/coverage/run.py
@@ -4,7 +4,7 @@
 #
 # Copyright (c) 2014-2020, Lars Asplund lars.anders.asplund@gmail.com
 
-from os.path import join, dirname
+from pathlib import Path
 from vunit import VUnit
 
 
@@ -15,7 +15,7 @@ def post_run(results):
 vu = VUnit.from_argv()
 
 lib = vu.add_library("lib")
-lib.add_source_files(join(dirname(__file__), "*.vhd"))
+lib.add_source_files(Path(__file__).parent / "*.vhd")
 
 lib.set_compile_option("rivierapro.vcom_flags", ["-coverage", "bs"])
 lib.set_compile_option("rivierapro.vlog_flags", ["-coverage", "bs"])

--- a/examples/vhdl/external_buffer/cp.py
+++ b/examples/vhdl/external_buffer/cp.py
@@ -5,25 +5,23 @@
 # Copyright (c) 2014-2020, Lars Asplund lars.anders.asplund@gmail.com
 
 from vunit import VUnit
-from os import popen
-from os.path import join, dirname
+from subprocess import check_call
+from pathlib import Path
 
-src_path = join(dirname(__file__), "src")
+src_path = Path(__file__).parent / "src"
 
-c_obj = join(src_path, "cp.o")
+c_obj = src_path / "cp.o"
 # Compile C application to an object
-print(
-    popen(" ".join(["gcc", "-fPIC", "-c", join(src_path, "cp.c"), "-o", c_obj])).read()
-)
+check_call(["gcc", "-fPIC", "-c", str(src_path / "cp.c"), "-o", str(c_obj)])
 
 # Enable the external feature for strings
 vu = VUnit.from_argv(vhdl_standard="2008", compile_builtins=False)
 vu.add_builtins({"string": True})
 
 lib = vu.add_library("lib")
-lib.add_source_files(join(src_path, "tb_extcp_*.vhd"))
+lib.add_source_files(str(src_path / "tb_extcp_*.vhd"))
 
 # Add the C object to the elaboration of GHDL
-vu.set_sim_option("ghdl.elab_flags", ["-Wl," + c_obj])
+vu.set_sim_option("ghdl.elab_flags", ["-Wl," + str(c_obj)])
 
 vu.main()

--- a/examples/vhdl/generate_tests/run.py
+++ b/examples/vhdl/generate_tests/run.py
@@ -13,7 +13,7 @@ with different generic values. Also demonstrates use of ``output_path`` generic
 to create test bench output files in location specified by VUnit python runner.
 """
 
-from os.path import join, dirname
+from pathlib import Path
 from itertools import product
 from vunit import VUnit
 
@@ -30,10 +30,10 @@ def make_post_check(data_width, sign):
 
         expected = ", ".join([str(data_width), str(sign).lower()]) + "\n"
 
-        output_file = join(output_path, "generics.txt")
+        output_file = Path(output_path) / "generics.txt"
 
-        print("Post check: %s" % output_file)
-        with open(output_file, "r") as fread:
+        print("Post check: %s" % str(output_file))
+        with output_file.open("r") as fread:
             got = fread.read()
             if not got == expected:
                 print("Content mismatch, got %r expected %r" % (got, expected))
@@ -60,11 +60,9 @@ def generate_tests(obj, signs, data_widths):
         )
 
 
-test_path = join(dirname(__file__), "test")
-
 vu = VUnit.from_argv()
 lib = vu.add_library("lib")
-lib.add_source_files(join(test_path, "*.vhd"))
+lib.add_source_files(Path(__file__).parent / "test" / "*.vhd")
 
 tb_generated = lib.test_bench("tb_generated")
 

--- a/examples/vhdl/json4vhdl/run.py
+++ b/examples/vhdl/json4vhdl/run.py
@@ -13,17 +13,17 @@ The content can be read from a file, or passed as a stringified generic.
 This is an alternative to composite generics, that supports any depth in the content structure.
 """
 
-from os.path import join, dirname
+from pathlib import Path
 from vunit import VUnit, read_json, encode_json
 
-root = dirname(__file__)
+test_path = Path(__file__).parent / "src" / "test"
 
 vu = VUnit.from_argv()
 vu.add_json4vhdl()
 
-vu.add_library("test").add_source_files(join(root, "src/test/*.vhd"))
+vu.add_library("test").add_source_files(test_path / "*.vhd")
 
-tb_cfg = read_json(join(root, "src/test/data/data.json"))
+tb_cfg = read_json(test_path / "data" / "data.json")
 tb_cfg["dump_debug_data"] = False
 vu.set_generic("tb_cfg", encode_json(tb_cfg))
 

--- a/examples/vhdl/logging/run.py
+++ b/examples/vhdl/logging/run.py
@@ -11,10 +11,10 @@ Logging
 Demonstrates VUnit's support for logging.
 """
 
-from os.path import join, dirname
+from pathlib import Path
 from vunit import VUnit
 
 vu = VUnit.from_argv()
-vu.add_library("lib").add_source_files(join(dirname(__file__), "*.vhd"))
+vu.add_library("lib").add_source_files(Path(__file__).parent / "*.vhd")
 
 vu.main()

--- a/examples/vhdl/run/run.py
+++ b/examples/vhdl/run/run.py
@@ -11,16 +11,16 @@ Run
 Demonstrates the VUnit run library.
 """
 
-from os.path import join, dirname
+from pathlib import Path
 from vunit import VUnit
 
-root = dirname(__file__)
+root = Path(__file__).parent
 
 vu = VUnit.from_argv()
 
 lib = vu.add_library("lib")
-lib.add_source_files(join(root, "*.vhd"))
+lib.add_source_files(root / "*.vhd")
 tb_with_lower_level_control = lib.entity("tb_with_lower_level_control")
-tb_with_lower_level_control.scan_tests_from_file(join(root, "test_control.vhd"))
+tb_with_lower_level_control.scan_tests_from_file(root / "test_control.vhd")
 
 vu.main()

--- a/examples/vhdl/third_party_integration/run.py
+++ b/examples/vhdl/third_party_integration/run.py
@@ -4,9 +4,9 @@
 #
 # Copyright (c) 2014-2020, Lars Asplund lars.anders.asplund@gmail.com
 
-from os.path import join, dirname
+from pathlib import Path
 from vunit import VUnit
 
 vu = VUnit.from_argv()
-vu.add_library("lib").add_source_files(join(dirname(__file__), "test", "*.vhd"))
+vu.add_library("lib").add_source_files(Path(__file__).parent / "test" / "*.vhd")
 vu.main()

--- a/examples/vhdl/uart/run.py
+++ b/examples/vhdl/uart/run.py
@@ -12,16 +12,16 @@ A more realistic test bench of an UART to show VUnit VHDL usage on a
 typical module.
 """
 
-from os.path import join, dirname
+from pathlib import Path
 from vunit import VUnit
 
 vu = VUnit.from_argv()
 vu.add_osvvm()
 vu.add_verification_components()
 
-src_path = join(dirname(__file__), "src")
+src_path = Path(__file__).parent / "src"
 
-vu.add_library("uart_lib").add_source_files(join(src_path, "*.vhd"))
-vu.add_library("tb_uart_lib").add_source_files(join(src_path, "test", "*.vhd"))
+vu.add_library("uart_lib").add_source_files(src_path / "*.vhd")
+vu.add_library("tb_uart_lib").add_source_files(src_path / "test" / "*.vhd")
 
 vu.main()

--- a/examples/vhdl/user_guide/run.py
+++ b/examples/vhdl/user_guide/run.py
@@ -12,9 +12,9 @@ The most minimal VUnit VHDL project covering the basics of the
 :ref:`User Guide <user_guide>`.
 """
 
-from os.path import join, dirname
+from pathlib import Path
 from vunit import VUnit
 
 vu = VUnit.from_argv()
-vu.add_library("lib").add_source_files(join(dirname(__file__), "*.vhd"))
+vu.add_library("lib").add_source_files(Path(__file__).parent / "*.vhd")
 vu.main()

--- a/examples/vhdl/vivado/run.py
+++ b/examples/vhdl/vivado/run.py
@@ -12,22 +12,22 @@ Demonstrates compiling and performing behavioral simulation of
 Vivado IPs with VUnit.
 """
 
-from os.path import join, dirname
+from pathlib import Path
 from vunit import VUnit
 from vivado_util import add_vivado_ip
 
-root = dirname(__file__)
-src_path = join(root, "src")
+root = Path(__file__).parent
+src_path = root / "src"
 
 vu = VUnit.from_argv()
 
-vu.add_library("lib").add_source_files(join(src_path, "*.vhd"))
-vu.add_library("tb_lib").add_source_files(join(src_path, "test", "*.vhd"))
+vu.add_library("lib").add_source_files(src_path / "*.vhd")
+vu.add_library("tb_lib").add_source_files(src_path / "test" / "*.vhd")
 
 add_vivado_ip(
     vu,
-    output_path=join(root, "vivado_libs"),
-    project_file=join(root, "myproject", "myproject.xpr"),
+    output_path=root / "vivado_libs",
+    project_file=root / "myproject" / "myproject.xpr",
 )
 
 vu.main()

--- a/vunit/ui/library.py
+++ b/vunit/ui/library.py
@@ -9,6 +9,7 @@ UI class Library
 """
 
 from os.path import abspath
+from pathlib import Path
 from glob import glob
 from fnmatch import fnmatch
 from typing import Optional, List
@@ -190,12 +191,14 @@ class Library(object):
         """
         if is_string_not_iterable(pattern):
             patterns = [pattern]
+        elif isinstance(pattern, Path):
+            patterns = [str(pattern)]
         else:
             patterns = pattern
 
         file_names: List[str] = []
         for pattern_instance in patterns:
-            new_file_names = glob(pattern_instance)
+            new_file_names = glob(str(pattern_instance))
             check_not_empty(
                 new_file_names,
                 allow_empty,


### PR DESCRIPTION
Since Python 2 is deprecated, in this PR the `run.py` files in `examples/vhdl/**` are modified to use `Path` from `pathlib`, instead of `join` and `dirname` from `os.path`.

At the same time in a couple of places `popen` from `os` was used. Those are replaced with `check_call` from `subprocess`.