### PR TITLE
use pathlib

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -2,7 +2,7 @@
 
 import os
 import sys
-from os.path import join
+from pathlib import Path
 
 # blog_title = u"VUnit Blog"
 # blog_baseurl = "http://vunit.github.io"
@@ -70,9 +70,9 @@ html_theme_options = {
 
 html_static_path = ["_static"]
 
-html_logo = join(html_static_path[0], "VUnit_logo_420x420.png")
+html_logo = str(Path(html_static_path[0]) / "VUnit_logo_420x420.png")
 
-html_favicon = join(html_static_path[0], "vunit.ico")
+html_favicon = str(Path(html_static_path[0]) / "vunit.ico")
 
 # Output file base name for HTML help builder.
 htmlhelp_basename = "vunitdoc"

--- a/examples/vhdl/vivado/vivado_util.py
+++ b/examples/vhdl/vivado/vivado_util.py
@@ -5,7 +5,7 @@
 # Copyright (c) 2014-2020, Lars Asplund lars.anders.asplund@gmail.com
 
 import sys
-from os.path import join, exists, abspath, dirname
+from pathlib import Path
 from vunit.sim_if.factory import SIMULATOR_FACTORY
 from vunit.vivado import (
     run_vivado,
@@ -19,14 +19,16 @@ def add_vivado_ip(vunit_obj, output_path, project_file):
     Add vivado (and compile if necessary) vivado ip to vunit project.
     """
 
-    if not exists(project_file):
+    if not Path(project_file).exists():
         print("Could not find vivado project %s" % project_file)
         sys.exit(1)
 
-    standard_library_path = join(output_path, "standard")
+    opath = Path(output_path)
+
+    standard_library_path = str(opath / "standard")
     compile_standard_libraries(vunit_obj, standard_library_path)
 
-    project_ip_path = join(output_path, "project_ip")
+    project_ip_path = str(opath / "project_ip")
     add_project_ip(vunit_obj, project_file, project_ip_path)
 
 
@@ -34,12 +36,15 @@ def compile_standard_libraries(vunit_obj, output_path):
     """
     Compile Xilinx standard libraries using Vivado TCL command
     """
-    done_token = join(output_path, "all_done.txt")
+    done_token = str(Path(output_path) / "all_done.txt")
 
     simulator_class = SIMULATOR_FACTORY.select_simulator()
 
-    if not exists(done_token):
-        print("Compiling standard libraries into %s ..." % abspath(output_path))
+    if not Path(done_token).exists():
+        print(
+            "Compiling standard libraries into %s ..."
+            % str(Path(output_path).resolve())
+        )
         simname = simulator_class.name
 
         # Vivado calls rivierapro for riviera
@@ -47,7 +52,7 @@ def compile_standard_libraries(vunit_obj, output_path):
             simname = "riviera"
 
         run_vivado(
-            join(dirname(__file__), "tcl", "compile_standard_libs.tcl"),
+            str(Path(__file__).parent / "tcl" / "compile_standard_libs.tcl"),
             tcl_args=[
                 simname,
                 simulator_class.find_prefix().replace("\\", "/"),
@@ -57,12 +62,13 @@ def compile_standard_libraries(vunit_obj, output_path):
 
     else:
         print(
-            "Standard libraries already exists in %s, skipping" % abspath(output_path)
+            "Standard libraries already exists in %s, skipping"
+            % str(Path(output_path).resolve())
         )
 
     for library_name in ["unisim", "unimacro", "unifast", "secureip", "xpm"]:
-        path = join(output_path, library_name)
-        if exists(path):
+        path = str(Path(output_path) / library_name)
+        if Path(path).exists():
             vunit_obj.add_external_library(library_name, path)
 
     with open(done_token, "w") as fptr:
@@ -79,16 +85,16 @@ def add_project_ip(vunit_obj, project_file, output_path, vivado_path=None, clean
     returns the list of SourceFile objects added
     """
 
-    compile_order_file = join(output_path, "compile_order.txt")
+    compile_order_file = str(Path(output_path) / "compile_order.txt")
 
-    if clean or not exists(compile_order_file):
+    if clean or not Path(compile_order_file).exists():
         create_compile_order_file(
             project_file, compile_order_file, vivado_path=vivado_path
         )
     else:
         print(
             "Vivado project Compile order already exists, re-using: %s"
-            % abspath(compile_order_file)
+            % str(Path(compile_order_file).resolve())
         )
 
     return add_from_compile_order_file(vunit_obj, compile_order_file)

--- a/tests/acceptance/artificial/verilog/run.py
+++ b/tests/acceptance/artificial/verilog/run.py
@@ -4,14 +4,14 @@
 #
 # Copyright (c) 2014-2020, Lars Asplund lars.anders.asplund@gmail.com
 
-from os.path import join, dirname
+from pathlib import Path
 from vunit.verilog import VUnit
 
-root = dirname(__file__)
+ROOT = Path(__file__).parent
 
 VU = VUnit.from_argv()
 LIB = VU.add_library("lib")
-LIB.add_source_files(join(root, "*.sv"), defines={"DEFINE_FROM_RUN_PY": ""})
+LIB.add_source_files(ROOT / "*.sv", defines={"DEFINE_FROM_RUN_PY": ""})
 
 
 def configure_tb_with_parameter_config():
@@ -35,7 +35,7 @@ def configure_tb_with_parameter_config():
     )
 
     def post_check(output_path):
-        with open(join(output_path, "post_check.txt"), "r") as fptr:
+        with (Path(output_path) / "post_check.txt").open("r") as fptr:
             return fptr.read() == "Test 4 was here"
 
     tests[4].add_config(
@@ -49,7 +49,7 @@ def configure_tb_with_parameter_config():
 
 def configure_tb_same_sim_all_pass(ui):
     def post_check(output_path):
-        with open(join(output_path, "post_check.txt"), "r") as fptr:
+        with (Path(output_path) / "post_check.txt").open("r") as fptr:
             return fptr.read() == "Test 3 was here"
 
     module = ui.library("lib").module("tb_same_sim_all_pass")
@@ -59,6 +59,6 @@ def configure_tb_same_sim_all_pass(ui):
 configure_tb_with_parameter_config()
 configure_tb_same_sim_all_pass(VU)
 LIB.module("tb_other_file_tests").scan_tests_from_file(
-    join(root, "other_file_tests.sv")
+    str(ROOT / "other_file_tests.sv")
 )
 VU.main()

--- a/tests/acceptance/artificial/vhdl/run.py
+++ b/tests/acceptance/artificial/vhdl/run.py
@@ -4,14 +4,14 @@
 #
 # Copyright (c) 2014-2020, Lars Asplund lars.anders.asplund@gmail.com
 
-from os.path import join, dirname
+from pathlib import Path
 from vunit import VUnit
 
-root = dirname(__file__)
+ROOT = Path(__file__).parent
 
 VU = VUnit.from_argv()
 LIB = VU.add_library("lib")
-LIB.add_source_files(join(root, "*.vhd"))
+LIB.add_source_files(ROOT / "*.vhd")
 
 
 def configure_tb_with_generic_config():
@@ -33,7 +33,7 @@ def configure_tb_with_generic_config():
     )
 
     def post_check(output_path):
-        with open(join(output_path, "post_check.txt"), "r") as fptr:
+        with (Path(output_path) / "post_check.txt").open("r") as fptr:
             return "Test 4 was here" in fptr.read()
 
     tests[4].add_config(
@@ -45,7 +45,7 @@ def configure_tb_with_generic_config():
 
 def configure_tb_same_sim_all_pass(ui):
     def post_check(output_path):
-        with open(join(output_path, "post_check.txt"), "r") as fptr:
+        with (Path(output_path) / "post_check.txt").open("r") as fptr:
             return "Test 3 was here" in fptr.read()
 
     ent = ui.library("lib").entity("tb_same_sim_all_pass")
@@ -93,6 +93,6 @@ configure_tb_assert_stop_level(VU)
 LIB.entity("tb_no_generic_override").set_generic("g_val", False)
 LIB.entity("tb_ieee_warning").test("pass").set_sim_option("disable_ieee_warnings", True)
 LIB.entity("tb_other_file_tests").scan_tests_from_file(
-    join(root, "other_file_tests.vhd")
+    str(ROOT / "other_file_tests.vhd")
 )
 VU.main()

--- a/tests/acceptance/test_artificial.py
+++ b/tests/acceptance/test_artificial.py
@@ -9,12 +9,14 @@ Acceptance test of VUnit end to end functionality
 """
 
 import unittest
-from os.path import join, dirname
+from pathlib import Path
 from os import environ
 from subprocess import call
 import sys
 from tests.common import check_report
 from vunit.sim_if.common import has_simulator, simulator_is
+
+ROOT = Path(__file__).parent
 
 
 @unittest.skipUnless(has_simulator(), "Requires simulator")
@@ -26,18 +28,14 @@ class TestVunitArtificial(unittest.TestCase):
 
     def setUp(self):
         if simulator_is("activehdl"):
-            self.output_path = join(dirname(__file__), "artificial_out")
+            self.output_path = str(ROOT / "artificial_out")
         else:
             # Spaces in path intentional to verify that it is supported
-            self.output_path = join(dirname(__file__), "artificial _out")
+            self.output_path = str(ROOT / "artificial _out")
 
-        self.report_file = join(self.output_path, "xunit.xml")
-        self.artificial_run_vhdl = join(
-            dirname(__file__), "artificial", "vhdl", "run.py"
-        )
-        self.artificial_run_verilog = join(
-            dirname(__file__), "artificial", "verilog", "run.py"
-        )
+        self.report_file = str(Path(self.output_path) / "xunit.xml")
+        self.artificial_run_vhdl = str(ROOT / "artificial" / "vhdl" / "run.py")
+        self.artificial_run_verilog = str(ROOT / "artificial" / "verilog" / "run.py")
 
     @unittest.skipUnless(
         simulator_is("modelsim", "rivierapro"),

--- a/tests/acceptance/test_dependencies.py
+++ b/tests/acceptance/test_dependencies.py
@@ -11,8 +11,10 @@ tests to expose those differences.
 
 
 import unittest
-from os.path import join, dirname
+from pathlib import Path
 from vunit import VUnit
+
+ROOT = Path(__file__).parent
 
 
 class TestDependencies(unittest.TestCase):
@@ -21,8 +23,8 @@ class TestDependencies(unittest.TestCase):
     """
 
     def setUp(self):
-        self.data_path = join(dirname(__file__), "dependencies")
-        self.output_path = join(dirname(__file__), "dependencies_vunit_out")
+        self.data_path = str(ROOT / "dependencies")
+        self.output_path = str(ROOT / "dependencies_vunit_out")
 
     def test_package_body_dependencies(self):
         """
@@ -36,9 +38,11 @@ class TestDependencies(unittest.TestCase):
             Utility function to first run with pkg_body1 then pkg_body2
             """
 
-            tb_pkg_file_name = join(self.data_path, "tb_pkg.vhd")
-            pkg_file_name = join(self.data_path, "pkg.vhd")
-            pkg_body_file_name = join(self.data_path, "pkg_body%i.vhd" % value)
+            dpath = Path(self.data_path)
+
+            tb_pkg_file_name = str(dpath / "tb_pkg.vhd")
+            pkg_file_name = str(dpath / "pkg.vhd")
+            pkg_body_file_name = str(dpath / ("pkg_body%i.vhd" % value))
 
             argv = ["--output-path=%s" % self.output_path, "-v"]
             if value == 1:

--- a/tests/acceptance/test_external_run_scripts.py
+++ b/tests/acceptance/test_external_run_scripts.py
@@ -9,14 +9,16 @@ Verify that all external run scripts work correctly
 """
 
 import unittest
+from pathlib import Path
 from os import environ
-from os.path import join, dirname
 from subprocess import call
 import sys
 from tests.common import check_report
-from vunit import ROOT
+from vunit import ROOT as RSTR
 from vunit.builtins import VHDL_PATH
 from vunit.sim_if.common import has_simulator, simulator_is, simulator_check
+
+ROOT = Path(RSTR)
 
 
 def simulator_supports_verilog():
@@ -34,15 +36,15 @@ class TestExternalRunScripts(unittest.TestCase):
     """
 
     def test_vhdl_uart_example_project(self):
-        self.check(join(ROOT, "examples", "vhdl", "uart", "run.py"))
+        self.check(ROOT / "examples" / "vhdl" / "uart" / "run.py")
 
     @unittest.skipUnless(simulator_supports_verilog(), "Verilog")
     def test_verilog_uart_example_project(self):
-        self.check(join(ROOT, "examples", "verilog", "uart", "run.py"))
+        self.check(ROOT / "examples" / "verilog" / "uart" / "run.py")
 
     @unittest.skipUnless(simulator_supports_verilog(), "Verilog")
     def test_verilog_ams_example(self):
-        self.check(join(ROOT, "examples", "verilog", "verilog_ams", "run.py"))
+        self.check(ROOT / "examples" / "verilog" / "verilog_ams" / "run.py")
         check_report(
             self.report_file,
             [
@@ -52,10 +54,10 @@ class TestExternalRunScripts(unittest.TestCase):
         )
 
     def test_vhdl_logging_example_project(self):
-        self.check(join(ROOT, "examples", "vhdl", "logging", "run.py"))
+        self.check(ROOT / "examples" / "vhdl" / "logging" / "run.py")
 
     def test_vhdl_run_example_project(self):
-        self.check(join(ROOT, "examples", "vhdl", "run", "run.py"), exit_code=1)
+        self.check(ROOT / "examples" / "vhdl" / "run" / "run.py", exit_code=1)
         check_report(
             self.report_file,
             [
@@ -98,7 +100,7 @@ class TestExternalRunScripts(unittest.TestCase):
 
     def test_vhdl_third_party_integration_example_project(self):
         self.check(
-            join(ROOT, "examples", "vhdl", "third_party_integration", "run.py"),
+            ROOT / "examples" / "vhdl" / "third_party_integration" / "run.py",
             exit_code=1,
         )
         check_report(
@@ -117,10 +119,10 @@ class TestExternalRunScripts(unittest.TestCase):
         )
 
     def test_vhdl_check_example_project(self):
-        self.check(join(ROOT, "examples", "vhdl", "check", "run.py"))
+        self.check(ROOT / "examples" / "vhdl" / "check" / "run.py")
 
     def test_vhdl_generate_tests_example_project(self):
-        self.check(join(ROOT, "examples", "vhdl", "generate_tests", "run.py"))
+        self.check(ROOT / "examples" / "vhdl" / "generate_tests" / "run.py")
         check_report(
             self.report_file,
             [
@@ -137,7 +139,7 @@ class TestExternalRunScripts(unittest.TestCase):
         )
 
     def test_vhdl_composite_generics_example_project(self):
-        self.check(join(ROOT, "examples", "vhdl", "composite_generics", "run.py"))
+        self.check(ROOT / "examples" / "vhdl" / "composite_generics" / "run.py")
         check_report(
             self.report_file,
             [
@@ -150,19 +152,19 @@ class TestExternalRunScripts(unittest.TestCase):
         simulator_is("ghdl"), "Support complex JSON strings as generic"
     )
     def test_vhdl_json4vhdl_example_project(self):
-        self.check(join(ROOT, "examples", "vhdl", "json4vhdl", "run.py"))
+        self.check(ROOT / "examples" / "vhdl" / "json4vhdl" / "run.py")
 
     def test_vhdl_array_example_project(self):
-        self.check(join(ROOT, "examples", "vhdl", "array", "run.py"))
+        self.check(ROOT / "examples" / "vhdl" / "array" / "run.py")
 
     def test_vhdl_array_axis_vcs_example_project(self):
-        self.check(join(ROOT, "examples", "vhdl", "array_axis_vcs", "run.py"))
+        self.check(ROOT / "examples" / "vhdl" / "array_axis_vcs" / "run.py")
 
     def test_vhdl_axi_dma_example_project(self):
-        self.check(join(ROOT, "examples", "vhdl", "axi_dma", "run.py"))
+        self.check(ROOT / "examples" / "vhdl" / "axi_dma" / "run.py")
 
     def test_vhdl_user_guide_example_project(self):
-        self.check(join(ROOT, "examples", "vhdl", "user_guide", "run.py"), exit_code=1)
+        self.check(ROOT / "examples" / "vhdl" / "user_guide" / "run.py", exit_code=1)
         check_report(
             self.report_file,
             [
@@ -174,9 +176,7 @@ class TestExternalRunScripts(unittest.TestCase):
 
     @unittest.skipUnless(simulator_supports_verilog(), "Verilog")
     def test_verilog_user_guide_example_project(self):
-        self.check(
-            join(ROOT, "examples", "verilog", "user_guide", "run.py"), exit_code=1
-        )
+        self.check(ROOT / "examples" / "verilog" / "user_guide" / "run.py", exit_code=1)
         check_report(
             self.report_file,
             [
@@ -194,85 +194,85 @@ class TestExternalRunScripts(unittest.TestCase):
         )
 
     def test_vhdl_com_example_project(self):
-        self.check(join(ROOT, "examples", "vhdl", "com", "run.py"))
+        self.check(ROOT / "examples" / "vhdl" / "com" / "run.py")
 
     def test_array_vhdl_2008(self):
-        self.check(join(VHDL_PATH, "array", "run.py"))
+        self.check(VHDL_PATH / "array" / "run.py")
 
     def test_data_types_vhdl_2008(self):
-        self.check(join(VHDL_PATH, "data_types", "run.py"))
+        self.check(VHDL_PATH / "data_types" / "run.py")
 
     def test_data_types_vhdl_2002(self):
-        self.check(join(VHDL_PATH, "data_types", "run.py"), vhdl_standard="2002")
+        self.check(VHDL_PATH / "data_types" / "run.py", vhdl_standard="2002")
 
     def test_data_types_vhdl_93(self):
-        self.check(join(VHDL_PATH, "data_types", "run.py"), vhdl_standard="93")
+        self.check(VHDL_PATH / "data_types" / "run.py", vhdl_standard="93")
 
     def test_random_vhdl_2008(self):
-        self.check(join(VHDL_PATH, "random", "run.py"))
+        self.check(VHDL_PATH / "random" / "run.py")
 
     def test_check_vhdl_2008(self):
-        self.check(join(VHDL_PATH, "check", "run.py"))
+        self.check(VHDL_PATH / "check" / "run.py")
 
     def test_check_vhdl_2002(self):
-        self.check(join(VHDL_PATH, "check", "run.py"), vhdl_standard="2002")
+        self.check(VHDL_PATH / "check" / "run.py", vhdl_standard="2002")
 
     def test_check_vhdl_93(self):
-        self.check(join(VHDL_PATH, "check", "run.py"), vhdl_standard="93")
+        self.check(VHDL_PATH / "check" / "run.py", vhdl_standard="93")
 
     def test_logging_vhdl_2008(self):
-        self.check(join(VHDL_PATH, "logging", "run.py"))
+        self.check(VHDL_PATH / "logging" / "run.py")
 
     def test_logging_vhdl_2002(self):
-        self.check(join(VHDL_PATH, "logging", "run.py"), vhdl_standard="2002")
+        self.check(VHDL_PATH / "logging" / "run.py", vhdl_standard="2002")
 
     def test_logging_vhdl_93(self):
-        self.check(join(VHDL_PATH, "logging", "run.py"), vhdl_standard="93")
+        self.check(VHDL_PATH / "logging" / "run.py", vhdl_standard="93")
 
     def test_run_vhdl_2008(self):
-        self.check(join(VHDL_PATH, "run", "run.py"))
+        self.check(VHDL_PATH / "run" / "run.py")
 
     def test_run_vhdl_2002(self):
-        self.check(join(VHDL_PATH, "run", "run.py"), vhdl_standard="2002")
+        self.check(VHDL_PATH / "run" / "run.py", vhdl_standard="2002")
 
     def test_run_vhdl_93(self):
-        self.check(join(VHDL_PATH, "run", "run.py"), vhdl_standard="93")
+        self.check(VHDL_PATH / "run" / "run.py", vhdl_standard="93")
 
     def test_string_ops_vhdl_2008(self):
-        self.check(join(VHDL_PATH, "string_ops", "run.py"))
+        self.check(VHDL_PATH / "string_ops" / "run.py")
 
     def test_string_ops_vhdl_2002(self):
-        self.check(join(VHDL_PATH, "string_ops", "run.py"), vhdl_standard="2002")
+        self.check(VHDL_PATH / "string_ops" / "run.py", vhdl_standard="2002")
 
     def test_string_ops_vhdl_93(self):
-        self.check(join(VHDL_PATH, "string_ops", "run.py"), vhdl_standard="93")
+        self.check(VHDL_PATH / "string_ops" / "run.py", vhdl_standard="93")
 
     def test_dictionary_vhdl_2008(self):
-        self.check(join(VHDL_PATH, "dictionary", "run.py"))
+        self.check(VHDL_PATH / "dictionary" / "run.py")
 
     def test_dictionary_vhdl_2002(self):
-        self.check(join(VHDL_PATH, "dictionary", "run.py"), vhdl_standard="2002")
+        self.check(VHDL_PATH / "dictionary" / "run.py", vhdl_standard="2002")
 
     def test_dictionary_vhdl_93(self):
-        self.check(join(VHDL_PATH, "dictionary", "run.py"), vhdl_standard="93")
+        self.check(VHDL_PATH / "dictionary" / "run.py", vhdl_standard="93")
 
     def test_path_vhdl_2008(self):
-        self.check(join(VHDL_PATH, "path", "run.py"))
+        self.check(VHDL_PATH / "path" / "run.py")
 
     def test_path_vhdl_2002(self):
-        self.check(join(VHDL_PATH, "path", "run.py"), vhdl_standard="2002")
+        self.check(VHDL_PATH / "path" / "run.py", vhdl_standard="2002")
 
     def test_path_vhdl_93(self):
-        self.check(join(VHDL_PATH, "path", "run.py"), vhdl_standard="93")
+        self.check(VHDL_PATH / "path" / "run.py", vhdl_standard="93")
 
     def test_com_vhdl_2008(self):
-        self.check(join(VHDL_PATH, "com", "run.py"))
+        self.check(VHDL_PATH / "com" / "run.py")
 
     def setUp(self):
-        self.output_path = join(dirname(__file__), "external_run_out")
-        self.report_file = join(self.output_path, "xunit.xml")
+        self.output_path = str(Path(__file__).parent / "external_run_out")
+        self.report_file = str(Path(self.output_path) / "xunit.xml")
 
-    def check(self, run_file, args=None, vhdl_standard="2008", exit_code=0):
+    def check(self, run_file: Path, args=None, vhdl_standard="2008", exit_code=0):
         """
         Run external run file and verify exit code
         """

--- a/tests/lint/test_pycodestyle.py
+++ b/tests/lint/test_pycodestyle.py
@@ -12,8 +12,10 @@ import unittest
 from subprocess import check_call
 import sys
 from glob import glob
-from os.path import join
-from vunit import ROOT
+from pathlib import Path
+from vunit import ROOT as RSTR
+
+ROOT = Path(RSTR)
 
 
 class TestPycodestyle(unittest.TestCase):
@@ -43,7 +45,7 @@ def get_files_and_folders():
     """
     Return all files and folders which shall be arguments to pycodestyle and pylint
     """
-    ret = [join(ROOT, "vunit")]
-    ret += list(glob(join(ROOT, "*.py")))
-    ret += list(glob(join(ROOT, "tools", "*.py")))
+    ret = [str(ROOT / "vunit")]
+    ret += list(glob(str(ROOT / "*.py")))
+    ret += list(glob(str(ROOT / "tools" / "*.py")))
     return ret

--- a/tests/lint/test_pylint.py
+++ b/tests/lint/test_pylint.py
@@ -11,7 +11,7 @@ Pylint check
 
 import unittest
 from subprocess import check_call
-from os.path import join, dirname
+from pathlib import Path
 import sys
 from tests.lint.test_pycodestyle import get_files_and_folders
 
@@ -28,7 +28,7 @@ class TestPylint(unittest.TestCase):
                 sys.executable,
                 "-m",
                 "pylint",
-                "--rcfile=" + join(dirname(__file__), "pylintrc"),
+                "--rcfile=" + str(Path(__file__).parent / "pylintrc"),
             ]
             + get_files_and_folders()
         )

--- a/tests/lint/test_readme.py
+++ b/tests/lint/test_readme.py
@@ -10,7 +10,7 @@ Check that README.rst matches VUnit docstring
 
 import unittest
 from warnings import simplefilter, catch_warnings
-from os.path import join
+from pathlib import Path
 from vunit import ROOT
 from vunit.about import doc
 
@@ -23,5 +23,5 @@ class TestReadMe(unittest.TestCase):
     def test_that_readme_file_matches_vunit_docstring(self):
         with catch_warnings():
             simplefilter("ignore", category=DeprecationWarning)
-            with open(join(ROOT, "README.rst"), "rU") as readme:
+            with Path(ROOT, "README.rst").open("rU") as readme:
                 self.assertEqual(readme.read(), doc())

--- a/tests/unit/test_activehdl_interface.py
+++ b/tests/unit/test_activehdl_interface.py
@@ -10,7 +10,7 @@ Test the ActiveHDL interface
 
 
 import unittest
-from os.path import join, dirname, exists
+from pathlib import Path
 import os
 from shutil import rmtree
 from unittest import mock
@@ -58,18 +58,18 @@ class TestActiveHDLInterface(unittest.TestCase):
         )
         simif.compile_project(project)
         process.assert_any_call(
-            [join("prefix", "vlib"), "lib", "lib_path"],
+            [str(Path("prefix") / "vlib"), "lib", "lib_path"],
             cwd=self.output_path,
             env=simif.get_env(),
         )
         process.assert_called_with(
-            [join("prefix", "vmap"), "lib", "lib_path"],
+            [str(Path("prefix") / "vmap"), "lib", "lib_path"],
             cwd=self.output_path,
             env=simif.get_env(),
         )
         check_output.assert_called_once_with(
             [
-                join("prefix", "vcom"),
+                str(Path("prefix") / "vcom"),
                 "-quiet",
                 "-j",
                 self.output_path,
@@ -93,18 +93,18 @@ class TestActiveHDLInterface(unittest.TestCase):
         )
         simif.compile_project(project)
         process.assert_any_call(
-            [join("prefix", "vlib"), "lib", "lib_path"],
+            [str(Path("prefix") / "vlib"), "lib", "lib_path"],
             cwd=self.output_path,
             env=simif.get_env(),
         )
         process.assert_called_with(
-            [join("prefix", "vmap"), "lib", "lib_path"],
+            [str(Path("prefix") / "vmap"), "lib", "lib_path"],
             cwd=self.output_path,
             env=simif.get_env(),
         )
         check_output.assert_called_once_with(
             [
-                join("prefix", "vcom"),
+                str(Path("prefix") / "vcom"),
                 "-quiet",
                 "-j",
                 self.output_path,
@@ -128,18 +128,18 @@ class TestActiveHDLInterface(unittest.TestCase):
         )
         simif.compile_project(project)
         process.assert_any_call(
-            [join("prefix", "vlib"), "lib", "lib_path"],
+            [str(Path("prefix") / "vlib"), "lib", "lib_path"],
             cwd=self.output_path,
             env=simif.get_env(),
         )
         process.assert_called_with(
-            [join("prefix", "vmap"), "lib", "lib_path"],
+            [str(Path("prefix") / "vmap"), "lib", "lib_path"],
             cwd=self.output_path,
             env=simif.get_env(),
         )
         check_output.assert_called_once_with(
             [
-                join("prefix", "vcom"),
+                str(Path("prefix") / "vcom"),
                 "-quiet",
                 "-j",
                 self.output_path,
@@ -162,18 +162,18 @@ class TestActiveHDLInterface(unittest.TestCase):
         source_file.set_compile_option("activehdl.vcom_flags", ["custom", "flags"])
         simif.compile_project(project)
         process.assert_any_call(
-            [join("prefix", "vlib"), "lib", "lib_path"],
+            [str(Path("prefix") / "vlib"), "lib", "lib_path"],
             cwd=self.output_path,
             env=simif.get_env(),
         )
         process.assert_called_with(
-            [join("prefix", "vmap"), "lib", "lib_path"],
+            [str(Path("prefix") / "vmap"), "lib", "lib_path"],
             cwd=self.output_path,
             env=simif.get_env(),
         )
         check_output.assert_called_once_with(
             [
-                join("prefix", "vcom"),
+                str(Path("prefix") / "vcom"),
                 "-quiet",
                 "-j",
                 self.output_path,
@@ -190,7 +190,7 @@ class TestActiveHDLInterface(unittest.TestCase):
     @mock.patch("vunit.sim_if.check_output", autospec=True, return_value="")
     @mock.patch("vunit.sim_if.activehdl.Process", autospec=True)
     def test_compile_project_verilog(self, process, check_output):
-        library_cfg = join(self.output_path, "library.cfg")
+        library_cfg = str(Path(self.output_path) / "library.cfg")
         simif = ActiveHDLInterface(prefix="prefix", output_path=self.output_path)
         project = Project()
         project.add_library("lib", "lib_path")
@@ -198,18 +198,18 @@ class TestActiveHDLInterface(unittest.TestCase):
         project.add_source_file("file.v", "lib", file_type="verilog")
         simif.compile_project(project)
         process.assert_any_call(
-            [join("prefix", "vlib"), "lib", "lib_path"],
+            [str(Path("prefix") / "vlib"), "lib", "lib_path"],
             cwd=self.output_path,
             env=simif.get_env(),
         )
         process.assert_called_with(
-            [join("prefix", "vmap"), "lib", "lib_path"],
+            [str(Path("prefix") / "vmap"), "lib", "lib_path"],
             cwd=self.output_path,
             env=simif.get_env(),
         )
         check_output.assert_called_once_with(
             [
-                join("prefix", "vlog"),
+                str(Path("prefix") / "vlog"),
                 "-quiet",
                 "-lc",
                 library_cfg,
@@ -225,7 +225,7 @@ class TestActiveHDLInterface(unittest.TestCase):
     @mock.patch("vunit.sim_if.check_output", autospec=True, return_value="")
     @mock.patch("vunit.sim_if.activehdl.Process", autospec=True)
     def test_compile_project_system_verilog(self, process, check_output):
-        library_cfg = join(self.output_path, "library.cfg")
+        library_cfg = str(Path(self.output_path) / "library.cfg")
         simif = ActiveHDLInterface(prefix="prefix", output_path=self.output_path)
         project = Project()
         project.add_library("lib", "lib_path")
@@ -233,18 +233,18 @@ class TestActiveHDLInterface(unittest.TestCase):
         project.add_source_file("file.sv", "lib", file_type="systemverilog")
         simif.compile_project(project)
         process.assert_any_call(
-            [join("prefix", "vlib"), "lib", "lib_path"],
+            [str(Path("prefix") / "vlib"), "lib", "lib_path"],
             cwd=self.output_path,
             env=simif.get_env(),
         )
         process.assert_called_with(
-            [join("prefix", "vmap"), "lib", "lib_path"],
+            [str(Path("prefix") / "vmap"), "lib", "lib_path"],
             cwd=self.output_path,
             env=simif.get_env(),
         )
         check_output.assert_called_once_with(
             [
-                join("prefix", "vlog"),
+                str(Path("prefix") / "vlog"),
                 "-quiet",
                 "-lc",
                 library_cfg,
@@ -260,7 +260,7 @@ class TestActiveHDLInterface(unittest.TestCase):
     @mock.patch("vunit.sim_if.check_output", autospec=True, return_value="")
     @mock.patch("vunit.sim_if.activehdl.Process", autospec=True)
     def test_compile_project_verilog_extra_flags(self, process, check_output):
-        library_cfg = join(self.output_path, "library.cfg")
+        library_cfg = str(Path(self.output_path) / "library.cfg")
         simif = ActiveHDLInterface(prefix="prefix", output_path=self.output_path)
         project = Project()
         project.add_library("lib", "lib_path")
@@ -269,18 +269,18 @@ class TestActiveHDLInterface(unittest.TestCase):
         source_file.set_compile_option("activehdl.vlog_flags", ["custom", "flags"])
         simif.compile_project(project)
         process.assert_any_call(
-            [join("prefix", "vlib"), "lib", "lib_path"],
+            [str(Path("prefix") / "vlib"), "lib", "lib_path"],
             cwd=self.output_path,
             env=simif.get_env(),
         )
         process.assert_called_with(
-            [join("prefix", "vmap"), "lib", "lib_path"],
+            [str(Path("prefix") / "vmap"), "lib", "lib_path"],
             cwd=self.output_path,
             env=simif.get_env(),
         )
         check_output.assert_called_once_with(
             [
-                join("prefix", "vlog"),
+                str(Path("prefix") / "vlog"),
                 "-quiet",
                 "-lc",
                 library_cfg,
@@ -298,7 +298,7 @@ class TestActiveHDLInterface(unittest.TestCase):
     @mock.patch("vunit.sim_if.check_output", autospec=True, return_value="")
     @mock.patch("vunit.sim_if.activehdl.Process", autospec=True)
     def test_compile_project_verilog_include(self, process, check_output):
-        library_cfg = join(self.output_path, "library.cfg")
+        library_cfg = str(Path(self.output_path) / "library.cfg")
         simif = ActiveHDLInterface(prefix="prefix", output_path=self.output_path)
         project = Project()
         project.add_library("lib", "lib_path")
@@ -308,18 +308,18 @@ class TestActiveHDLInterface(unittest.TestCase):
         )
         simif.compile_project(project)
         process.assert_any_call(
-            [join("prefix", "vlib"), "lib", "lib_path"],
+            [str(Path("prefix") / "vlib"), "lib", "lib_path"],
             cwd=self.output_path,
             env=simif.get_env(),
         )
         process.assert_called_with(
-            [join("prefix", "vmap"), "lib", "lib_path"],
+            [str(Path("prefix") / "vmap"), "lib", "lib_path"],
             cwd=self.output_path,
             env=simif.get_env(),
         )
         check_output.assert_called_once_with(
             [
-                join("prefix", "vlog"),
+                str(Path("prefix") / "vlog"),
                 "-quiet",
                 "-lc",
                 library_cfg,
@@ -336,7 +336,7 @@ class TestActiveHDLInterface(unittest.TestCase):
     @mock.patch("vunit.sim_if.check_output", autospec=True, return_value="")
     @mock.patch("vunit.sim_if.activehdl.Process", autospec=True)
     def test_compile_project_verilog_define(self, process, check_output):
-        library_cfg = join(self.output_path, "library.cfg")
+        library_cfg = str(Path(self.output_path) / "library.cfg")
         simif = ActiveHDLInterface(prefix="prefix", output_path=self.output_path)
         project = Project()
         project.add_library("lib", "lib_path")
@@ -346,18 +346,18 @@ class TestActiveHDLInterface(unittest.TestCase):
         )
         simif.compile_project(project)
         process.assert_any_call(
-            [join("prefix", "vlib"), "lib", "lib_path"],
+            [str(Path("prefix") / "vlib"), "lib", "lib_path"],
             cwd=self.output_path,
             env=simif.get_env(),
         )
         process.assert_called_with(
-            [join("prefix", "vmap"), "lib", "lib_path"],
+            [str(Path("prefix") / "vmap"), "lib", "lib_path"],
             cwd=self.output_path,
             env=simif.get_env(),
         )
         check_output.assert_called_once_with(
             [
-                join("prefix", "vlog"),
+                str(Path("prefix") / "vlog"),
                 "-quiet",
                 "-lc",
                 library_cfg,
@@ -390,7 +390,7 @@ class TestActiveHDLInterface(unittest.TestCase):
         self.assertFalse(simif.supports_vhdl_package_generics())
 
     def setUp(self):
-        self.output_path = join(dirname(__file__), "test_activehdl_out")
+        self.output_path = str(Path(__file__).parent / "test_activehdl_out")
         renew_path(self.output_path)
         self.project = Project()
         self.cwd = os.getcwd()
@@ -398,7 +398,7 @@ class TestActiveHDLInterface(unittest.TestCase):
 
     def tearDown(self):
         os.chdir(self.cwd)
-        if exists(self.output_path):
+        if Path(self.output_path).exists():
             rmtree(self.output_path)
 
 

--- a/tests/unit/test_configuration.py
+++ b/tests/unit/test_configuration.py
@@ -13,7 +13,7 @@ Tests the test test_bench module
 
 import unittest
 import contextlib
-from os.path import join
+from pathlib import Path
 from unittest import mock
 from tests.common import with_tempdir, create_tempdir
 from tests.unit.test_test_bench import Entity
@@ -61,10 +61,12 @@ class TestConfiguration(unittest.TestCase):
     @with_tempdir
     def test_adds_tb_path_generic(self, tempdir):
         design_unit_tb_path = Entity(
-            "tb_entity_without_tb_path", file_name=join(tempdir, "file.vhd")
+            "tb_entity_without_tb_path", file_name=str(Path(tempdir) / "file.vhd")
         )
-        tb_path = join(tempdir, "other_path")
-        design_unit_tb_path.original_file_name = join(tb_path, "original_file.vhd")
+        tb_path = str(Path(tempdir) / "other_path")
+        design_unit_tb_path.original_file_name = str(
+            Path(tb_path) / "original_file.vhd"
+        )
         design_unit_tb_path.generic_names = ["runner_cfg", "tb_path"]
         config_tb_path = Configuration("name", design_unit_tb_path)
         self.assertEqual(
@@ -298,7 +300,7 @@ def _create_config(**kwargs):
     Helper function to create a config
     """
     with create_tempdir() as tempdir:
-        design_unit = Entity("tb_entity", file_name=join(tempdir, "file.vhd"))
+        design_unit = Entity("tb_entity", file_name=str(Path(tempdir) / "file.vhd"))
         design_unit.generic_names = ["runner_cfg"]
         yield Configuration("name", design_unit, **kwargs)
 

--- a/tests/unit/test_csv_logs.py
+++ b/tests/unit/test_csv_logs.py
@@ -11,7 +11,7 @@ Test csv log functionality
 import unittest
 from shutil import rmtree
 from os import remove
-from os.path import join
+from pathlib import Path
 from tempfile import NamedTemporaryFile, mkdtemp
 from vunit.csv_logs import CsvLogs
 
@@ -25,8 +25,8 @@ class TestCsvLogs(unittest.TestCase):
         self._log_files = []
         self._all_fields_dir = mkdtemp()
         self._few_fields_dir = mkdtemp()
-        self._all_fields_files = join(self._all_fields_dir, "*.csv")
-        self._few_fields_files = join(self._few_fields_dir, "*.csv")
+        self._all_fields_files = str(Path(self._all_fields_dir) / "*.csv")
+        self._few_fields_files = str(Path(self._few_fields_dir) / "*.csv")
 
         def make_log(directory, contents):
             """

--- a/tests/unit/test_database.py
+++ b/tests/unit/test_database.py
@@ -9,7 +9,7 @@ Test the database related classes
 """
 
 import unittest
-from os.path import join
+from pathlib import Path
 from tests.common import with_tempdir
 from vunit.database import DataBase, PickledDataBase
 
@@ -26,7 +26,7 @@ class TestDataBase(unittest.TestCase):
 
     @staticmethod
     def create_database(tempdir, new=False):
-        return DataBase(join(tempdir, "database"), new=new)
+        return DataBase(str(Path(tempdir) / "database"), new=new)
 
     def _test_add_items(self, tempdir):
         """

--- a/tests/unit/test_ghdl_interface.py
+++ b/tests/unit/test_ghdl_interface.py
@@ -9,7 +9,7 @@ Test the GHDL interface
 """
 
 import unittest
-from os.path import join, dirname, exists
+from pathlib import Path
 import os
 from shutil import rmtree
 from unittest import mock
@@ -120,7 +120,7 @@ warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE."""
         simif.compile_project(project)
         check_output.assert_called_once_with(
             [
-                join("prefix", "ghdl"),
+                str(Path("prefix") / "ghdl"),
                 "-a",
                 "--workdir=lib_path",
                 "--work=lib",
@@ -146,7 +146,7 @@ warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE."""
         simif.compile_project(project)
         check_output.assert_called_once_with(
             [
-                join("prefix", "ghdl"),
+                str(Path("prefix") / "ghdl"),
                 "-a",
                 "--workdir=lib_path",
                 "--work=lib",
@@ -172,7 +172,7 @@ warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE."""
         simif.compile_project(project)
         check_output.assert_called_once_with(
             [
-                join("prefix", "ghdl"),
+                str(Path("prefix") / "ghdl"),
                 "-a",
                 "--workdir=lib_path",
                 "--work=lib",
@@ -197,7 +197,7 @@ warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE."""
         simif.compile_project(project)
         check_output.assert_called_once_with(
             [
-                join("prefix", "ghdl"),
+                str(Path("prefix") / "ghdl"),
                 "-a",
                 "--workdir=lib_path",
                 "--work=lib",
@@ -211,9 +211,9 @@ warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE."""
         )
 
     def test_elaborate_e_project(self):
-        design_unit = Entity("tb_entity", file_name=join("tempdir", "file.vhd"))
-        design_unit.original_file_name = join(
-            "tempdir", "other_path", "original_file.vhd"
+        design_unit = Entity("tb_entity", file_name=str(Path("tempdir") / "file.vhd"))
+        design_unit.original_file_name = str(
+            Path("tempdir") / "other_path" / "original_file.vhd"
         )
         design_unit.generic_names = ["runner_cfg", "tb_path"]
 
@@ -228,17 +228,17 @@ warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE."""
 
         self.assertEqual(
             simif._get_command(  # pylint: disable=protected-access
-                config, join("output_path", "ghdl"), True, True, None
+                config, str(Path("output_path") / "ghdl"), True, True, None
             ),
             [
-                join("prefix", "ghdl"),
+                str(Path("prefix") / "ghdl"),
                 "-e",
                 "--std=08",
                 "--work=lib",
                 "--workdir=lib_path",
                 "-Plib_path",
                 "-o",
-                join("output_path", "ghdl", "tb_entity-arch"),
+                str(Path("output_path") / "ghdl" / "tb_entity-arch"),
                 "tb_entity",
                 "arch",
             ],
@@ -254,7 +254,7 @@ warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE."""
         self.assertRaises(CompileError, simif.compile_project, project)
 
     def setUp(self):
-        self.output_path = join(dirname(__file__), "test_ghdl_interface_out")
+        self.output_path = str(Path(__file__).parent / "test_ghdl_interface_out")
         renew_path(self.output_path)
         self.project = Project()
         self.cwd = os.getcwd()
@@ -262,5 +262,5 @@ warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE."""
 
     def tearDown(self):
         os.chdir(self.cwd)
-        if exists(self.output_path):
+        if Path(self.output_path).exists():
             rmtree(self.output_path)

--- a/tests/unit/test_incisive_interface.py
+++ b/tests/unit/test_incisive_interface.py
@@ -12,7 +12,7 @@ Test the Incisive interface
 
 
 import unittest
-from os.path import join, dirname, exists, basename
+from pathlib import Path
 import os
 from shutil import rmtree
 from unittest import mock
@@ -44,9 +44,9 @@ class TestIncisiveInterface(unittest.TestCase):
             "file.vhd", "lib", file_type="vhdl", vhdl_standard=VHDL.standard("2008")
         )
         simif.compile_project(project)
-        args_file = join(self.output_path, "irun_compile_vhdl_file_lib.args")
+        args_file = str(Path(self.output_path) / "irun_compile_vhdl_file_lib.args")
         check_output.assert_called_once_with(
-            [join("prefix", "irun"), "-f", args_file], env=simif.get_env()
+            [str(Path("prefix") / "irun"), "-f", args_file], env=simif.get_env()
         )
         self.assertEqual(
             read_file(args_file).splitlines(),
@@ -58,10 +58,11 @@ class TestIncisiveInterface(unittest.TestCase):
                 "-nowarn DLCVAR",
                 "-v200x -extv200x",
                 "-work work",
-                '-cdslib "%s"' % join(self.output_path, "cds.lib"),
-                '-log "%s"' % join(self.output_path, "irun_compile_vhdl_file_lib.log"),
+                '-cdslib "%s"' % str(Path(self.output_path) / "cds.lib"),
+                '-log "%s"'
+                % str(Path(self.output_path) / "irun_compile_vhdl_file_lib.log"),
                 "-quiet",
-                '-nclibdirname ""',
+                '-nclibdirname "."',
                 "-makelib lib_path",
                 '"file.vhd"',
                 "-endlib",
@@ -69,7 +70,7 @@ class TestIncisiveInterface(unittest.TestCase):
         )
 
         self.assertEqual(
-            read_file(join(self.output_path, "cds.lib")),
+            read_file(str(Path(self.output_path) / "cds.lib")),
             """\
 ## cds.lib: Defines the locations of compiled libraries.
 softinclude cds_root_irun/tools/inca/files/cds.lib
@@ -98,9 +99,9 @@ define work "%s/libraries/work"
             "file.vhd", "lib", file_type="vhdl", vhdl_standard=VHDL.standard("2002")
         )
         simif.compile_project(project)
-        args_file = join(self.output_path, "irun_compile_vhdl_file_lib.args")
+        args_file = str(Path(self.output_path) / "irun_compile_vhdl_file_lib.args")
         check_output.assert_called_once_with(
-            [join("prefix", "irun"), "-f", args_file], env=simif.get_env()
+            [str(Path("prefix") / "irun"), "-f", args_file], env=simif.get_env()
         )
         self.assertEqual(
             read_file(args_file).splitlines(),
@@ -112,10 +113,11 @@ define work "%s/libraries/work"
                 "-nowarn DLCVAR",
                 "-v200x -extv200x",
                 "-work work",
-                '-cdslib "%s"' % join(self.output_path, "cds.lib"),
-                '-log "%s"' % join(self.output_path, "irun_compile_vhdl_file_lib.log"),
+                '-cdslib "%s"' % str(Path(self.output_path) / "cds.lib"),
+                '-log "%s"'
+                % str(Path(self.output_path) / "irun_compile_vhdl_file_lib.log"),
                 "-quiet",
-                '-nclibdirname ""',
+                '-nclibdirname "."',
                 "-makelib lib_path",
                 '"file.vhd"',
                 "-endlib",
@@ -138,9 +140,9 @@ define work "%s/libraries/work"
             "file.vhd", "lib", file_type="vhdl", vhdl_standard=VHDL.standard("93")
         )
         simif.compile_project(project)
-        args_file = join(self.output_path, "irun_compile_vhdl_file_lib.args")
+        args_file = str(Path(self.output_path) / "irun_compile_vhdl_file_lib.args")
         check_output.assert_called_once_with(
-            [join("prefix", "irun"), "-f", args_file], env=simif.get_env()
+            [str(Path("prefix") / "irun"), "-f", args_file], env=simif.get_env()
         )
         self.assertEqual(
             read_file(args_file).splitlines(),
@@ -152,10 +154,11 @@ define work "%s/libraries/work"
                 "-nowarn DLCVAR",
                 "-v93",
                 "-work work",
-                '-cdslib "%s"' % join(self.output_path, "cds.lib"),
-                '-log "%s"' % join(self.output_path, "irun_compile_vhdl_file_lib.log"),
+                '-cdslib "%s"' % str(Path(self.output_path) / "cds.lib"),
+                '-log "%s"'
+                % str(Path(self.output_path) / "irun_compile_vhdl_file_lib.log"),
                 "-quiet",
-                '-nclibdirname ""',
+                '-nclibdirname "."',
                 "-makelib lib_path",
                 '"file.vhd"',
                 "-endlib",
@@ -177,9 +180,9 @@ define work "%s/libraries/work"
         source_file = project.add_source_file("file.vhd", "lib", file_type="vhdl")
         source_file.set_compile_option("incisive.irun_vhdl_flags", ["custom", "flags"])
         simif.compile_project(project)
-        args_file = join(self.output_path, "irun_compile_vhdl_file_lib.args")
+        args_file = str(Path(self.output_path) / "irun_compile_vhdl_file_lib.args")
         check_output.assert_called_once_with(
-            [join("prefix", "irun"), "-f", args_file], env=simif.get_env()
+            [str(Path("prefix") / "irun"), "-f", args_file], env=simif.get_env()
         )
         self.assertEqual(
             read_file(args_file).splitlines(),
@@ -191,12 +194,13 @@ define work "%s/libraries/work"
                 "-nowarn DLCVAR",
                 "-v200x -extv200x",
                 "-work work",
-                '-cdslib "%s"' % join(self.output_path, "cds.lib"),
-                '-log "%s"' % join(self.output_path, "irun_compile_vhdl_file_lib.log"),
+                '-cdslib "%s"' % str(Path(self.output_path) / "cds.lib"),
+                '-log "%s"'
+                % str(Path(self.output_path) / "irun_compile_vhdl_file_lib.log"),
                 "-quiet",
                 "custom",
                 "flags",
-                '-nclibdirname ""',
+                '-nclibdirname "."',
                 "-makelib lib_path",
                 '"file.vhd"',
                 "-endlib",
@@ -219,9 +223,9 @@ define work "%s/libraries/work"
         write_file("file.vhd", "")
         project.add_source_file("file.vhd", "lib", file_type="vhdl")
         simif.compile_project(project)
-        args_file = join(self.output_path, "irun_compile_vhdl_file_lib.args")
+        args_file = str(Path(self.output_path) / "irun_compile_vhdl_file_lib.args")
         check_output.assert_called_once_with(
-            [join("prefix", "irun"), "-f", args_file], env=simif.get_env()
+            [str(Path("prefix") / "irun"), "-f", args_file], env=simif.get_env()
         )
         self.assertEqual(
             read_file(args_file).splitlines(),
@@ -233,11 +237,12 @@ define work "%s/libraries/work"
                 "-nowarn DLCVAR",
                 "-v200x -extv200x",
                 "-work work",
-                '-cdslib "%s"' % join(self.output_path, "cds.lib"),
+                '-cdslib "%s"' % str(Path(self.output_path) / "cds.lib"),
                 '-hdlvar "custom_hdlvar"',
-                '-log "%s"' % join(self.output_path, "irun_compile_vhdl_file_lib.log"),
+                '-log "%s"'
+                % str(Path(self.output_path) / "irun_compile_vhdl_file_lib.log"),
                 "-quiet",
-                '-nclibdirname ""',
+                '-nclibdirname "."',
                 "-makelib lib_path",
                 '"file.vhd"',
                 "-endlib",
@@ -258,9 +263,9 @@ define work "%s/libraries/work"
         write_file("file.v", "")
         project.add_source_file("file.v", "lib", file_type="verilog")
         simif.compile_project(project)
-        args_file = join(self.output_path, "irun_compile_verilog_file_lib.args")
+        args_file = str(Path(self.output_path) / "irun_compile_verilog_file_lib.args")
         check_output.assert_called_once_with(
-            [join("prefix", "irun"), "-f", args_file], env=simif.get_env()
+            [str(Path("prefix") / "irun"), "-f", args_file], env=simif.get_env()
         )
         self.assertEqual(
             read_file(args_file).splitlines(),
@@ -272,12 +277,12 @@ define work "%s/libraries/work"
                 "-nowarn DLCPTH",
                 "-nowarn DLCVAR",
                 "-work work",
-                '-cdslib "%s"' % join(self.output_path, "cds.lib"),
+                '-cdslib "%s"' % str(Path(self.output_path) / "cds.lib"),
                 '-log "%s"'
-                % join(self.output_path, "irun_compile_verilog_file_lib.log"),
+                % str(Path(self.output_path) / "irun_compile_verilog_file_lib.log"),
                 "-quiet",
                 '-incdir "cds_root_irun/tools/spectre/etc/ahdl/"',
-                '-nclibdirname ""',
+                '-nclibdirname "."',
                 "-makelib lib",
                 '"file.v"',
                 "-endlib",
@@ -298,9 +303,9 @@ define work "%s/libraries/work"
         write_file("file.sv", "")
         project.add_source_file("file.sv", "lib", file_type="systemverilog")
         simif.compile_project(project)
-        args_file = join(self.output_path, "irun_compile_verilog_file_lib.args")
+        args_file = str(Path(self.output_path) / "irun_compile_verilog_file_lib.args")
         check_output.assert_called_once_with(
-            [join("prefix", "irun"), "-f", args_file], env=simif.get_env()
+            [str(Path("prefix") / "irun"), "-f", args_file], env=simif.get_env()
         )
         self.assertEqual(
             read_file(args_file).splitlines(),
@@ -312,12 +317,12 @@ define work "%s/libraries/work"
                 "-nowarn DLCPTH",
                 "-nowarn DLCVAR",
                 "-work work",
-                '-cdslib "%s"' % join(self.output_path, "cds.lib"),
+                '-cdslib "%s"' % str(Path(self.output_path) / "cds.lib"),
                 '-log "%s"'
-                % join(self.output_path, "irun_compile_verilog_file_lib.log"),
+                % str(Path(self.output_path) / "irun_compile_verilog_file_lib.log"),
                 "-quiet",
                 '-incdir "cds_root_irun/tools/spectre/etc/ahdl/"',
-                '-nclibdirname ""',
+                '-nclibdirname "."',
                 "-makelib lib",
                 '"file.sv"',
                 "-endlib",
@@ -325,7 +330,7 @@ define work "%s/libraries/work"
         )
 
         self.assertEqual(
-            read_file(join(self.output_path, "cds.lib")),
+            read_file(str(Path(self.output_path) / "cds.lib")),
             """\
 ## cds.lib: Defines the locations of compiled libraries.
 softinclude cds_root_irun/tools/inca/files/cds.lib
@@ -355,9 +360,9 @@ define work "%s/libraries/work"
             "incisive.irun_verilog_flags", ["custom", "flags"]
         )
         simif.compile_project(project)
-        args_file = join(self.output_path, "irun_compile_verilog_file_lib.args")
+        args_file = str(Path(self.output_path) / "irun_compile_verilog_file_lib.args")
         check_output.assert_called_once_with(
-            [join("prefix", "irun"), "-f", args_file], env=simif.get_env()
+            [str(Path("prefix") / "irun"), "-f", args_file], env=simif.get_env()
         )
         self.assertEqual(
             read_file(args_file).splitlines(),
@@ -371,12 +376,12 @@ define work "%s/libraries/work"
                 "-work work",
                 "custom",
                 "flags",
-                '-cdslib "%s"' % join(self.output_path, "cds.lib"),
+                '-cdslib "%s"' % str(Path(self.output_path) / "cds.lib"),
                 '-log "%s"'
-                % join(self.output_path, "irun_compile_verilog_file_lib.log"),
+                % str(Path(self.output_path) / "irun_compile_verilog_file_lib.log"),
                 "-quiet",
                 '-incdir "cds_root_irun/tools/spectre/etc/ahdl/"',
-                '-nclibdirname ""',
+                '-nclibdirname "."',
                 "-makelib lib",
                 '"file.v"',
                 "-endlib",
@@ -399,9 +404,9 @@ define work "%s/libraries/work"
             "file.v", "lib", file_type="verilog", include_dirs=["include"]
         )
         simif.compile_project(project)
-        args_file = join(self.output_path, "irun_compile_verilog_file_lib.args")
+        args_file = str(Path(self.output_path) / "irun_compile_verilog_file_lib.args")
         check_output.assert_called_once_with(
-            [join("prefix", "irun"), "-f", args_file], env=simif.get_env()
+            [str(Path("prefix") / "irun"), "-f", args_file], env=simif.get_env()
         )
         self.assertEqual(
             read_file(args_file).splitlines(),
@@ -413,13 +418,13 @@ define work "%s/libraries/work"
                 "-nowarn DLCPTH",
                 "-nowarn DLCVAR",
                 "-work work",
-                '-cdslib "%s"' % join(self.output_path, "cds.lib"),
+                '-cdslib "%s"' % str(Path(self.output_path) / "cds.lib"),
                 '-log "%s"'
-                % join(self.output_path, "irun_compile_verilog_file_lib.log"),
+                % str(Path(self.output_path) / "irun_compile_verilog_file_lib.log"),
                 "-quiet",
                 '-incdir "include"',
                 '-incdir "cds_root_irun/tools/spectre/etc/ahdl/"',
-                '-nclibdirname ""',
+                '-nclibdirname "."',
                 "-makelib lib",
                 '"file.v"',
                 "-endlib",
@@ -442,9 +447,9 @@ define work "%s/libraries/work"
             "file.v", "lib", file_type="verilog", defines=dict(defname="defval")
         )
         simif.compile_project(project)
-        args_file = join(self.output_path, "irun_compile_verilog_file_lib.args")
+        args_file = str(Path(self.output_path) / "irun_compile_verilog_file_lib.args")
         check_output.assert_called_once_with(
-            [join("prefix", "irun"), "-f", args_file], env=simif.get_env()
+            [str(Path("prefix") / "irun"), "-f", args_file], env=simif.get_env()
         )
         self.assertEqual(
             read_file(args_file).splitlines(),
@@ -456,13 +461,13 @@ define work "%s/libraries/work"
                 "-nowarn DLCPTH",
                 "-nowarn DLCVAR",
                 "-work work",
-                '-cdslib "%s"' % join(self.output_path, "cds.lib"),
+                '-cdslib "%s"' % str(Path(self.output_path) / "cds.lib"),
                 '-log "%s"'
-                % join(self.output_path, "irun_compile_verilog_file_lib.log"),
+                % str(Path(self.output_path) / "irun_compile_verilog_file_lib.log"),
                 "-quiet",
                 '-incdir "cds_root_irun/tools/spectre/etc/ahdl/"',
                 "-define defname=defval",
-                '-nclibdirname ""',
+                '-nclibdirname "."',
                 "-makelib lib",
                 '"file.v"',
                 "-endlib",
@@ -487,9 +492,9 @@ define work "%s/libraries/work"
             "file.v", "lib", file_type="verilog", defines=dict(defname="defval")
         )
         simif.compile_project(project)
-        args_file = join(self.output_path, "irun_compile_verilog_file_lib.args")
+        args_file = str(Path(self.output_path) / "irun_compile_verilog_file_lib.args")
         check_output.assert_called_once_with(
-            [join("prefix", "irun"), "-f", args_file], env=simif.get_env()
+            [str(Path("prefix") / "irun"), "-f", args_file], env=simif.get_env()
         )
         self.assertEqual(
             read_file(args_file).splitlines(),
@@ -501,14 +506,14 @@ define work "%s/libraries/work"
                 "-nowarn DLCPTH",
                 "-nowarn DLCVAR",
                 "-work work",
-                '-cdslib "%s"' % join(self.output_path, "cds.lib"),
+                '-cdslib "%s"' % str(Path(self.output_path) / "cds.lib"),
                 '-hdlvar "custom_hdlvar"',
                 '-log "%s"'
-                % join(self.output_path, "irun_compile_verilog_file_lib.log"),
+                % str(Path(self.output_path) / "irun_compile_verilog_file_lib.log"),
                 "-quiet",
                 '-incdir "cds_root_irun/tools/spectre/etc/ahdl/"',
                 "-define defname=defval",
-                '-nclibdirname ""',
+                '-nclibdirname "."',
                 "-makelib lib",
                 '"file.v"',
                 "-endlib",
@@ -522,7 +527,7 @@ define work "%s/libraries/work"
         find_cds_root_virtuoso.return_value = None
         IncisiveInterface(prefix="prefix", output_path=self.output_path)
         self.assertEqual(
-            read_file(join(self.output_path, "cds.lib")),
+            read_file(str(Path(self.output_path) / "cds.lib")),
             """\
 ## cds.lib: Defines the locations of compiled libraries.
 softinclude cds_root_irun/tools/inca/files/cds.lib
@@ -541,7 +546,7 @@ define work "%s/libraries/work"
         find_cds_root_virtuoso.return_value = "cds_root_virtuoso"
         IncisiveInterface(prefix="prefix", output_path=self.output_path)
         self.assertEqual(
-            read_file(join(self.output_path, "cds.lib")),
+            read_file(str(Path(self.output_path) / "cds.lib")),
             """\
 ## cds.lib: Defines the locations of compiled libraries.
 softinclude cds_root_irun/tools/inca/files/cds.lib
@@ -574,20 +579,26 @@ define work "%s/libraries/work"
 
         config = make_config()
         self.assertTrue(simif.simulate("suite_output_path", "test_suite_name", config))
-        elaborate_args_file = join(
-            "suite_output_path", simif.name, "irun_elaborate.args"
+        elaborate_args_file = str(
+            Path("suite_output_path") / simif.name / "irun_elaborate.args"
         )
-        simulate_args_file = join("suite_output_path", simif.name, "irun_simulate.args")
+        simulate_args_file = str(
+            Path("suite_output_path") / simif.name / "irun_simulate.args"
+        )
         run_command.assert_has_calls(
             [
                 mock.call(
-                    [join("prefix", "irun"), "-f", basename(elaborate_args_file)],
-                    cwd=dirname(elaborate_args_file),
+                    [
+                        str(Path("prefix") / "irun"),
+                        "-f",
+                        Path(elaborate_args_file).name,
+                    ],
+                    cwd=str(Path(elaborate_args_file).parent),
                     env=simif.get_env(),
                 ),
                 mock.call(
-                    [join("prefix", "irun"), "-f", basename(simulate_args_file)],
-                    cwd=dirname(simulate_args_file),
+                    [str(Path("prefix") / "irun"), "-f", Path(simulate_args_file).name],
+                    cwd=str(Path(simulate_args_file).parent),
                     env=simif.get_env(),
                 ),
             ]
@@ -607,10 +618,10 @@ define work "%s/libraries/work"
                 "-ncerror EVBSTR",
                 "-ncerror EVBNAT",
                 "-work work",
-                '-nclibdirname "%s"' % join(self.output_path, "libraries"),
-                '-cdslib "%s"' % join(self.output_path, "cds.lib"),
+                '-nclibdirname "%s"' % str(Path(self.output_path) / "libraries"),
+                '-cdslib "%s"' % str(Path(self.output_path) / "cds.lib"),
                 '-log "%s"'
-                % join("suite_output_path", simif.name, "irun_elaborate.log"),
+                % str(Path("suite_output_path") / simif.name / "irun_elaborate.log"),
                 "-quiet",
                 '-reflib "lib_path"',
                 "-access +r",
@@ -632,10 +643,10 @@ define work "%s/libraries/work"
                 "-ncerror EVBSTR",
                 "-ncerror EVBNAT",
                 "-work work",
-                '-nclibdirname "%s"' % join(self.output_path, "libraries"),
-                '-cdslib "%s"' % join(self.output_path, "cds.lib"),
+                '-nclibdirname "%s"' % str(Path(self.output_path) / "libraries"),
+                '-cdslib "%s"' % str(Path(self.output_path) / "cds.lib"),
                 '-log "%s"'
-                % join("suite_output_path", simif.name, "irun_simulate.log"),
+                % str(Path("suite_output_path") / simif.name / "irun_simulate.log"),
                 "-quiet",
                 '-reflib "lib_path"',
                 "-access +r",
@@ -666,20 +677,26 @@ define work "%s/libraries/work"
 
         config = make_config(verilog=True)
         self.assertTrue(simif.simulate("suite_output_path", "test_suite_name", config))
-        elaborate_args_file = join(
-            "suite_output_path", simif.name, "irun_elaborate.args"
+        elaborate_args_file = str(
+            Path("suite_output_path") / simif.name / "irun_elaborate.args"
         )
-        simulate_args_file = join("suite_output_path", simif.name, "irun_simulate.args")
+        simulate_args_file = str(
+            Path("suite_output_path") / simif.name / "irun_simulate.args"
+        )
         run_command.assert_has_calls(
             [
                 mock.call(
-                    [join("prefix", "irun"), "-f", basename(elaborate_args_file)],
-                    cwd=dirname(elaborate_args_file),
+                    [
+                        str(Path("prefix") / "irun"),
+                        "-f",
+                        Path(elaborate_args_file).name,
+                    ],
+                    cwd=str(Path(elaborate_args_file).parent),
                     env=simif.get_env(),
                 ),
                 mock.call(
-                    [join("prefix", "irun"), "-f", basename(simulate_args_file)],
-                    cwd=dirname(simulate_args_file),
+                    [str(Path("prefix") / "irun"), "-f", Path(simulate_args_file).name],
+                    cwd=str(Path(simulate_args_file).parent),
                     env=simif.get_env(),
                 ),
             ]
@@ -699,10 +716,10 @@ define work "%s/libraries/work"
                 "-ncerror EVBSTR",
                 "-ncerror EVBNAT",
                 "-work work",
-                '-nclibdirname "%s"' % join(self.output_path, "libraries"),
-                '-cdslib "%s"' % join(self.output_path, "cds.lib"),
+                '-nclibdirname "%s"' % str(Path(self.output_path) / "libraries"),
+                '-cdslib "%s"' % str(Path(self.output_path) / "cds.lib"),
                 '-log "%s"'
-                % join("suite_output_path", simif.name, "irun_elaborate.log"),
+                % str(Path("suite_output_path") / simif.name / "irun_elaborate.log"),
                 "-quiet",
                 '-reflib "lib_path"',
                 "-access +r",
@@ -724,10 +741,10 @@ define work "%s/libraries/work"
                 "-ncerror EVBSTR",
                 "-ncerror EVBNAT",
                 "-work work",
-                '-nclibdirname "%s"' % join(self.output_path, "libraries"),
-                '-cdslib "%s"' % join(self.output_path, "cds.lib"),
+                '-nclibdirname "%s"' % str(Path(self.output_path) / "libraries"),
+                '-cdslib "%s"' % str(Path(self.output_path) / "cds.lib"),
                 '-log "%s"'
-                % join("suite_output_path", simif.name, "irun_simulate.log"),
+                % str(Path("suite_output_path") / simif.name / "irun_simulate.log"),
                 "-quiet",
                 '-reflib "lib_path"',
                 "-access +r",
@@ -749,20 +766,26 @@ define work "%s/libraries/work"
             sim_options={"incisive.irun_sim_flags": ["custom", "flags"]}
         )
         self.assertTrue(simif.simulate("suite_output_path", "test_suite_name", config))
-        elaborate_args_file = join(
-            "suite_output_path", simif.name, "irun_elaborate.args"
+        elaborate_args_file = str(
+            Path("suite_output_path") / simif.name / "irun_elaborate.args"
         )
-        simulate_args_file = join("suite_output_path", simif.name, "irun_simulate.args")
+        simulate_args_file = str(
+            Path("suite_output_path") / simif.name / "irun_simulate.args"
+        )
         run_command.assert_has_calls(
             [
                 mock.call(
-                    [join("prefix", "irun"), "-f", basename(elaborate_args_file)],
-                    cwd=dirname(elaborate_args_file),
+                    [
+                        str(Path("prefix") / "irun"),
+                        "-f",
+                        Path(elaborate_args_file).name,
+                    ],
+                    cwd=str(Path(elaborate_args_file).parent),
                     env=simif.get_env(),
                 ),
                 mock.call(
-                    [join("prefix", "irun"), "-f", basename(simulate_args_file)],
-                    cwd=dirname(simulate_args_file),
+                    [str(Path("prefix") / "irun"), "-f", Path(simulate_args_file).name],
+                    cwd=str(Path(simulate_args_file).parent),
                     env=simif.get_env(),
                 ),
             ]
@@ -789,20 +812,26 @@ define work "%s/libraries/work"
             verilog=True, generics={"genstr": "genval", "genint": 1, "genbool": True}
         )
         self.assertTrue(simif.simulate("suite_output_path", "test_suite_name", config))
-        elaborate_args_file = join(
-            "suite_output_path", simif.name, "irun_elaborate.args"
+        elaborate_args_file = str(
+            Path("suite_output_path") / simif.name / "irun_elaborate.args"
         )
-        simulate_args_file = join("suite_output_path", simif.name, "irun_simulate.args")
+        simulate_args_file = str(
+            Path("suite_output_path") / simif.name / "irun_simulate.args"
+        )
         run_command.assert_has_calls(
             [
                 mock.call(
-                    [join("prefix", "irun"), "-f", basename(elaborate_args_file)],
-                    cwd=dirname(elaborate_args_file),
+                    [
+                        str(Path("prefix") / "irun"),
+                        "-f",
+                        Path(elaborate_args_file).name,
+                    ],
+                    cwd=str(Path(elaborate_args_file).parent),
                     env=simif.get_env(),
                 ),
                 mock.call(
-                    [join("prefix", "irun"), "-f", basename(simulate_args_file)],
-                    cwd=dirname(simulate_args_file),
+                    [str(Path("prefix") / "irun"), "-f", Path(simulate_args_file).name],
+                    cwd=str(Path(simulate_args_file).parent),
                     env=simif.get_env(),
                 ),
             ]
@@ -827,20 +856,26 @@ define work "%s/libraries/work"
         )
         config = make_config()
         self.assertTrue(simif.simulate("suite_output_path", "test_suite_name", config))
-        elaborate_args_file = join(
-            "suite_output_path", simif.name, "irun_elaborate.args"
+        elaborate_args_file = str(
+            Path("suite_output_path") / simif.name / "irun_elaborate.args"
         )
-        simulate_args_file = join("suite_output_path", simif.name, "irun_simulate.args")
+        simulate_args_file = str(
+            Path("suite_output_path") / simif.name / "irun_simulate.args"
+        )
         run_command.assert_has_calls(
             [
                 mock.call(
-                    [join("prefix", "irun"), "-f", basename(elaborate_args_file)],
-                    cwd=dirname(elaborate_args_file),
+                    [
+                        str(Path("prefix") / "irun"),
+                        "-f",
+                        Path(elaborate_args_file).name,
+                    ],
+                    cwd=str(Path(elaborate_args_file).parent),
                     env=simif.get_env(),
                 ),
                 mock.call(
-                    [join("prefix", "irun"), "-f", basename(simulate_args_file)],
-                    cwd=dirname(simulate_args_file),
+                    [str(Path("prefix") / "irun"), "-f", Path(simulate_args_file).name],
+                    cwd=str(Path(simulate_args_file).parent),
                     env=simif.get_env(),
                 ),
             ]
@@ -863,14 +898,18 @@ define work "%s/libraries/work"
                 "suite_output_path", "test_suite_name", config, elaborate_only=True
             )
         )
-        elaborate_args_file = join(
-            "suite_output_path", simif.name, "irun_elaborate.args"
+        elaborate_args_file = str(
+            Path("suite_output_path") / simif.name / "irun_elaborate.args"
         )
         run_command.assert_has_calls(
             [
                 mock.call(
-                    [join("prefix", "irun"), "-f", basename(elaborate_args_file)],
-                    cwd=dirname(elaborate_args_file),
+                    [
+                        str(Path("prefix") / "irun"),
+                        "-f",
+                        Path(elaborate_args_file).name,
+                    ],
+                    cwd=str(Path(elaborate_args_file).parent),
                     env=simif.get_env(),
                 )
             ]
@@ -890,10 +929,10 @@ define work "%s/libraries/work"
                 "-ncerror EVBSTR",
                 "-ncerror EVBNAT",
                 "-work work",
-                '-nclibdirname "%s"' % join(self.output_path, "libraries"),
-                '-cdslib "%s"' % join(self.output_path, "cds.lib"),
+                '-nclibdirname "%s"' % str(Path(self.output_path) / "libraries"),
+                '-cdslib "%s"' % str(Path(self.output_path) / "cds.lib"),
                 '-log "%s"'
-                % join("suite_output_path", simif.name, "irun_elaborate.log"),
+                % str(Path("suite_output_path") / simif.name / "irun_elaborate.log"),
                 "-quiet",
                 "-access +r",
                 '-input "@run"',
@@ -912,14 +951,18 @@ define work "%s/libraries/work"
         simif = IncisiveInterface(prefix="prefix", output_path=self.output_path)
         config = make_config()
         self.assertFalse(simif.simulate("suite_output_path", "test_suite_name", config))
-        elaborate_args_file = join(
-            "suite_output_path", simif.name, "irun_elaborate.args"
+        elaborate_args_file = str(
+            Path("suite_output_path") / simif.name / "irun_elaborate.args"
         )
         run_command.assert_has_calls(
             [
                 mock.call(
-                    [join("prefix", "irun"), "-f", basename(elaborate_args_file)],
-                    cwd=dirname(elaborate_args_file),
+                    [
+                        str(Path("prefix") / "irun"),
+                        "-f",
+                        Path(elaborate_args_file).name,
+                    ],
+                    cwd=str(Path(elaborate_args_file).parent),
                     env=simif.get_env(),
                 )
             ]
@@ -938,20 +981,26 @@ define work "%s/libraries/work"
         simif = IncisiveInterface(prefix="prefix", output_path=self.output_path)
         config = make_config()
         self.assertFalse(simif.simulate("suite_output_path", "test_suite_name", config))
-        elaborate_args_file = join(
-            "suite_output_path", simif.name, "irun_elaborate.args"
+        elaborate_args_file = str(
+            Path("suite_output_path") / simif.name / "irun_elaborate.args"
         )
-        simulate_args_file = join("suite_output_path", simif.name, "irun_simulate.args")
+        simulate_args_file = str(
+            Path("suite_output_path") / simif.name / "irun_simulate.args"
+        )
         run_command.assert_has_calls(
             [
                 mock.call(
-                    [join("prefix", "irun"), "-f", basename(elaborate_args_file)],
-                    cwd=dirname(elaborate_args_file),
+                    [
+                        str(Path("prefix") / "irun"),
+                        "-f",
+                        Path(elaborate_args_file).name,
+                    ],
+                    cwd=str(Path(elaborate_args_file).parent),
                     env=simif.get_env(),
                 ),
                 mock.call(
-                    [join("prefix", "irun"), "-f", basename(simulate_args_file)],
-                    cwd=dirname(simulate_args_file),
+                    [str(Path("prefix") / "irun"), "-f", Path(simulate_args_file).name],
+                    cwd=str(Path(simulate_args_file).parent),
                     env=simif.get_env(),
                 ),
             ]
@@ -980,20 +1029,26 @@ define work "%s/libraries/work"
             simif.compile_project(project)
         config = make_config()
         self.assertTrue(simif.simulate("suite_output_path", "test_suite_name", config))
-        elaborate_args_file = join(
-            "suite_output_path", simif.name, "irun_elaborate.args"
+        elaborate_args_file = str(
+            Path("suite_output_path") / simif.name / "irun_elaborate.args"
         )
-        simulate_args_file = join("suite_output_path", simif.name, "irun_simulate.args")
+        simulate_args_file = str(
+            Path("suite_output_path") / simif.name / "irun_simulate.args"
+        )
         run_command.assert_has_calls(
             [
                 mock.call(
-                    [join("prefix", "irun"), "-f", basename(elaborate_args_file)],
-                    cwd=dirname(elaborate_args_file),
+                    [
+                        str(Path("prefix") / "irun"),
+                        "-f",
+                        Path(elaborate_args_file).name,
+                    ],
+                    cwd=str(Path(elaborate_args_file).parent),
                     env=simif.get_env(),
                 ),
                 mock.call(
-                    [join("prefix", "irun"), "-f", basename(simulate_args_file)],
-                    cwd=dirname(simulate_args_file),
+                    [str(Path("prefix") / "irun"), "-f", Path(simulate_args_file).name],
+                    cwd=str(Path(simulate_args_file).parent),
                     env=simif.get_env(),
                 ),
             ]
@@ -1012,10 +1067,10 @@ define work "%s/libraries/work"
                 "-ncerror EVBSTR",
                 "-ncerror EVBNAT",
                 "-work work",
-                '-nclibdirname "%s"' % join(self.output_path, "libraries"),
-                '-cdslib "%s"' % join(self.output_path, "cds.lib"),
+                '-nclibdirname "%s"' % str(Path(self.output_path) / "libraries"),
+                '-cdslib "%s"' % str(Path(self.output_path) / "cds.lib"),
                 '-log "%s"'
-                % join("suite_output_path", simif.name, "irun_elaborate.log"),
+                % str(Path("suite_output_path") / simif.name / "irun_elaborate.log"),
                 "-quiet",
                 '-reflib "lib_path"',
                 "-access +rwc",
@@ -1037,10 +1092,10 @@ define work "%s/libraries/work"
                 "-ncerror EVBSTR",
                 "-ncerror EVBNAT",
                 "-work work",
-                '-nclibdirname "%s"' % join(self.output_path, "libraries"),
-                '-cdslib "%s"' % join(self.output_path, "cds.lib"),
+                '-nclibdirname "%s"' % str(Path(self.output_path) / "libraries"),
+                '-cdslib "%s"' % str(Path(self.output_path) / "cds.lib"),
                 '-log "%s"'
-                % join("suite_output_path", simif.name, "irun_simulate.log"),
+                % str(Path("suite_output_path") / simif.name / "irun_simulate.log"),
                 "-quiet",
                 '-reflib "lib_path"',
                 "-access +rwc",
@@ -1050,7 +1105,7 @@ define work "%s/libraries/work"
         )
 
     def setUp(self):
-        self.output_path = join(dirname(__file__), "test_incisive_out")
+        self.output_path = str(Path(__file__).parent / "test_incisive_out")
         renew_path(self.output_path)
         self.project = Project()
         self.cwd = os.getcwd()
@@ -1058,7 +1113,7 @@ define work "%s/libraries/work"
 
     def tearDown(self):
         os.chdir(self.cwd)
-        if exists(self.output_path):
+        if Path(self.output_path).exists():
             rmtree(self.output_path)
 
 

--- a/tests/unit/test_modelsim_interface.py
+++ b/tests/unit/test_modelsim_interface.py
@@ -10,7 +10,7 @@ Test the ModelSim interface
 
 
 import unittest
-from os.path import join, dirname, exists
+from pathlib import Path
 import os
 from shutil import rmtree
 from unittest import mock
@@ -39,13 +39,13 @@ class TestModelSimInterface(unittest.TestCase):
             "file.vhd", "lib", file_type="vhdl", vhdl_standard=VHDL.standard("2008")
         )
         simif.compile_project(project)
-        process_args = [join(self.prefix_path, "vlib"), "-unix", "lib_path"]
+        process_args = [str(Path(self.prefix_path) / "vlib"), "-unix", "lib_path"]
         process.assert_called_once_with(process_args, env=simif.get_env())
         check_args = [
-            join(self.prefix_path, "vcom"),
+            str(Path(self.prefix_path) / "vcom"),
             "-quiet",
             "-modelsimini",
-            join(self.output_path, "modelsim.ini"),
+            str(Path(self.output_path) / "modelsim.ini"),
             "-2008",
             "-work",
             "lib",
@@ -66,13 +66,13 @@ class TestModelSimInterface(unittest.TestCase):
             "file.vhd", "lib", file_type="vhdl", vhdl_standard=VHDL.standard("2002")
         )
         simif.compile_project(project)
-        process_args = [join(self.prefix_path, "vlib"), "-unix", "lib_path"]
+        process_args = [str(Path(self.prefix_path) / "vlib"), "-unix", "lib_path"]
         process.assert_called_once_with(process_args, env=simif.get_env())
         check_args = [
-            join(self.prefix_path, "vcom"),
+            str(Path(self.prefix_path) / "vcom"),
             "-quiet",
             "-modelsimini",
-            join(self.output_path, "modelsim.ini"),
+            str(Path(self.output_path) / "modelsim.ini"),
             "-2002",
             "-work",
             "lib",
@@ -93,13 +93,13 @@ class TestModelSimInterface(unittest.TestCase):
             "file.vhd", "lib", file_type="vhdl", vhdl_standard=VHDL.standard("93")
         )
         simif.compile_project(project)
-        process_args = [join(self.prefix_path, "vlib"), "-unix", "lib_path"]
+        process_args = [str(Path(self.prefix_path) / "vlib"), "-unix", "lib_path"]
         process.assert_called_once_with(process_args, env=simif.get_env())
         check_args = [
-            join(self.prefix_path, "vcom"),
+            str(Path(self.prefix_path) / "vcom"),
             "-quiet",
             "-modelsimini",
-            join(self.output_path, "modelsim.ini"),
+            str(Path(self.output_path) / "modelsim.ini"),
             "-93",
             "-work",
             "lib",
@@ -119,13 +119,13 @@ class TestModelSimInterface(unittest.TestCase):
         source_file = project.add_source_file("file.vhd", "lib", file_type="vhdl")
         source_file.set_compile_option("modelsim.vcom_flags", ["custom", "flags"])
         simif.compile_project(project)
-        process_args = [join(self.prefix_path, "vlib"), "-unix", "lib_path"]
+        process_args = [str(Path(self.prefix_path) / "vlib"), "-unix", "lib_path"]
         process.assert_called_once_with(process_args, env=simif.get_env())
         check_args = [
-            join(self.prefix_path, "vcom"),
+            str(Path(self.prefix_path) / "vcom"),
             "-quiet",
             "-modelsimini",
-            join(self.output_path, "modelsim.ini"),
+            str(Path(self.output_path) / "modelsim.ini"),
             "custom",
             "flags",
             "-2008",
@@ -146,13 +146,13 @@ class TestModelSimInterface(unittest.TestCase):
         write_file("file.v", "")
         project.add_source_file("file.v", "lib", file_type="verilog")
         simif.compile_project(project)
-        process_args = [join(self.prefix_path, "vlib"), "-unix", "lib_path"]
+        process_args = [str(Path(self.prefix_path) / "vlib"), "-unix", "lib_path"]
         process.assert_called_once_with(process_args, env=simif.get_env())
         check_args = [
-            join(self.prefix_path, "vlog"),
+            str(Path(self.prefix_path) / "vlog"),
             "-quiet",
             "-modelsimini",
-            join(self.output_path, "modelsim.ini"),
+            str(Path(self.output_path) / "modelsim.ini"),
             "-work",
             "lib",
             "file.v",
@@ -172,13 +172,13 @@ class TestModelSimInterface(unittest.TestCase):
         write_file("file.sv", "")
         project.add_source_file("file.sv", "lib", file_type="systemverilog")
         simif.compile_project(project)
-        process_args = [join(self.prefix_path, "vlib"), "-unix", "lib_path"]
+        process_args = [str(Path(self.prefix_path) / "vlib"), "-unix", "lib_path"]
         process.assert_called_once_with(process_args, env=simif.get_env())
         check_args = [
-            join(self.prefix_path, "vlog"),
+            str(Path(self.prefix_path) / "vlog"),
             "-quiet",
             "-modelsimini",
-            join(self.output_path, "modelsim.ini"),
+            str(Path(self.output_path) / "modelsim.ini"),
             "-sv",
             "-work",
             "lib",
@@ -200,13 +200,13 @@ class TestModelSimInterface(unittest.TestCase):
         source_file = project.add_source_file("file.v", "lib", file_type="verilog")
         source_file.set_compile_option("modelsim.vlog_flags", ["custom", "flags"])
         simif.compile_project(project)
-        process_args = [join(self.prefix_path, "vlib"), "-unix", "lib_path"]
+        process_args = [str(Path(self.prefix_path) / "vlib"), "-unix", "lib_path"]
         process.assert_called_once_with(process_args, env=simif.get_env())
         check_args = [
-            join(self.prefix_path, "vlog"),
+            str(Path(self.prefix_path) / "vlog"),
             "-quiet",
             "-modelsimini",
-            join(self.output_path, "modelsim.ini"),
+            str(Path(self.output_path) / "modelsim.ini"),
             "custom",
             "flags",
             "-work",
@@ -230,13 +230,13 @@ class TestModelSimInterface(unittest.TestCase):
             "file.v", "lib", file_type="verilog", include_dirs=["include"]
         )
         simif.compile_project(project)
-        process_args = [join(self.prefix_path, "vlib"), "-unix", "lib_path"]
+        process_args = [str(Path(self.prefix_path) / "vlib"), "-unix", "lib_path"]
         process.assert_called_once_with(process_args, env=simif.get_env())
         check_args = [
-            join(self.prefix_path, "vlog"),
+            str(Path(self.prefix_path) / "vlog"),
             "-quiet",
             "-modelsimini",
-            join(self.output_path, "modelsim.ini"),
+            str(Path(self.output_path) / "modelsim.ini"),
             "-work",
             "lib",
             "file.v",
@@ -259,13 +259,13 @@ class TestModelSimInterface(unittest.TestCase):
             "file.v", "lib", file_type="verilog", defines={"defname": "defval"}
         )
         simif.compile_project(project)
-        process_args = [join(self.prefix_path, "vlib"), "-unix", "lib_path"]
+        process_args = [str(Path(self.prefix_path) / "vlib"), "-unix", "lib_path"]
         process.assert_called_once_with(process_args, env=simif.get_env())
         process_args = [
-            join(self.prefix_path, "vlog"),
+            str(Path(self.prefix_path) / "vlog"),
             "-quiet",
             "-modelsimini",
-            join(self.output_path, "modelsim.ini"),
+            str(Path(self.output_path) / "modelsim.ini"),
             "-work",
             "lib",
             "file.v",
@@ -275,10 +275,15 @@ class TestModelSimInterface(unittest.TestCase):
         ]
         check_output.assert_called_once_with(process_args, env=simif.get_env())
 
+    def _get_inis(self):
+        return (
+            str(Path(self.output_path) / "modelsim.ini"),
+            str(Path(self.prefix_path) / ".." / "modelsim.ini"),
+            str(Path(self.test_path) / "my_modelsim.ini"),
+        )
+
     def test_copies_modelsim_ini_file_from_install(self):
-        modelsim_ini = join(self.output_path, "modelsim.ini")
-        installed_modelsim_ini = join(self.prefix_path, "..", "modelsim.ini")
-        user_modelsim_ini = join(self.test_path, "my_modelsim.ini")
+        (modelsim_ini, installed_modelsim_ini, user_modelsim_ini) = self._get_inis()
 
         with open(installed_modelsim_ini, "w") as fptr:
             fptr.write("installed")
@@ -293,9 +298,7 @@ class TestModelSimInterface(unittest.TestCase):
             self.assertEqual(fptr.read(), "installed")
 
     def test_copies_modelsim_ini_file_from_user(self):
-        modelsim_ini = join(self.output_path, "modelsim.ini")
-        installed_modelsim_ini = join(self.prefix_path, "..", "modelsim.ini")
-        user_modelsim_ini = join(self.test_path, "my_modelsim.ini")
+        (modelsim_ini, installed_modelsim_ini, user_modelsim_ini) = self._get_inis()
 
         with open(installed_modelsim_ini, "w") as fptr:
             fptr.write("installed")
@@ -312,9 +315,7 @@ class TestModelSimInterface(unittest.TestCase):
             self.assertEqual(fptr.read(), "user")
 
     def test_overwrites_modelsim_ini_file_from_install(self):
-        modelsim_ini = join(self.output_path, "modelsim.ini")
-        installed_modelsim_ini = join(self.prefix_path, "..", "modelsim.ini")
-        user_modelsim_ini = join(self.test_path, "my_modelsim.ini")
+        (modelsim_ini, installed_modelsim_ini, user_modelsim_ini) = self._get_inis()
 
         with open(modelsim_ini, "w") as fptr:
             fptr.write("existing")
@@ -332,9 +333,7 @@ class TestModelSimInterface(unittest.TestCase):
             self.assertEqual(fptr.read(), "installed")
 
     def test_overwrites_modelsim_ini_file_from_user(self):
-        modelsim_ini = join(self.output_path, "modelsim.ini")
-        installed_modelsim_ini = join(self.prefix_path, "..", "modelsim.ini")
-        user_modelsim_ini = join(self.test_path, "my_modelsim.ini")
+        (modelsim_ini, installed_modelsim_ini, user_modelsim_ini) = self._get_inis()
 
         with open(modelsim_ini, "w") as fptr:
             fptr.write("existing")
@@ -354,13 +353,14 @@ class TestModelSimInterface(unittest.TestCase):
             self.assertEqual(fptr.read(), "user")
 
     def setUp(self):
-        self.test_path = join(dirname(__file__), "test_modelsim_out")
-        self.output_path = join(self.test_path, "modelsim")
-        self.prefix_path = join(self.test_path, "prefix", "bin")
+        self.test_path = str(Path(__file__).parent / "test_modelsim_out")
+
+        self.output_path = str(Path(self.test_path) / "modelsim")
+        self.prefix_path = str(Path(self.test_path) / "prefix" / "bin")
         renew_path(self.test_path)
         renew_path(self.output_path)
         renew_path(self.prefix_path)
-        installed_modelsim_ini = join(self.prefix_path, "..", "modelsim.ini")
+        installed_modelsim_ini = str(Path(self.prefix_path) / ".." / "modelsim.ini")
         write_file(installed_modelsim_ini, "[Library]")
         self.project = Project()
         self.cwd = os.getcwd()
@@ -368,5 +368,5 @@ class TestModelSimInterface(unittest.TestCase):
 
     def tearDown(self):
         os.chdir(self.cwd)
-        if exists(self.test_path):
+        if Path(self.test_path).exists():
             rmtree(self.test_path)

--- a/tests/unit/test_ostools.py
+++ b/tests/unit/test_ostools.py
@@ -10,8 +10,8 @@ Test the os-dependent functionality wrappers
 
 
 from unittest import TestCase
+from pathlib import Path
 from shutil import rmtree
-from os.path import exists, dirname, join, abspath
 import sys
 from vunit.ostools import Process, renew_path
 
@@ -22,11 +22,11 @@ class TestOSTools(TestCase):
     """
 
     def setUp(self):
-        self.tmp_dir = join(dirname(__file__), "test_ostools_tmp")
+        self.tmp_dir = str(Path(__file__).parent / "test_ostools_tmp")
         renew_path(self.tmp_dir)
 
     def tearDown(self):
-        if exists(self.tmp_dir):
+        if Path(self.tmp_dir).exists():
             rmtree(self.tmp_dir)
 
     def make_file(self, file_name, contents):
@@ -34,7 +34,7 @@ class TestOSTools(TestCase):
         Create a file in the temporary directory with contents
         Returns the absolute path to the file.
         """
-        full_file_name = abspath(join(self.tmp_dir, file_name))
+        full_file_name = str((Path(self.tmp_dir) / file_name).resolve())
         with open(full_file_name, "w") as outfile:
             outfile.write(contents)
         return full_file_name
@@ -101,7 +101,7 @@ sleep(1000)
         self.assertEqual(message, "message")
 
     def test_non_utf8_in_output(self):
-        python_script = join(dirname(__file__), "non_utf8_printer.py")
+        python_script = str(Path(__file__).parent / "non_utf8_printer.py")
         output = []
         process = Process([sys.executable, python_script])
         process.consume_output(output.append)

--- a/tests/unit/test_project.py
+++ b/tests/unit/test_project.py
@@ -12,9 +12,9 @@ Test the project functionality
 
 
 import unittest
-from shutil import rmtree
-from os.path import join, exists, dirname
+from pathlib import Path
 import os
+from shutil import rmtree
 from time import sleep
 import itertools
 from unittest import mock
@@ -30,7 +30,7 @@ class TestProject(unittest.TestCase):  # pylint: disable=too-many-public-methods
     """
 
     def setUp(self):
-        self.output_path = join(dirname(__file__), "test_project_out")
+        self.output_path = str(Path(__file__).parent / "test_project_out")
         renew_path(self.output_path)
         self.project = Project()
         self.cwd = os.getcwd()
@@ -38,7 +38,7 @@ class TestProject(unittest.TestCase):  # pylint: disable=too-many-public-methods
 
     def tearDown(self):
         os.chdir(self.cwd)
-        if exists(self.output_path):
+        if Path(self.output_path).exists():
             rmtree(self.output_path)
 
     def test_parses_entity_architecture(self):
@@ -196,7 +196,7 @@ end entity;
         self.project.add_library("lib", "lib_path")
         a_foo = self.add_source_file(
             "lib",
-            join("a", "foo.vhd"),
+            str(Path("a") / "foo.vhd"),
             """
 entity a_foo is
 end entity;
@@ -205,7 +205,7 @@ end entity;
 
         b_foo = self.add_source_file(
             "lib",
-            join("b", "foo.vhd"),
+            str(Path("b") / "foo.vhd"),
             """
 entity b_foo is
 end entity;
@@ -891,7 +891,7 @@ endpackage
 
         for source_file in files:
             self.update(source_file)
-            self.assertTrue(exists(self.hash_file_name_of(source_file)))
+            self.assertTrue(Path(self.hash_file_name_of(source_file)).exists())
 
     def test_should_not_recompile_updated_files(self):
         file1, file2, file3 = self.create_dummy_three_file_project()

--- a/tests/unit/test_rivierapro_interface.py
+++ b/tests/unit/test_rivierapro_interface.py
@@ -10,7 +10,7 @@ Test the RivieraPro interface
 
 
 import unittest
-from os.path import join, dirname, exists
+from pathlib import Path
 import os
 from shutil import rmtree
 from unittest import mock
@@ -37,18 +37,18 @@ class TestRivieraProInterface(unittest.TestCase):
         )
         simif.compile_project(project)
         process.assert_any_call(
-            [join("prefix", "vlib"), "lib", "lib_path"],
+            [str(Path("prefix") / "vlib"), "lib", "lib_path"],
             cwd=self.output_path,
             env=simif.get_env(),
         )
         process.assert_called_with(
-            [join("prefix", "vmap"), "lib", "lib_path"],
+            [str(Path("prefix") / "vmap"), "lib", "lib_path"],
             cwd=self.output_path,
             env=simif.get_env(),
         )
         check_output.assert_called_once_with(
             [
-                join("prefix", "vcom"),
+                str(Path("prefix") / "vcom"),
                 "-quiet",
                 "-j",
                 self.output_path,
@@ -72,18 +72,18 @@ class TestRivieraProInterface(unittest.TestCase):
         )
         simif.compile_project(project)
         process.assert_any_call(
-            [join("prefix", "vlib"), "lib", "lib_path"],
+            [str(Path("prefix") / "vlib"), "lib", "lib_path"],
             cwd=self.output_path,
             env=simif.get_env(),
         )
         process.assert_called_with(
-            [join("prefix", "vmap"), "lib", "lib_path"],
+            [str(Path("prefix") / "vmap"), "lib", "lib_path"],
             cwd=self.output_path,
             env=simif.get_env(),
         )
         check_output.assert_called_once_with(
             [
-                join("prefix", "vcom"),
+                str(Path("prefix") / "vcom"),
                 "-quiet",
                 "-j",
                 self.output_path,
@@ -107,18 +107,18 @@ class TestRivieraProInterface(unittest.TestCase):
         )
         simif.compile_project(project)
         process.assert_any_call(
-            [join("prefix", "vlib"), "lib", "lib_path"],
+            [str(Path("prefix") / "vlib"), "lib", "lib_path"],
             cwd=self.output_path,
             env=simif.get_env(),
         )
         process.assert_called_with(
-            [join("prefix", "vmap"), "lib", "lib_path"],
+            [str(Path("prefix") / "vmap"), "lib", "lib_path"],
             cwd=self.output_path,
             env=simif.get_env(),
         )
         check_output.assert_called_once_with(
             [
-                join("prefix", "vcom"),
+                str(Path("prefix") / "vcom"),
                 "-quiet",
                 "-j",
                 self.output_path,
@@ -142,18 +142,18 @@ class TestRivieraProInterface(unittest.TestCase):
         )
         simif.compile_project(project)
         process.assert_any_call(
-            [join("prefix", "vlib"), "lib", "lib_path"],
+            [str(Path("prefix") / "vlib"), "lib", "lib_path"],
             cwd=self.output_path,
             env=simif.get_env(),
         )
         process.assert_called_with(
-            [join("prefix", "vmap"), "lib", "lib_path"],
+            [str(Path("prefix") / "vmap"), "lib", "lib_path"],
             cwd=self.output_path,
             env=simif.get_env(),
         )
         check_output.assert_called_once_with(
             [
-                join("prefix", "vcom"),
+                str(Path("prefix") / "vcom"),
                 "-quiet",
                 "-j",
                 self.output_path,
@@ -176,18 +176,18 @@ class TestRivieraProInterface(unittest.TestCase):
         source_file.set_compile_option("rivierapro.vcom_flags", ["custom", "flags"])
         simif.compile_project(project)
         process.assert_any_call(
-            [join("prefix", "vlib"), "lib", "lib_path"],
+            [str(Path("prefix") / "vlib"), "lib", "lib_path"],
             cwd=self.output_path,
             env=simif.get_env(),
         )
         process.assert_called_with(
-            [join("prefix", "vmap"), "lib", "lib_path"],
+            [str(Path("prefix") / "vmap"), "lib", "lib_path"],
             cwd=self.output_path,
             env=simif.get_env(),
         )
         check_output.assert_called_once_with(
             [
-                join("prefix", "vcom"),
+                str(Path("prefix") / "vcom"),
                 "-quiet",
                 "-j",
                 self.output_path,
@@ -204,7 +204,7 @@ class TestRivieraProInterface(unittest.TestCase):
     @mock.patch("vunit.sim_if.check_output", autospec=True, return_value="")
     @mock.patch("vunit.sim_if.rivierapro.Process", autospec=True)
     def test_compile_project_verilog(self, process, check_output):
-        library_cfg = join(self.output_path, "library.cfg")
+        library_cfg = str(Path(self.output_path) / "library.cfg")
         simif = RivieraProInterface(prefix="prefix", output_path=self.output_path)
         project = Project()
         project.add_library("lib", "lib_path")
@@ -212,18 +212,18 @@ class TestRivieraProInterface(unittest.TestCase):
         project.add_source_file("file.v", "lib", file_type="verilog")
         simif.compile_project(project)
         process.assert_any_call(
-            [join("prefix", "vlib"), "lib", "lib_path"],
+            [str(Path("prefix") / "vlib"), "lib", "lib_path"],
             cwd=self.output_path,
             env=simif.get_env(),
         )
         process.assert_called_with(
-            [join("prefix", "vmap"), "lib", "lib_path"],
+            [str(Path("prefix") / "vmap"), "lib", "lib_path"],
             cwd=self.output_path,
             env=simif.get_env(),
         )
         check_output.assert_called_once_with(
             [
-                join("prefix", "vlog"),
+                str(Path("prefix") / "vlog"),
                 "-quiet",
                 "-lc",
                 library_cfg,
@@ -239,7 +239,7 @@ class TestRivieraProInterface(unittest.TestCase):
     @mock.patch("vunit.sim_if.check_output", autospec=True, return_value="")
     @mock.patch("vunit.sim_if.rivierapro.Process", autospec=True)
     def test_compile_project_system_verilog(self, process, check_output):
-        library_cfg = join(self.output_path, "library.cfg")
+        library_cfg = str(Path(self.output_path) / "library.cfg")
         simif = RivieraProInterface(prefix="prefix", output_path=self.output_path)
         project = Project()
         project.add_library("lib", "lib_path")
@@ -247,18 +247,18 @@ class TestRivieraProInterface(unittest.TestCase):
         project.add_source_file("file.sv", "lib", file_type="systemverilog")
         simif.compile_project(project)
         process.assert_any_call(
-            [join("prefix", "vlib"), "lib", "lib_path"],
+            [str(Path("prefix") / "vlib"), "lib", "lib_path"],
             cwd=self.output_path,
             env=simif.get_env(),
         )
         process.assert_called_with(
-            [join("prefix", "vmap"), "lib", "lib_path"],
+            [str(Path("prefix") / "vmap"), "lib", "lib_path"],
             cwd=self.output_path,
             env=simif.get_env(),
         )
         check_output.assert_called_once_with(
             [
-                join("prefix", "vlog"),
+                str(Path("prefix") / "vlog"),
                 "-quiet",
                 "-lc",
                 library_cfg,
@@ -275,7 +275,7 @@ class TestRivieraProInterface(unittest.TestCase):
     @mock.patch("vunit.sim_if.check_output", autospec=True, return_value="")
     @mock.patch("vunit.sim_if.rivierapro.Process", autospec=True)
     def test_compile_project_verilog_extra_flags(self, process, check_output):
-        library_cfg = join(self.output_path, "library.cfg")
+        library_cfg = str(Path(self.output_path) / "library.cfg")
         simif = RivieraProInterface(prefix="prefix", output_path=self.output_path)
         project = Project()
         project.add_library("lib", "lib_path")
@@ -284,18 +284,18 @@ class TestRivieraProInterface(unittest.TestCase):
         source_file.set_compile_option("rivierapro.vlog_flags", ["custom", "flags"])
         simif.compile_project(project)
         process.assert_any_call(
-            [join("prefix", "vlib"), "lib", "lib_path"],
+            [str(Path("prefix") / "vlib"), "lib", "lib_path"],
             cwd=self.output_path,
             env=simif.get_env(),
         )
         process.assert_called_with(
-            [join("prefix", "vmap"), "lib", "lib_path"],
+            [str(Path("prefix") / "vmap"), "lib", "lib_path"],
             cwd=self.output_path,
             env=simif.get_env(),
         )
         check_output.assert_called_once_with(
             [
-                join("prefix", "vlog"),
+                str(Path("prefix") / "vlog"),
                 "-quiet",
                 "-lc",
                 library_cfg,
@@ -313,7 +313,7 @@ class TestRivieraProInterface(unittest.TestCase):
     @mock.patch("vunit.sim_if.check_output", autospec=True, return_value="")
     @mock.patch("vunit.sim_if.rivierapro.Process", autospec=True)
     def test_compile_project_verilog_include(self, process, check_output):
-        library_cfg = join(self.output_path, "library.cfg")
+        library_cfg = str(Path(self.output_path) / "library.cfg")
         simif = RivieraProInterface(prefix="prefix", output_path=self.output_path)
         project = Project()
         project.add_library("lib", "lib_path")
@@ -323,16 +323,18 @@ class TestRivieraProInterface(unittest.TestCase):
         )
         simif.compile_project(project)
         process.assert_any_call(
-            [join("prefix", "vlib"), "lib", "lib_path"], cwd=self.output_path, env=None
+            [str(Path("prefix") / "vlib"), "lib", "lib_path"],
+            cwd=self.output_path,
+            env=None,
         )
         process.assert_called_with(
-            [join("prefix", "vmap"), "lib", "lib_path"],
+            [str(Path("prefix") / "vmap"), "lib", "lib_path"],
             cwd=self.output_path,
             env=simif.get_env(),
         )
         check_output.assert_called_once_with(
             [
-                join("prefix", "vlog"),
+                str(Path("prefix") / "vlog"),
                 "-quiet",
                 "-lc",
                 library_cfg,
@@ -349,7 +351,7 @@ class TestRivieraProInterface(unittest.TestCase):
     @mock.patch("vunit.sim_if.check_output", autospec=True, return_value="")
     @mock.patch("vunit.sim_if.rivierapro.Process", autospec=True)
     def test_compile_project_verilog_define(self, process, check_output):
-        library_cfg = join(self.output_path, "library.cfg")
+        library_cfg = str(Path(self.output_path) / "library.cfg")
         simif = RivieraProInterface(prefix="prefix", output_path=self.output_path)
         project = Project()
         project.add_library("lib", "lib_path")
@@ -359,18 +361,18 @@ class TestRivieraProInterface(unittest.TestCase):
         )
         simif.compile_project(project)
         process.assert_any_call(
-            [join("prefix", "vlib"), "lib", "lib_path"],
+            [str(Path("prefix") / "vlib"), "lib", "lib_path"],
             cwd=self.output_path,
             env=simif.get_env(),
         )
         process.assert_called_with(
-            [join("prefix", "vmap"), "lib", "lib_path"],
+            [str(Path("prefix") / "vmap"), "lib", "lib_path"],
             cwd=self.output_path,
             env=simif.get_env(),
         )
         check_output.assert_called_once_with(
             [
-                join("prefix", "vlog"),
+                str(Path("prefix") / "vlog"),
                 "-quiet",
                 "-lc",
                 library_cfg,
@@ -385,7 +387,7 @@ class TestRivieraProInterface(unittest.TestCase):
         )
 
     def setUp(self):
-        self.output_path = join(dirname(__file__), "test_rivierapro_out")
+        self.output_path = str(Path(__file__).parent / "test_rivierapro_out")
         renew_path(self.output_path)
         self.project = Project()
         self.cwd = os.getcwd()
@@ -393,5 +395,5 @@ class TestRivieraProInterface(unittest.TestCase):
 
     def tearDown(self):
         os.chdir(self.cwd)
-        if exists(self.output_path):
+        if Path(self.output_path).exists():
             rmtree(self.output_path)

--- a/tests/unit/test_simulator_interface.py
+++ b/tests/unit/test_simulator_interface.py
@@ -9,8 +9,8 @@ Test the SimulatorInterface class
 """
 
 import unittest
-from os.path import join, dirname, exists
-import os
+from pathlib import Path
+from os import chdir, getcwd
 import subprocess
 from shutil import rmtree
 from unittest import mock
@@ -248,15 +248,15 @@ Compile failed
         environ.get.assert_called_once_with("VUNIT_SIMNAME_PATH", None)
 
     def setUp(self):
-        self.output_path = join(dirname(__file__), "test_simulator_interface__out")
+        self.output_path = str(Path(__file__).parent / "test_simulator_interface__out")
         renew_path(self.output_path)
         self.project = Project()
-        self.cwd = os.getcwd()
-        os.chdir(self.output_path)
+        self.cwd = getcwd()
+        chdir(self.output_path)
 
     def tearDown(self):
-        os.chdir(self.cwd)
-        if exists(self.output_path):
+        chdir(self.cwd)
+        if Path(self.output_path).exists():
             rmtree(self.output_path)
 
 

--- a/tests/unit/test_test_bench_list.py
+++ b/tests/unit/test_test_bench_list.py
@@ -11,7 +11,7 @@ Tests the test test_bench module
 """
 
 import unittest
-from os.path import join
+from pathlib import Path
 from unittest import mock
 from tests.unit.test_test_bench import Entity, Module
 from tests.common import with_tempdir
@@ -29,19 +29,21 @@ class TestTestBenchList(unittest.TestCase):
 
     @with_tempdir
     def test_tb_filter_requires_runner_cfg(self, tempdir):
-        design_unit = Entity("tb_entity", file_name=join(tempdir, "file.vhd"))
+        fname = str(Path(tempdir) / "file.vhd")
+
+        design_unit = Entity("tb_entity", file_name=fname)
         design_unit.generic_names = ["runner_cfg"]
         self.assertTrue(tb_filter(design_unit))
 
-        design_unit = Entity("tb_entity", file_name=join(tempdir, "file.vhd"))
+        design_unit = Entity("tb_entity", file_name=fname)
         design_unit.generic_names = []
         self.assertFalse(tb_filter(design_unit))
 
-        design_unit = Module("tb_module", file_name=join(tempdir, "file.vhd"))
+        design_unit = Module("tb_module", file_name=fname)
         design_unit.generic_names = ["runner_cfg"]
         self.assertTrue(tb_filter(design_unit))
 
-        design_unit = Module("tb_module", file_name=join(tempdir, "file.vhd"))
+        design_unit = Module("tb_module", file_name=fname)
         design_unit.generic_names = []
         self.assertFalse(tb_filter(design_unit))
 
@@ -51,7 +53,9 @@ class TestTestBenchList(unittest.TestCase):
         Issue #263
         """
         with mock.patch("vunit.test.bench_list.LOGGER", autospec=True) as logger:
-            design_unit = Entity("mul_tbl_scale", file_name=join(tempdir, "file.vhd"))
+            design_unit = Entity(
+                "mul_tbl_scale", file_name=str(Path(tempdir) / "file.vhd")
+            )
             self.assertFalse(tb_filter(design_unit))
             self.assertFalse(logger.warning.called)
 
@@ -59,7 +63,9 @@ class TestTestBenchList(unittest.TestCase):
     def test_tb_filter_warning_on_missing_runner_cfg_when_matching_tb_pattern(
         self, tempdir
     ):
-        design_unit = Module("tb_module_not_ok", file_name=join(tempdir, "file.vhd"))
+        design_unit = Module(
+            "tb_module_not_ok", file_name=str(Path(tempdir) / "file.vhd")
+        )
         design_unit.generic_names = []
 
         with mock.patch("vunit.test.bench_list.LOGGER", autospec=True) as logger:
@@ -82,7 +88,7 @@ class TestTestBenchList(unittest.TestCase):
     @with_tempdir
     def test_tb_filter_warning_on_runner_cfg_but_not_matching_tb_pattern(self, tempdir):
         design_unit = Entity(
-            "entity_ok_but_warning", file_name=join(tempdir, "file.vhd")
+            "entity_ok_but_warning", file_name=str(Path(tempdir) / "file.vhd")
         )
         design_unit.generic_names = ["runner_cfg"]
 

--- a/tests/unit/test_test_report.py
+++ b/tests/unit/test_test_report.py
@@ -10,7 +10,7 @@ Test the test report functionality
 
 from unittest import TestCase
 import os
-from os.path import basename, dirname, join
+from pathlib import Path
 from xml.etree import ElementTree
 from vunit.test.report import TestReport, PASSED, SKIPPED, FAILED
 from vunit.ui.common import TEST_OUTPUT_PATH
@@ -26,7 +26,7 @@ class TestTestReport(TestCase):
         self.printer = StubPrinter()
 
         self.output_file_contents = 'Output file contents\n<xml>&13!--"<\\xml>'
-        self.output_file_name = join(dirname(__file__), "test_report_output.txt")
+        self.output_file_name = str(Path(__file__).parent / "test_report_output.txt")
         with open(self.output_file_name, "w") as fwrite:
             fwrite.write(self.output_file_contents)
 
@@ -277,15 +277,15 @@ Elapsed time was 3.0 seconds
         )
 
     def test_dict_report_with_all_passed_tests(self):
-        opath = dirname(dirname(self.output_file_name))
-        test_path = join(opath, TEST_OUTPUT_PATH, "unit")
-        output_file_name = join(test_path, basename(self.output_file_name))
+        opath = Path(self.output_file_name).parent.parent
+        test_path = opath / TEST_OUTPUT_PATH / "unit"
+        output_file_name = test_path / Path(self.output_file_name).name
         results = Results(
             opath, None, self._report_with_all_passed_tests(output_file_name)
         )
         report = results.get_report()
         for _, test in report.tests.items():
-            self.assertEqual(basename(test.path), test.relpath)
+            self.assertEqual(test.path.name, test.relpath)
         test0 = report.tests["passed_test0"]
         test1 = report.tests["passed_test1"]
         self.assertEqual(

--- a/tests/unit/test_test_runner.py
+++ b/tests/unit/test_test_runner.py
@@ -8,7 +8,7 @@
 Test the test runner
 """
 
-from os.path import join, abspath
+from pathlib import Path
 import unittest
 from unittest import mock
 from tests.common import with_tempdir
@@ -143,8 +143,9 @@ class TestTestRunner(unittest.TestCase):
                 test_output = create_output_path(output_path, test_name)
                 self.assertEqual(
                     test_output,
-                    join(
-                        abspath(output_path), test_name + "_" + hash_string(test_name)
+                    str(
+                        Path(output_path).resolve()
+                        / (test_name + "_" + hash_string(test_name))
                     ),
                 )
 
@@ -153,8 +154,9 @@ class TestTestRunner(unittest.TestCase):
                 test_output = create_output_path(output_path, test_name)
                 self.assertEqual(
                     test_output,
-                    join(
-                        abspath(output_path), test_name + "_" + hash_string(test_name)
+                    str(
+                        Path(output_path).resolve()
+                        / (test_name + "_" + hash_string(test_name))
                     ),
                 )
 
@@ -164,8 +166,9 @@ class TestTestRunner(unittest.TestCase):
                 test_output = create_output_path(output_path, test_name)
                 self.assertEqual(
                     test_output,
-                    join(
-                        abspath(output_path), safe_name + "_" + hash_string(test_name)
+                    str(
+                        Path(output_path).resolve()
+                        / (safe_name + "_" + hash_string(test_name))
                     ),
                 )
 
@@ -185,8 +188,9 @@ class TestTestRunner(unittest.TestCase):
                 test_output = create_output_path(output_path, test_name)
                 self.assertEqual(
                     test_output,
-                    join(
-                        abspath(output_path), test_name + "_" + hash_string(test_name)
+                    str(
+                        Path(output_path).resolve()
+                        / (test_name + "_" + hash_string(test_name))
                     ),
                 )
 
@@ -195,7 +199,8 @@ class TestTestRunner(unittest.TestCase):
                 test_name = "_" * 400
                 test_output = create_output_path(output_path, test_name)
                 self.assertEqual(
-                    test_output, join(abspath(output_path), hash_string(test_name))
+                    test_output,
+                    str(Path(output_path).resolve() / hash_string(test_name)),
                 )
 
     @staticmethod

--- a/tests/unit/test_test_suites.py
+++ b/tests/unit/test_test_suites.py
@@ -8,7 +8,7 @@
 Test the test suites
 """
 
-from os.path import join
+from pathlib import Path
 from unittest import TestCase
 from tests.common import create_tempdir
 from vunit.test.suites import TestRun
@@ -94,9 +94,9 @@ test_suite_done""",
         Helper method to test the read_test_results function
         """
         with create_tempdir() as path:
-            file_name = join(path, "vunit_results")
+            file_name = Path(path) / "vunit_results"
             if contents is not None:
-                with open(file_name, "w") as fptr:
+                with file_name.open("w") as fptr:
                     fptr.write(contents)
 
             run = TestRun(
@@ -162,9 +162,9 @@ test_suite_done""",
         Helper method to test the check_results function
         """
         with create_tempdir() as path:
-            file_name = join(path, "vunit_results")
+            file_name = Path(path) / "vunit_results"
             if contents is not None:
-                with open(file_name, "w") as fptr:
+                with file_name.open("w") as fptr:
                     fptr.write(contents)
 
             sim_if = SimulatorInterface

--- a/tests/unit/test_verilog_parser.py
+++ b/tests/unit/test_verilog_parser.py
@@ -10,7 +10,7 @@ Test of the Verilog parser
 
 from unittest import TestCase, mock
 import os
-from os.path import join, dirname, exists
+from pathlib import Path
 import time
 import shutil
 from vunit.ostools import renew_path
@@ -23,7 +23,7 @@ class TestVerilogParser(TestCase):  # pylint: disable=too-many-public-methods
     """
 
     def setUp(self):
-        self.output_path = join(dirname(__file__), "test_verilog_parser_out")
+        self.output_path = str(Path(__file__).parent / "test_verilog_parser_out")
         renew_path(self.output_path)
         self.cwd = os.getcwd()
         os.chdir(self.output_path)
@@ -327,10 +327,10 @@ endmodule;
 
     def test_cached_parsing_updated_by_higher_priority_file(self):
         cache = {}
-        include_paths = [self.output_path, join(self.output_path, "lower_prio")]
+        include_paths = [self.output_path, str(Path(self.output_path) / "lower_prio")]
 
         self.write_file(
-            join("lower_prio", "include.svh"),
+            str(Path("lower_prio") / "include.svh"),
             """
 module mod_lower_prio;
 endmodule;
@@ -381,11 +381,11 @@ endmodule;
         """
         Write file with contents into output path
         """
-        full_name = join(self.output_path, file_name)
-        full_path = dirname(full_name)
-        if not exists(full_path):
-            os.makedirs(full_path)
-        with open(full_name, "w") as fptr:
+        full_name = Path(self.output_path) / file_name
+        full_path = full_name.parent
+        if not full_path.exists():
+            os.makedirs(str(full_path))
+        with full_name.open("w") as fptr:
             fptr.write(contents)
 
     def parse(self, code, include_paths=None, cache=None, defines=None):

--- a/tests/unit/test_verilog_preprocessor.py
+++ b/tests/unit/test_verilog_preprocessor.py
@@ -12,7 +12,7 @@
 Test of the Verilog preprocessor
 """
 
-from os.path import join, dirname, exists
+from pathlib import Path
 import os
 from unittest import TestCase, mock
 import shutil
@@ -28,7 +28,7 @@ class TestVerilogPreprocessor(TestCase):
     """
 
     def setUp(self):
-        self.output_path = join(dirname(__file__), "test_verilog_preprocessor_out")
+        self.output_path = str(Path(__file__).parent / "test_verilog_preprocessor_out")
         renew_path(self.output_path)
         self.cwd = os.getcwd()
         os.chdir(self.output_path)
@@ -150,7 +150,7 @@ class TestVerilogPreprocessor(TestCase):
             '`include "include.svh"', include_paths=[self.output_path]
         )
         result.assert_has_tokens("hello hey")
-        result.assert_included_files([join(self.output_path, "include.svh")])
+        result.assert_included_files([str(Path(self.output_path) / "include.svh")])
 
     def test_detects_circular_includes(self):
         self.write_file("include1.svh", '`include "include2.svh"')
@@ -267,7 +267,7 @@ class TestVerilogPreprocessor(TestCase):
             include_paths=[self.output_path],
         )
         result.assert_has_tokens("hello hey")
-        result.assert_included_files([join(self.output_path, "include.svh")])
+        result.assert_included_files([str(Path(self.output_path) / "include.svh")])
 
     def test_preprocess_include_directive_from_define_with_args(self):
         self.write_file("include.svh", "hello hey")
@@ -278,7 +278,7 @@ class TestVerilogPreprocessor(TestCase):
             include_paths=[self.output_path],
         )
         result.assert_has_tokens("hello hey")
-        result.assert_included_files([join(self.output_path, "include.svh")])
+        result.assert_included_files([str(Path(self.output_path) / "include.svh")])
 
     def test_preprocess_macros_are_recursively_expanded(self):
         result = self.preprocess(
@@ -674,7 +674,7 @@ keep""",
             '\n\n`include "include.svh"', include_paths=[self.output_path]
         )
         result.assert_has_tokens("\n\n")
-        result.assert_included_files([join(self.output_path, "include.svh")])
+        result.assert_included_files([str(Path(self.output_path) / "include.svh")])
         result.logger.warning.assert_called_once_with(
             "Verilog `include bad argument\n%s",
             "from fn.v line 3:\n"
@@ -863,11 +863,11 @@ keep_end"""
         """
         Write file with contents into output path
         """
-        full_name = join(self.output_path, file_name)
-        full_path = dirname(full_name)
-        if not exists(full_path):
-            os.makedirs(full_path)
-        with open(full_name, "w") as fptr:
+        full_name = Path(self.output_path) / file_name
+        full_path = full_name.parent
+        if not full_path.exists():
+            os.makedirs(str(full_path))
+        with full_name.open("w") as fptr:
             fptr.write(contents)
 
 

--- a/tools/build_docs.py
+++ b/tools/build_docs.py
@@ -9,7 +9,7 @@ Command line utility to build documentation/website
 """
 
 from subprocess import check_call
-from os.path import join, dirname
+from pathlib import Path
 import sys
 from sys import argv
 from create_release_notes import create_release_notes
@@ -30,7 +30,7 @@ def main():
         ] + ([] if len(argv) < 2 else argv[2:]) + [
             "-TEWanb",
             "html",
-            join(dirname(__file__), "..", "docs"),
+            Path(__file__).parent.parent / "docs",
             argv[1],
         ]
     )

--- a/tools/create_release_notes.py
+++ b/tools/create_release_notes.py
@@ -8,21 +8,22 @@
 Create monolithic release notes file from several input files
 """
 
-from os.path import join, dirname, basename, splitext, relpath
+from pathlib import Path
+from os.path import relpath
 from glob import glob
 from subprocess import check_output, CalledProcessError
 from shutil import which
 import datetime
 
 
-def get_releases(source_path):
+def get_releases(source_path: Path):
     """
     Get all releases defined by release note files
     """
-    release_notes = join(source_path, "release_notes")
+    release_notes = source_path / "release_notes"
     releases = []
     for idx, file_name in enumerate(
-        sorted(glob(join(release_notes, "*.rst")), reverse=True)
+        sorted(glob(str(release_notes / "*.rst")), reverse=True)
     ):
         releases.append(Release(file_name, is_latest=idx == 0))
     return releases
@@ -32,7 +33,7 @@ def create_release_notes():
     """
     Create monolithic release notes file from several input files
     """
-    source_path = join(dirname(__file__), "..", "docs")
+    source_path = Path(__file__).parent.parent / "docs"
 
     releases = get_releases(source_path)
     latest_release = releases[0]
@@ -40,7 +41,7 @@ def create_release_notes():
     def banner(fptr):
         fptr.write("\n" + ("-" * 80) + "\n\n")
 
-    with open(join(source_path, "release_notes.rst"), "w") as fptr:
+    with (source_path / "release_notes.rst").open("w") as fptr:
         fptr.write(
             """
 .. _release_notes:
@@ -96,7 +97,7 @@ class Release(object):
 
     def __init__(self, file_name, is_latest):
         self.file_name = file_name
-        self.name = splitext(basename(file_name))[0]
+        self.name = str(Path(file_name).with_suffix("").name)
         self.tag = "v" + self.name
         self.is_latest = is_latest
 

--- a/tools/release.py
+++ b/tools/release.py
@@ -15,7 +15,7 @@ import argparse
 import json
 from urllib.request import urlopen  # pylint: disable=no-name-in-module, import-error
 import sys
-from os.path import dirname, join, exists
+from pathlib import Path
 import subprocess
 from shutil import which
 
@@ -67,8 +67,8 @@ def make_release_commit(version):
     """
     Add release notes and make the release commit
     """
-    run(["git", "add", release_note_file_name(version)])
-    run(["git", "add", ABOUT_PY])
+    run(["git", "add", str(release_note_file_name(version))])
+    run(["git", "add", str(ABOUT_PY)])
     run(["git", "commit", "-m", "Release %s" % version])
     run(["git", "tag", "v%s" % version, "-a", "-m", "release %s" % version])
 
@@ -77,7 +77,7 @@ def make_next_pre_release_commit(version):
     """
     Add release notes and make the release commit
     """
-    run(["git", "add", ABOUT_PY])
+    run(["git", "add", str(ABOUT_PY)])
     run(["git", "commit", "-m", "Start of next release candidate %s" % version])
 
 
@@ -87,18 +87,18 @@ def validate_new_release(version, pre_tag):
     """
 
     release_note = release_note_file_name(version)
-    if not exists(release_note):
+    if not release_note.exists():
         print(
             "Not releasing version %s since release note %s does not exist"
-            % (version, release_note)
+            % (version, str(release_note))
         )
         sys.exit(1)
 
-    with open(release_note, "r") as fptr:
+    with release_note.open("r") as fptr:
         if not fptr.read():
             print(
                 "Not releasing version %s since release note %s is empty"
-                % (version, release_note)
+                % (version, str(release_note))
             )
             sys.exit(1)
 
@@ -135,7 +135,7 @@ def set_version(version):
     Update vunit/about.py with correct version
     """
 
-    with open(ABOUT_PY, "r") as fptr:
+    with ABOUT_PY.open("r") as fptr:
         content = fptr.read()
 
     print("Set local version to %s" % version)
@@ -143,14 +143,14 @@ def set_version(version):
         'VERSION = "%s"' % get_local_version(), 'VERSION = "%s"' % version
     )
 
-    with open(ABOUT_PY, "w") as fptr:
+    with ABOUT_PY.open("w") as fptr:
         fptr.write(content)
 
     assert get_local_version() == version
 
 
-def release_note_file_name(version):
-    return join(REPO_ROOT, "docs", "release_notes", version + ".rst")
+def release_note_file_name(version) -> Path:
+    return REPO_ROOT / "docs" / "release_notes" / (version + ".rst")
 
 
 def get_local_version():
@@ -160,7 +160,7 @@ def get_local_version():
     """
     version = (
         subprocess.check_output(
-            [sys.executable, join(REPO_ROOT, "setup.py"), "--version"]
+            [sys.executable, str(REPO_ROOT / "setup.py"), "--version"]
         )
         .decode()
         .strip()
@@ -180,8 +180,8 @@ def run(cmd):
     subprocess.check_call(cmd)
 
 
-REPO_ROOT = join(dirname(__file__), "..")
-ABOUT_PY = join(REPO_ROOT, "vunit", "about.py")
+REPO_ROOT = Path(__file__).parent.parent
+ABOUT_PY = REPO_ROOT / "vunit" / "about.py"
 
 
 if __name__ == "__main__":

--- a/vunit/__init__.py
+++ b/vunit/__init__.py
@@ -8,14 +8,14 @@
 Public VUnit interface
 """
 
-from os.path import dirname, join, abspath
+from pathlib import Path
 import vunit.version_check
 from vunit.ui import VUnit
 from vunit.vunit_cli import VUnitCLI
 from vunit.about import version, doc
 
 # Repository root
-ROOT = abspath(join(dirname(__file__), ".."))
+ROOT = str(Path(__file__).parent.parent.resolve())
 
 __version__ = version()
 __doc__ = doc()  # pylint: disable=redefined-builtin

--- a/vunit/configuration.py
+++ b/vunit/configuration.py
@@ -10,7 +10,7 @@ Contains Configuration class which contains configuration of a test run
 
 import logging
 import inspect
-from os.path import dirname
+from pathlib import Path
 from copy import copy
 from vunit.sim_if.factory import SIMULATOR_FACTORY
 
@@ -46,7 +46,7 @@ class Configuration(object):  # pylint: disable=too-many-instance-attributes
         self.sim_options = {} if sim_options is None else sim_options
         self.attributes = {} if attributes is None else attributes
 
-        self.tb_path = dirname(design_unit.original_file_name)
+        self.tb_path = str(Path(design_unit.original_file_name).parent)
 
         # Fill in tb_path generic with location of test bench
         if "tb_path" in design_unit.generic_names:

--- a/vunit/csv_logs.py
+++ b/vunit/csv_logs.py
@@ -10,7 +10,7 @@ Provides csv log functionality
 
 from csv import Sniffer, DictReader, DictWriter
 from glob import glob
-from os.path import abspath
+from pathlib import Path
 
 
 class CsvLogs(object):
@@ -35,7 +35,7 @@ class CsvLogs(object):
 
     def add(self, pattern):
         # pylint: disable=missing-docstring
-        for csv_file in [abspath(p) for p in glob(pattern)]:
+        for csv_file in [str(Path(p).resolve()) for p in glob(pattern)]:
             with open(csv_file, "r") as fread:
                 sample = fread.readline()
                 fread.seek(0)

--- a/vunit/database.py
+++ b/vunit/database.py
@@ -8,7 +8,7 @@
 A simple file based database
 """
 
-from os.path import join, exists
+from pathlib import Path
 import os
 import pickle
 import io
@@ -39,7 +39,7 @@ class DataBase(object):
 
         if new:
             renew_path(path)
-        elif not exists(path):
+        elif not Path(path).exists():
             os.makedirs(path)
 
         # Map keys to nodes indexes
@@ -55,7 +55,7 @@ class DataBase(object):
         """
         keys_to_nodes = {}
         for file_base_name in os.listdir(self._path):
-            key = self._read_key(join(self._path, file_base_name))
+            key = self._read_key(str(Path(self._path) / file_base_name))
             assert key not in keys_to_nodes  # Two nodes contains the same key
             keys_to_nodes[key] = int(file_base_name)
         return keys_to_nodes
@@ -100,7 +100,7 @@ class DataBase(object):
         """
         Convert key to file name
         """
-        return join(self._path, str(self._keys_to_nodes[key]))
+        return str(Path(self._path) / str(self._keys_to_nodes[key]))
 
     def _allocate_node_for_key(self, key):
         """

--- a/vunit/ostools.py
+++ b/vunit/ostools.py
@@ -15,8 +15,10 @@ import subprocess
 import threading
 import shutil
 from queue import Queue, Empty
-from os.path import exists, getmtime, dirname, relpath, splitdrive
+from pathlib import Path
+from os.path import getmtime, relpath, splitdrive
 import os
+from os import getcwd, makedirs
 import io
 
 import logging
@@ -296,12 +298,12 @@ def read_file(file_name, encoding="utf-8", newline=None):
 def write_file(file_name, contents, encoding="utf-8"):
     """ To stub during testing """
 
-    path = dirname(file_name)
+    path = str(Path(file_name).parent)
     if path == "":
         path = "."
 
     if not file_exists(path):
-        os.makedirs(path)
+        makedirs(path)
 
     with io.open(file_name, "wb") as file_to_write:
         file_to_write.write(contents.encode(encoding=encoding))
@@ -309,7 +311,7 @@ def write_file(file_name, contents, encoding="utf-8"):
 
 def file_exists(file_name):
     """ To stub during testing """
-    return exists(file_name)
+    return Path(file_name).exists()
 
 
 def get_modification_time(file_name):
@@ -334,14 +336,14 @@ def renew_path(path):
     """
     if IS_WINDOWS_SYSTEM:
         retries = 10
-        while retries > 0 and exists(path):
+        while retries > 0 and Path(path).exists():
             shutil.rmtree(path, ignore_errors=retries > 1)
             time.sleep(0.01)
             retries -= 1
     else:
-        if exists(path):
+        if Path(path).exists():
             shutil.rmtree(path)
-    os.makedirs(path)
+    makedirs(path)
 
 
 def simplify_path(path):
@@ -349,7 +351,7 @@ def simplify_path(path):
     Return relative path towards current working directory
     unless it is a separate Windows drive
     """
-    cwd = os.getcwd()
+    cwd = getcwd()
     drive_cwd = splitdrive(cwd)[0]
     drive_path = splitdrive(path)[0]
     if drive_path == drive_cwd:

--- a/vunit/parsing/verilog/parser.py
+++ b/vunit/parsing/verilog/parser.py
@@ -12,7 +12,7 @@ Verilog parsing functionality
 """
 
 import logging
-from os.path import dirname, exists, abspath
+from pathlib import Path
 from vunit.ostools import read_file
 from vunit.parsing.encodings import HDL_FILE_ENCODING
 from vunit.parsing.tokenizer import TokenStream, EOFException, LocationException
@@ -63,7 +63,7 @@ class VerilogParser(object):
 
         defines = {} if defines is None else defines
         include_paths = [] if include_paths is None else include_paths
-        include_paths = [dirname(file_name)] + include_paths
+        include_paths = [str(Path(file_name).parent)] + include_paths
 
         cached = self._lookup_parse_cache(file_name, include_paths, defines)
         if cached is not None:
@@ -99,7 +99,7 @@ class VerilogParser(object):
         """
         Returns the database key for parse results of file_name
         """
-        return ("CachedVerilogParser.parse(%s)" % abspath(file_name)).encode()
+        return ("CachedVerilogParser.parse(%s)" % str(Path(file_name).resolve)).encode()
 
     def _store_result(self, file_name, result, included_files, defines):
         """
@@ -124,7 +124,7 @@ class VerilogParser(object):
         """
         Hash the contents of the file
         """
-        if file_name is None or not exists(file_name):
+        if file_name is None or not Path(file_name).exists():
             return None
         if file_name not in self._content_cache:
             self._content_cache[file_name] = file_content_hash(

--- a/vunit/parsing/verilog/preprocess.py
+++ b/vunit/parsing/verilog/preprocess.py
@@ -10,7 +10,7 @@
 """
 Verilog parsing functionality
 """
-from os.path import join, exists, abspath
+from pathlib import Path
 import logging
 from vunit.parsing.tokenizer import (
     TokenStream,
@@ -350,8 +350,8 @@ def find_included_file(include_paths, file_name):
     Find the file to include given include_paths
     """
     for include_path in include_paths:
-        full_name = abspath(join(include_path, file_name))
-        if exists(full_name):
+        full_name = str((Path(include_path) / file_name).resolve())
+        if Path(full_name).exists():
             return full_name
     return None
 

--- a/vunit/project.py
+++ b/vunit/project.py
@@ -9,10 +9,9 @@
 """
 Functionality to represent and operate on a HDL code project
 """
-from os.path import join, basename, dirname, isdir, exists
+from typing import Optional
 from pathlib import Path
 import logging
-from typing import Optional
 from collections import OrderedDict
 from vunit.hashing import hash_string
 from vunit.dependency_graph import DependencyGraph, CircularDependencyException
@@ -610,9 +609,12 @@ class Project(object):  # pylint: disable=too-many-instance-attributes
         Returns the name of the hash file associated with the source_file
         """
         library = self.get_library(source_file.library.name)
-        prefix = hash_string(dirname(source_file.name))
-        return join(
-            library.directory, prefix, basename(source_file.name) + ".vunit_hash"
+        prefix = hash_string(str(Path(source_file.name).parent))
+        return str(
+            Path(library.directory)
+            / prefix
+            / Path(source_file.name).name
+            / ".vunit_hash"
         )
 
     def update(self, source_file):

--- a/vunit/project.py
+++ b/vunit/project.py
@@ -9,7 +9,7 @@
 """
 Functionality to represent and operate on a HDL code project
 """
-from typing import Optional
+from typing import Optional, Union
 from pathlib import Path
 import logging
 from collections import OrderedDict
@@ -83,7 +83,7 @@ class Project(object):  # pylint: disable=too-many-instance-attributes
     def add_library(
         self,
         logical_name,
-        directory,
+        directory: Union[str, Path],
         vhdl_standard: VHDLStandard = VHDL.STD_2008,
         is_external=False,
     ):
@@ -93,19 +93,18 @@ class Project(object):  # pylint: disable=too-many-instance-attributes
         """
         self._validate_new_library_name(logical_name)
 
+        dpath = Path(directory)
+        dstr = str(directory)
+
         if is_external:
-            if not exists(directory):
-                raise ValueError("External library %r does not exist" % directory)
+            if not dpath.exists():
+                raise ValueError("External library %r does not exist" % dstr)
 
-            if not isdir(directory):
-                raise ValueError(
-                    "External library must be a directory. Got %r" % directory
-                )
+            if not dpath.is_dir():
+                raise ValueError("External library must be a directory. Got %r" % dstr)
 
-        library = Library(
-            logical_name, directory, vhdl_standard, is_external=is_external
-        )
-        LOGGER.debug("Adding library %s with path %s", logical_name, directory)
+        library = Library(logical_name, dstr, vhdl_standard, is_external=is_external)
+        LOGGER.debug("Adding library %s with path %s", logical_name, dstr)
 
         self._libraries[logical_name] = library
         self._lower_library_names_dict[logical_name.lower()] = library.name

--- a/vunit/sim_if/ghdl.py
+++ b/vunit/sim_if/ghdl.py
@@ -303,7 +303,7 @@ class GHDLInterface(SimulatorInterface):
                 cmd += ["--no-run"]
         else:
             try:
-                os.makedirs(output_path, mode=0o777)
+                makedirs(output_path, mode=0o777)
             except OSError:
                 pass
             with (Path(output_path) / "args.json").open("w") as fname:
@@ -337,7 +337,7 @@ class GHDLInterface(SimulatorInterface):
 
         if self._gtkwave_fmt is not None:
             data_file_name = str(Path(script_path) / ("wave.%s" % self._gtkwave_fmt))
-            if  Path(data_file_name).exists():
+            if Path(data_file_name).exists():
                 remove(data_file_name)
         else:
             data_file_name = None

--- a/vunit/source_file.py
+++ b/vunit/source_file.py
@@ -9,7 +9,6 @@ Functionality to represent and operate on VHDL and Verilog source files
 """
 from pathlib import Path
 from typing import Union
-from os.path import splitext
 import logging
 from copy import copy
 import traceback
@@ -369,7 +368,7 @@ def file_type_of(file_name):
     """
     Return the file type of file_name based on the file ending
     """
-    _, ext = splitext(file_name)
+    ext = str(Path(file_name).suffix)
     if ext.lower() in VHDL_EXTENSIONS:
         return "vhdl"
 

--- a/vunit/test/bench.py
+++ b/vunit/test/bench.py
@@ -9,7 +9,7 @@ Contains classes to represent a test bench and test cases
 """
 
 import logging
-from os.path import basename
+from pathlib import Path
 import re
 import bisect
 import collections
@@ -98,7 +98,7 @@ class TestBench(ConfigurationVisitor):
                     % (
                         design_unit.name,
                         ", ".join(
-                            "%s:%s" % (name, basename(fname))
+                            "%s:%s" % (name, str(Path(fname).name))
                             for name, fname in sorted(
                                 design_unit.architecture_names.items()
                             )

--- a/vunit/test/report.py
+++ b/vunit/test/report.py
@@ -13,7 +13,7 @@ from xml.etree import ElementTree
 import os
 import socket
 import re
-from os.path import dirname
+from pathlib import Path
 from vunit.color_printer import COLOR_PRINTER
 from vunit.ostools import read_file
 
@@ -325,5 +325,5 @@ class TestResult(object):
         return {
             "status": self._status.name,
             "time": self.time,
-            "path": dirname(self._output_file_name),
+            "path": str(Path(self._output_file_name).parent),
         }

--- a/vunit/test/suites.py
+++ b/vunit/test/suites.py
@@ -8,7 +8,7 @@
 Contains different kinds of test suites
 """
 
-from os.path import join
+from pathlib import Path
 from .. import ostools
 from .report import PASSED, SKIPPED, FAILED
 
@@ -345,4 +345,4 @@ def _full_name(test_suite_name, test_case_name):
 
 
 def get_result_file_name(output_path):
-    return join(output_path, "vunit_results")
+    return str(Path(output_path) / "vunit_results")

--- a/vunit/ui/packagefacade.py
+++ b/vunit/ui/packagefacade.py
@@ -8,7 +8,7 @@
 UI class PackageFacade
 """
 
-from os.path import join, splitext
+from pathlib import Path
 from ..com import codec_generator
 
 
@@ -33,9 +33,9 @@ class PackageFacade(object):
             codec_package_name = self._package_name + "_codecs"
 
         if output_file_name is None:
-            codecs_path = join(self._parent.codecs_path, self._library_name)
-            file_extension = splitext(self._design_unit.source_file.name)[1]
-            output_file_name = join(codecs_path, codec_package_name + file_extension)
+            codecs_path = Path(self._parent.codecs_path) / self._library_name
+            file_extension = Path(self._design_unit.source_file.name).suffix
+            output_file_name = codecs_path / (codec_package_name + file_extension)
 
         codec_generator.generate_codecs(
             self._design_unit, codec_package_name, used_packages, output_file_name

--- a/vunit/ui/results.py
+++ b/vunit/ui/results.py
@@ -8,7 +8,8 @@
 UI class Results
 """
 
-from os.path import join, basename, normpath
+from pathlib import Path
+from typing import Dict, Union
 from .common import TEST_OUTPUT_PATH
 
 
@@ -45,7 +46,7 @@ class Results(object):
             report.tests.update(
                 {
                     test.name: TestResult(
-                        join(self._output_path, TEST_OUTPUT_PATH),
+                        Path(self._output_path) / TEST_OUTPUT_PATH,
                         obj["status"],
                         obj["time"],
                         obj["path"],
@@ -63,9 +64,9 @@ class Report(object):
     :data tests: Dictionary of :class:`TestResult` objects
     """
 
-    def __init__(self, output_path):
-        self.output_path = output_path
-        self.tests = {}
+    def __init__(self, output_path: Union[str, Path]):
+        self.output_path = Path(output_path)
+        self.tests: Dict[str, TestResult] = {}
 
 
 class TestResult(object):
@@ -93,20 +94,22 @@ class TestResult(object):
        vu.main(post_run=post_func)
     """
 
-    def __init__(self, test_output_path, status, time, path):
-        self._test_output_path = test_output_path
+    def __init__(
+        self, test_output_path: Union[str, Path], status, time, path: Union[str, Path]
+    ):
+        self._test_output_path = Path(test_output_path)
         self.status = status
         self.time = time
-        self.path = path
+        self.path = Path(path)
 
     @property
-    def relpath(self):
+    def relpath(self) -> str:
         """
         If the path is a subdir to the default TEST_OUTPUT_PATH, return the subdir only
         """
-        base = basename(self.path)
-        return (
+        base = self.path.name
+        return str(
             base
-            if normpath(join(self._test_output_path, base)) == normpath(self.path)
+            if (self._test_output_path / base).resolve() == self.path.resolve()
             else self.path
         )

--- a/vunit/vhdl/check/tools/generate_check_equal.py
+++ b/vunit/vhdl/check/tools/generate_check_equal.py
@@ -4,7 +4,7 @@
 #
 # Copyright (c) 2014-2020, Lars Asplund lars.anders.asplund@gmail.com
 
-from os.path import join, dirname
+from pathlib import Path
 from string import Template
 
 api_template = """  procedure check_equal(
@@ -767,14 +767,14 @@ def replace_region(region_name, file_name, new_contents):
 
 
 def main():
-    check_api_file_name = join(dirname(__file__), "..", "src", "check_api.vhd")
+    check_api_file_name = str(Path(__file__).parent.parent / "src" / "check_api.vhd")
     replace_region("check_equal", check_api_file_name, generate_api())
 
-    check_file_name = join(dirname(__file__), "..", "src", "check.vhd")
+    check_file_name = str(Path(__file__).parent.parent / "src" / "check.vhd")
     replace_region("check_equal", check_file_name, generate_impl())
 
-    with open(
-        join(dirname(__file__), "..", "test", "tb_check_equal.vhd"), "wb"
+    with (Path(__file__).parent.parent / "test" / "tb_check_equal.vhd").open(
+        "wb"
     ) as fptr:
         fptr.write(generate_test().encode())
 

--- a/vunit/vhdl/check/tools/generate_check_match.py
+++ b/vunit/vhdl/check/tools/generate_check_match.py
@@ -4,7 +4,7 @@
 #
 # Copyright (c) 2014-2020, Lars Asplund lars.anders.asplund@gmail.com
 
-from os.path import join, dirname
+from pathlib import Path
 from string import Template
 from generate_check_equal import replace_region
 
@@ -448,14 +448,14 @@ end test_fixture;
 
 
 def main():
-    check_api_file_name = join(dirname(__file__), "..", "src", "check_api.vhd")
+    check_api_file_name = str(Path(__file__).parent.parent / "src" / "check_api.vhd")
     replace_region("check_match", check_api_file_name, generate_api())
 
-    check_file_name = join(dirname(__file__), "..", "src", "check.vhd")
+    check_file_name = str(Path(__file__).parent.parent / "src" / "check.vhd")
     replace_region("check_match", check_file_name, generate_impl())
 
-    with open(
-        join(dirname(__file__), "..", "test", "tb_check_match.vhd"), "wb"
+    with (Path(__file__).parent.parent / "test" / "tb_check_match.vhd").open(
+        "wb"
     ) as fptr:
         fptr.write(generate_test().encode())
 

--- a/vunit/vhdl/com/run.py
+++ b/vunit/vhdl/com/run.py
@@ -4,17 +4,16 @@
 #
 # Copyright (c) 2014-2020, Lars Asplund lars.anders.asplund@gmail.com
 
-from os.path import join, dirname
+from pathlib import Path
 from vunit import VUnit
 
-root = dirname(__file__)
+ROOT = Path(__file__).parent
 
-prj = VUnit.from_argv()
-prj.add_com()
-tb_com_lib = prj.add_library("tb_com_lib")
-tb_com_lib.add_source_files(join(root, "test", "*.vhd"))
-pkg = tb_com_lib.package("custom_types_pkg")
-pkg.generate_codecs(
+UI = VUnit.from_argv()
+UI.add_com()
+TB_COM_LIB = UI.add_library("tb_com_lib")
+TB_COM_LIB.add_source_files(ROOT / "test" / "*.vhd")
+TB_COM_LIB.package("custom_types_pkg").generate_codecs(
     codec_package_name="custom_codec_pkg",
     used_packages=[
         "ieee.std_logic_1164",
@@ -22,4 +21,5 @@ pkg.generate_codecs(
         "tb_com_lib.more_constants_pkg",
     ],
 )
-prj.main()
+
+UI.main()

--- a/vunit/vhdl/dictionary/run.py
+++ b/vunit/vhdl/dictionary/run.py
@@ -4,12 +4,12 @@
 #
 # Copyright (c) 2014-2020, Lars Asplund lars.anders.asplund@gmail.com
 
-from os.path import join, dirname
+from pathlib import Path
 from vunit import VUnit
 
-root = dirname(__file__)
+ROOT = Path(__file__).parent
 
-ui = VUnit.from_argv()
-lib = ui.add_library("lib")
-lib.add_source_files(join(root, "test", "*.vhd"))
-ui.main()
+UI = VUnit.from_argv()
+UI.add_library("lib").add_source_files(ROOT / "test" / "*.vhd")
+
+UI.main()

--- a/vunit/vhdl/logging/run.py
+++ b/vunit/vhdl/logging/run.py
@@ -4,11 +4,12 @@
 #
 # Copyright (c) 2014-2020, Lars Asplund lars.anders.asplund@gmail.com
 
-from os.path import join, dirname
+from pathlib import Path
 from vunit import VUnit
 
-root = dirname(__file__)
-ui = VUnit.from_argv()
-lib = ui.library("vunit_lib")
-lib.add_source_files(join(root, "test", "*.vhd"))
-ui.main()
+ROOT = Path(__file__).parent
+
+UI = VUnit.from_argv()
+UI.library("vunit_lib").add_source_files(ROOT / "test" / "*.vhd")
+
+UI.main()

--- a/vunit/vhdl/path/run.py
+++ b/vunit/vhdl/path/run.py
@@ -4,11 +4,12 @@
 #
 # Copyright (c) 2014-2020, Lars Asplund lars.anders.asplund@gmail.com
 
-from os.path import join, dirname
+from pathlib import Path
 from vunit import VUnit
 
-root = dirname(__file__)
-ui = VUnit.from_argv()
-lib = ui.add_library("lib")
-lib.add_source_files(join(root, "test", "*.vhd"))
-ui.main()
+ROOT = Path(__file__).parent
+
+UI = VUnit.from_argv()
+UI.add_library("lib").add_source_files(ROOT / "test" / "*.vhd")
+
+UI.main()

--- a/vunit/vhdl/random/run.py
+++ b/vunit/vhdl/random/run.py
@@ -4,13 +4,13 @@
 #
 # Copyright (c) 2014-2020, Lars Asplund lars.anders.asplund@gmail.com
 
-from os.path import join, dirname
+from pathlib import Path
 from vunit import VUnit
 
-root = dirname(__file__)
+ROOT = Path(__file__).parent
 
-ui = VUnit.from_argv()
-ui.add_random()
-lib = ui.library("vunit_lib")
-lib.add_source_files(join(root, "test", "*.vhd"))
-ui.main()
+UI = VUnit.from_argv()
+UI.add_random()
+UI.library("vunit_lib").add_source_files(ROOT / "test" / "*.vhd")
+
+UI.main()

--- a/vunit/vhdl/run/run.py
+++ b/vunit/vhdl/run/run.py
@@ -4,12 +4,12 @@
 #
 # Copyright (c) 2014-2020, Lars Asplund lars.anders.asplund@gmail.com
 
-from os.path import join, dirname
+from pathlib import Path
 from vunit import VUnit
 
-root = dirname(__file__)
-ui = VUnit.from_argv()
+ROOT = Path(__file__).parent
 
-lib = ui.add_library("tb_run_lib")
-lib.add_source_files(join(root, "test", "*.vhd"))
-ui.main()
+UI = VUnit.from_argv()
+UI.add_library("tb_run_lib").add_source_files(ROOT / "test" / "*.vhd")
+
+UI.main()

--- a/vunit/vhdl/string_ops/run.py
+++ b/vunit/vhdl/string_ops/run.py
@@ -4,14 +4,12 @@
 #
 # Copyright (c) 2014-2020, Lars Asplund lars.anders.asplund@gmail.com
 
-from os.path import join, dirname
+from pathlib import Path
 from vunit import VUnit
 
-root = dirname(__file__)
-common_path = join(root, "..", "common", "test")
+ROOT = Path(__file__).parent
 
-ui = VUnit.from_argv()
-lib = ui.add_library("lib")
-lib.add_source_files(join(root, "test", "*.vhd"))
+UI = VUnit.from_argv()
+UI.add_library("lib").add_source_files(ROOT / "test" / "*.vhd")
 
-ui.main()
+UI.main()

--- a/vunit/vhdl/verification_components/run.py
+++ b/vunit/vhdl/verification_components/run.py
@@ -4,17 +4,17 @@
 #
 # Copyright (c) 2014-2020, Lars Asplund lars.anders.asplund@gmail.com
 
-from os.path import join, dirname
+from pathlib import Path
 from itertools import product
 from vunit import VUnit
 
-root = dirname(__file__)
+ROOT = Path(__file__).parent
 
-ui = VUnit.from_argv()
-ui.add_random()
-ui.add_verification_components()
-lib = ui.library("vunit_lib")
-lib.add_source_files(join(root, "test", "*.vhd"))
+UI = VUnit.from_argv()
+UI.add_random()
+UI.add_verification_components()
+LIB = UI.library("vunit_lib")
+LIB.add_source_files(ROOT / "test" / "*.vhd")
 
 
 def encode(tb_cfg):
@@ -67,12 +67,12 @@ def gen_avalon_master_tests(obj, *args):
         obj.add_config(name=config_name, generics=dict(encoded_tb_cfg=encode(tb_cfg)))
 
 
-tb_avalon_slave = lib.test_bench("tb_avalon_slave")
+tb_avalon_slave = LIB.test_bench("tb_avalon_slave")
 
 for test in tb_avalon_slave.get_tests():
     gen_avalon_tests(test, [32], [1, 2, 64], [1.0, 0.3], [0.0, 0.4])
 
-tb_avalon_master = lib.test_bench("tb_avalon_master")
+tb_avalon_master = LIB.test_bench("tb_avalon_master")
 
 for test in tb_avalon_master.get_tests():
     if test.name == "wr single rd single":
@@ -82,19 +82,19 @@ for test in tb_avalon_master.get_tests():
             test, [64], [1.0, 0.3], [0.0, 0.7], [1.0, 0.3], [1.0, 0.3]
         )
 
-TB_WISHBONE_SLAVE = lib.test_bench("tb_wishbone_slave")
+TB_WISHBONE_SLAVE = LIB.test_bench("tb_wishbone_slave")
 
 for test in TB_WISHBONE_SLAVE.get_tests():
     #  TODO strobe_prob not implemented in slave tb
     gen_wb_tests(test, [8, 32], [1, 64], [1.0], [0.3, 1.0], [0.4, 0.0])
 
 
-TB_WISHBONE_MASTER = lib.test_bench("tb_wishbone_master")
+TB_WISHBONE_MASTER = LIB.test_bench("tb_wishbone_master")
 
 for test in TB_WISHBONE_MASTER.get_tests():
     gen_wb_tests(test, [8, 32], [1, 64], [0.3, 1.0], [0.3, 1.0], [0.4, 0.0])
 
-TB_AXI_STREAM = lib.test_bench("tb_axi_stream")
+TB_AXI_STREAM = LIB.test_bench("tb_axi_stream")
 
 for id_length in [0, 8]:
     for dest_length in [0, 8]:
@@ -110,7 +110,7 @@ for id_length in [0, 8]:
                     ),
                 )
 
-TB_AXI_STREAM_PROTOCOL_CHECKER = lib.test_bench("tb_axi_stream_protocol_checker")
+TB_AXI_STREAM_PROTOCOL_CHECKER = LIB.test_bench("tb_axi_stream_protocol_checker")
 
 for data_length in [0, 8]:
     for test in TB_AXI_STREAM_PROTOCOL_CHECKER.get_tests("*passing*tdata*"):
@@ -140,4 +140,4 @@ TB_AXI_STREAM.test("test random stall on slave").add_config(
     name="stall_slave", generics=dict(g_stall_percentage_slave=30)
 )
 
-ui.main()
+UI.main()

--- a/vunit/vhdl_parser.py
+++ b/vunit/vhdl_parser.py
@@ -11,7 +11,7 @@ VHDL parsing functionality
 """
 
 import re
-from os.path import abspath
+from pathlib import Path
 import logging
 from vunit.cached import cached
 from vunit.parsing.encodings import HDL_FILE_ENCODING
@@ -32,7 +32,7 @@ class VHDLParser(object):
         Parse the VHDL code and return a VHDLDesignFile parse result
         parse result is re-used if content hash found in database
         """
-        file_name = abspath(file_name)
+        file_name = str(Path(file_name).resolve())
         return cached(
             "CachedVHDLParser.parse",
             VHDLDesignFile.parse,

--- a/vunit/vunit_cli.py
+++ b/vunit/vunit_cli.py
@@ -39,7 +39,7 @@ A :class:`.VUnitCLI` object has a ``parser`` field which is an
 """
 
 import argparse
-from os.path import join, abspath
+from pathlib import Path
 import os
 from vunit.sim_if.factory import SIMULATOR_FACTORY
 from vunit.about import version
@@ -80,7 +80,7 @@ def _create_argument_parser(description=None, for_documentation=False):
     if for_documentation:
         default_output_path = "./vunit_out"
     else:
-        default_output_path = join(abspath(os.getcwd()), "vunit_out")
+        default_output_path = str(Path(os.getcwd()).resolve() / "vunit_out")
 
     parser = argparse.ArgumentParser(description=description)
 


### PR DESCRIPTION
In this PR, all usages of `abspath`, `basename`, `dirname`, `exists`, `isdir`, `join`, `isfile`, `splittext`... from `os.path` are replaced with `Path` from `pathlib`. A few resources from `os.path` are kept (`getmtime`, `relpath`, `splitdrive`, `commonprefix`).

The modifications in this PR should NOT introduce any breaking change, as I tried to keep internal data types (strings).

In the second commit, some type annotations are added to `vunit/ui/__init__.py`.

Actually, this PR is a cleaning phase before properly using `Path` internally. Future work should consist on evaluating when explicit conversions to `str` can be avoided. I believe this should be done together with adding type annotations, as it allows to better catch inconsistencies.