### PR TITLE
rename compile option 'ghdl.flags' to 'ghdl.a_flags'

### DIFF
--- a/docs/py/opts.rst
+++ b/docs/py/opts.rst
@@ -7,9 +7,12 @@ Compilation options allow customization of compilation behavior. Since simulator
 differing options available, generic options may be specified through this interface.
 The following compilation options are known.
 
-``ghdl.flags``
+``ghdl.a_flags``
    Extra arguments passed to ``ghdl -a`` command during compilation.
    Must be a list of strings.
+
+``ghdl.flags``
+  Deprecated alias of ``ghdl.a_flags``. It will be removed in future releases.
 
 ``incisive.irun_vhdl_flags``
    Extra arguments passed to the Incisive ``irun`` command when compiling VHDL files.

--- a/vunit/sim_if/ghdl.py
+++ b/vunit/sim_if/ghdl.py
@@ -14,6 +14,7 @@ import logging
 import subprocess
 import shlex
 from sys import stdout  # To avoid output catched in non-verbose mode
+from warnings import warn
 from ..exceptions import CompileError
 from ..ostools import Process
 from . import SimulatorInterface, ListOfStringOption, StringOption, BooleanOption
@@ -32,7 +33,10 @@ class GHDLInterface(SimulatorInterface):
     supports_gui_flag = True
     supports_colors_in_gui = True
 
-    compile_options = [ListOfStringOption("ghdl.flags")]
+    compile_options = [
+        ListOfStringOption("ghdl.a_flags"),
+        ListOfStringOption("ghdl.flags"),
+    ]
 
     sim_options = [
         ListOfStringOption("ghdl.sim_flags"),
@@ -213,7 +217,20 @@ class GHDLInterface(SimulatorInterface):
         ]
         for library in self._project.get_libraries():
             cmd += ["-P%s" % library.directory]
-        cmd += source_file.compile_options.get("ghdl.flags", [])
+
+        a_flags = source_file.compile_options.get("ghdl.a_flags", [])
+        flags = source_file.compile_options.get("ghdl.flags", [])
+        if flags != []:
+            warn(
+                (
+                    "'ghdl.flags' is deprecated and it will be removed in future releases; "
+                    "use 'ghdl.a_flags' instead"
+                ),
+                Warning,
+            )
+            a_flags += flags
+
+        cmd += a_flags
         cmd += [source_file.name]
         return cmd
 

--- a/vunit/ui/__init__.py
+++ b/vunit/ui/__init__.py
@@ -395,7 +395,7 @@ class VUnit(  # pylint: disable=too-many-instance-attributes, too-many-public-me
 
         .. code-block:: python
 
-           prj.set_sim_option("ghdl.flags", ["--no-vital-checks"])
+           prj.set_sim_option("ghdl.a_flags", ["--no-vital-checks"])
 
         .. note::
            Only affects test benches added *before* the option is set.
@@ -418,7 +418,7 @@ class VUnit(  # pylint: disable=too-many-instance-attributes, too-many-public-me
 
         .. code-block:: python
 
-           prj.set_compile_option("ghdl.flags", ["--no-vital-checks"])
+           prj.set_compile_option("ghdl.a_flags", ["--no-vital-checks"])
 
 
         .. note::

--- a/vunit/ui/library.py
+++ b/vunit/ui/library.py
@@ -94,7 +94,7 @@ class Library(object):
 
         .. code-block:: python
 
-           lib.set_sim_option("ghdl.flags", ["--no-vital-checks"])
+           lib.set_sim_option("ghdl.a_flags", ["--no-vital-checks"])
 
         .. note::
            Only affects test benches added *before* the option is set.
@@ -114,7 +114,7 @@ class Library(object):
 
         .. code-block:: python
 
-           lib.set_compile_option("ghdl.flags", ["--no-vital-checks"])
+           lib.set_compile_option("ghdl.a_flags", ["--no-vital-checks"])
 
 
         .. note::

--- a/vunit/ui/source.py
+++ b/vunit/ui/source.py
@@ -30,7 +30,7 @@ class SourceFileList(list):
 
         .. code-block:: python
 
-           files.set_compile_option("ghdl.flags", ["--no-vital-checks"])
+           files.set_compile_option("ghdl.a_flags", ["--no-vital-checks"])
         """
         for source_file in self:
             source_file.set_compile_option(name, value)
@@ -108,7 +108,7 @@ class SourceFile(object):
 
         .. code-block:: python
 
-           my_file.set_compile_option("ghdl.flags", ["--no-vital-checks"])
+           my_file.set_compile_option("ghdl.a_flags", ["--no-vital-checks"])
         """
         self._source_file.set_compile_option(name, value)
 

--- a/vunit/ui/test.py
+++ b/vunit/ui/test.py
@@ -148,7 +148,7 @@ class Test(object):
 
         .. code-block:: python
 
-           test.set_sim_option("ghdl.flags", ["--no-vital-checks"])
+           test.set_sim_option("ghdl.a_flags", ["--no-vital-checks"])
 
         """
         self._test_case.set_sim_option(name, value, overwrite)

--- a/vunit/ui/testbench.py
+++ b/vunit/ui/testbench.py
@@ -98,7 +98,7 @@ class TestBench(object):
 
         .. code-block:: python
 
-           test_bench.set_sim_option("ghdl.flags", ["--no-vital-checks"])
+           test_bench.set_sim_option("ghdl.a_flags", ["--no-vital-checks"])
 
         """
         self._test_bench.set_sim_option(name, value, overwrite)


### PR DESCRIPTION
As commented in #620, apart from renaming the option, the deprecated `ghdl.flags` is kept as an *alias* and a warning is shown. This should be kept for many releases, because it is a very used feature and the warning might be overlooked easily.