### PR TITLE
Fix "ghdl.flags" error in documentation

### DIFF
--- a/docs/py/opts.rst
+++ b/docs/py/opts.rst
@@ -86,10 +86,6 @@ The following simulation options are known.
 ``pli``
   A list of PLI file names.
 
-``ghdl.flags``
-   Extra arguments passed to ``ghdl --elab-run`` command *before* executable specific flags.
-   Must be a list of strings.
-
 ``incisive.irun_sim_flags``
    Extra arguments passed to the Incisive ``irun`` command when loading the design.
    Must be a list of strings.


### PR DESCRIPTION
I believe this must be a copy-paste error. "ghdl.flags" is for compilation options, and is documented as such further up in the file. "ghdl.elab_flags" and "ghdl.sim_flags", which are for simulation options are documented below.