### PR TITLE
fix parsing adjacent hyphens in a literal

### DIFF
--- a/tests/unit/test_vhdl_parser.py
+++ b/tests/unit/test_vhdl_parser.py
@@ -538,6 +538,10 @@ record
     def test_remove_comments(self):
         self.assertEqual(remove_comments("a\n-- foo  \nb"), "a\n        \nb")
 
+    def test_issue_529(self):
+        stimulus = "signal a : std_logic_vector(3 downto 0) := \"----\";"
+        self.assertEqual(remove_comments(stimulus), stimulus)
+
     def parse_single_entity(self, code):
         """
         Helper function to parse a single entity

--- a/tests/unit/test_vhdl_parser.py
+++ b/tests/unit/test_vhdl_parser.py
@@ -538,8 +538,8 @@ record
     def test_remove_comments(self):
         self.assertEqual(remove_comments("a\n-- foo  \nb"), "a\n        \nb")
 
-    def test_issue_529(self):
-        stimulus = "signal a : std_logic_vector(3 downto 0) := \"----\";"
+    def test_two_adjacent_hyphens_in_a_literal(self):
+        stimulus = 'signal a : std_logic_vector(3 downto 0) := "----";'
         self.assertEqual(remove_comments(stimulus), stimulus)
 
     def parse_single_entity(self, code):

--- a/vunit/vhdl_parser.py
+++ b/vunit/vhdl_parser.py
@@ -1131,7 +1131,8 @@ class VHDLReference(object):
         return self.name_within == "all"
 
 
-VHDL_REMOVE_COMMENT_RE = re.compile(r"--[^\n]*")
+VHDL_REMOVE_COMMENT_RE = r"(?:(?:\"[^\"]*\")|(--[^\n]*))"
+VHDL_REMOVE_COMMENT_COMPILED_RE = re.compile(VHDL_REMOVE_COMMENT_RE, re.MULTILINE)
 
 
 def _comment_repl(match):
@@ -1139,7 +1140,9 @@ def _comment_repl(match):
     Replace comment with equal amount of whitespace to make
     lexical position unaffected
     """
-    text = match.group(0)
+    text = match.group(1)
+    if text is None:
+        return match.group(0)
     return " " * len(text)
 
 
@@ -1147,4 +1150,4 @@ def remove_comments(code):
     """
     Return the code with comments removed
     """
-    return VHDL_REMOVE_COMMENT_RE.sub(_comment_repl, code)
+    return VHDL_REMOVE_COMMENT_COMPILED_RE.sub(_comment_repl, code)


### PR DESCRIPTION
Addresses #529 by improving the comment removal regular expression. But this time it actually works!

Will rebase into a single commit tonight.