### PR TITLE
add code coverage support for ghdl

### DIFF
--- a/docs/py/opts.rst
+++ b/docs/py/opts.rst
@@ -46,6 +46,11 @@ The following compilation options are known.
    Extra arguments passed to Active HDL ``vcom`` command.
    Must be a list of strings.
 
+``enable_coverage``
+   Enables compilation flags needed for code coverage and tells VUnit to handle
+   the coverage files created at compilation. Only used for coverage with GHDL.
+   Must be a boolean value. Default is False.
+
 .. note::
    Only affects source files added *before* the option is set.
 
@@ -73,17 +78,22 @@ The following simulation options are known.
   Must be a boolean value. Default is False.
 
   When coverage is enabled VUnit only takes the minimal steps required
-  to make the simulator creates an unique coverage file for the
-  simulation run. The VUnit users must still set :ref:`sim
+  to make the simulator create a unique coverage file for the
+  simulation run.
+
+  For RiverieraPRO and Modelsim/Questa, the VUnit users must still set :ref:`sim
   <sim_options>` and :ref:`compile <compile_options>` options to
   configure the simulator specific coverage options they want. The
   reason for this to allow the VUnit users maximum control of their
   coverage settings.
 
+  For GHDL with GCC backend there is less configurability for coverage, and all
+  necessary flags are set by the the ``enable_coverage`` sim and compile options.
+
   An example of a ``run.py`` file using coverage can be found
   :vunit_example:`here <vhdl/coverage>`.
 
-  .. note: Supported by RivieraPRO and Modelsim/Questa simulators.
+  .. note: Supported by GHDL with GCC backend, RivieraPRO and Modelsim/Questa simulators.
 
 
 ``pli``

--- a/examples/vhdl/coverage/run.py
+++ b/examples/vhdl/coverage/run.py
@@ -26,9 +26,6 @@ LIB.set_compile_option("rivierapro.vcom_flags", ["-coverage", "bs"])
 LIB.set_compile_option("rivierapro.vlog_flags", ["-coverage", "bs"])
 LIB.set_compile_option("modelsim.vcom_flags", ["+cover=bs"])
 LIB.set_compile_option("modelsim.vlog_flags", ["+cover=bs"])
-LIB.set_compile_option(
-    "ghdl.a_flags", ["-fprofile-arcs", "-ftest-coverage"]
-)
-LIB.set_sim_option("ghdl.elab_flags", ["-Wl,-lgcov"])
+LIB.set_compile_option("enable_coverage", True)
 
 VU.main(post_run=post_run)

--- a/examples/vhdl/coverage/run.py
+++ b/examples/vhdl/coverage/run.py
@@ -6,10 +6,13 @@
 
 from pathlib import Path
 from vunit import VUnit
+from subprocess import call
 
 
 def post_run(results):
     results.merge_coverage(file_name="coverage_data")
+    if VU.get_simulator_name() == "ghdl":
+        call(["gcovr", "coverage_data"])
 
 
 VU = VUnit.from_argv()
@@ -17,10 +20,15 @@ VU = VUnit.from_argv()
 LIB = VU.add_library("lib")
 LIB.add_source_files(Path(__file__).parent / "*.vhd")
 
+LIB.set_sim_option("enable_coverage", True)
+
 LIB.set_compile_option("rivierapro.vcom_flags", ["-coverage", "bs"])
 LIB.set_compile_option("rivierapro.vlog_flags", ["-coverage", "bs"])
 LIB.set_compile_option("modelsim.vcom_flags", ["+cover=bs"])
 LIB.set_compile_option("modelsim.vlog_flags", ["+cover=bs"])
-LIB.set_sim_option("enable_coverage", True)
+LIB.set_compile_option(
+    "ghdl.a_flags", ["-g", "-O2", "-fprofile-arcs", "-ftest-coverage"]
+)
+LIB.set_sim_option("ghdl.elab_flags", ["-Wl,-lgcov"])
 
 VU.main(post_run=post_run)

--- a/examples/vhdl/coverage/run.py
+++ b/examples/vhdl/coverage/run.py
@@ -27,7 +27,7 @@ LIB.set_compile_option("rivierapro.vlog_flags", ["-coverage", "bs"])
 LIB.set_compile_option("modelsim.vcom_flags", ["+cover=bs"])
 LIB.set_compile_option("modelsim.vlog_flags", ["+cover=bs"])
 LIB.set_compile_option(
-    "ghdl.a_flags", ["-g", "-O2", "-fprofile-arcs", "-ftest-coverage"]
+    "ghdl.a_flags", ["-fprofile-arcs", "-ftest-coverage"]
 )
 LIB.set_sim_option("ghdl.elab_flags", ["-Wl,-lgcov"])
 

--- a/tests/acceptance/test_external_run_scripts.py
+++ b/tests/acceptance/test_external_run_scripts.py
@@ -121,6 +121,13 @@ class TestExternalRunScripts(unittest.TestCase):
     def test_vhdl_check_example_project(self):
         self.check(ROOT / "examples" / "vhdl" / "check" / "run.py")
 
+    @unittest.skipIf(
+        simulator_check(lambda simclass: not simclass.supports_coverage()),
+        "This simulator/backend does not support coverage",
+    )
+    def test_vhdl_coverage_example_project(self):
+        self.check(join(ROOT, "examples", "vhdl", "coverage", "run.py"))
+
     def test_vhdl_generate_tests_example_project(self):
         self.check(ROOT / "examples" / "vhdl" / "generate_tests" / "run.py")
         check_report(

--- a/vunit/sim_if/__init__.py
+++ b/vunit/sim_if/__init__.py
@@ -223,7 +223,7 @@ class SimulatorInterface(object):  # pylint: disable=too-many-public-methods
         Implemented by specific simulators
         """
 
-    def __compile_source_file(self, source_file, printer):
+    def _compile_source_file(self, source_file, printer):
         """
         Compiles a single source file and prints status information
         """
@@ -304,7 +304,7 @@ class SimulatorInterface(object):  # pylint: disable=too-many-public-methods
                 printer.write("\n")
                 continue
 
-            if self.__compile_source_file(source_file, printer):
+            if self._compile_source_file(source_file, printer):
                 project.update(source_file)
             else:
                 source_files_to_skip.update(

--- a/vunit/sim_if/__init__.py
+++ b/vunit/sim_if/__init__.py
@@ -172,7 +172,14 @@ class SimulatorInterface(object):  # pylint: disable=too-many-public-methods
     @staticmethod
     def supports_vhpi():
         """
-        Return if the simulator supports VHPI
+        Returns True when the simulator supports VHPI
+        """
+        return False
+
+    @staticmethod
+    def supports_coverage():
+        """
+        Returns True when the simulator supports coverage
         """
         return False
 

--- a/vunit/sim_if/activehdl.py
+++ b/vunit/sim_if/activehdl.py
@@ -68,6 +68,13 @@ class ActiveHDLInterface(SimulatorInterface):
 
         return False
 
+    @staticmethod
+    def supports_coverage():
+        """
+        Returns True when the simulator supports coverage
+        """
+        return True
+
     def __init__(self, prefix, output_path, gui=False):
         SimulatorInterface.__init__(self, output_path, gui)
         self._library_cfg = str(Path(output_path) / "library.cfg")

--- a/vunit/sim_if/factory.py
+++ b/vunit/sim_if/factory.py
@@ -39,7 +39,7 @@ class SimulatorFactory(object):
         """
         Return all supported compile options
         """
-        result = dict()
+        result = dict((opt.name, opt) for opt in [BooleanOption("enable_coverage"),])
         for sim_class in self.supported_simulators():
             for opt in sim_class.compile_options:
                 assert hasattr(opt, "name")

--- a/vunit/sim_if/factory.py
+++ b/vunit/sim_if/factory.py
@@ -39,7 +39,7 @@ class SimulatorFactory(object):
         """
         Return all supported compile options
         """
-        result = dict((opt.name, opt) for opt in [BooleanOption("enable_coverage"),])
+        result = dict((opt.name, opt) for opt in [BooleanOption("enable_coverage")])
         for sim_class in self.supported_simulators():
             for opt in sim_class.compile_options:
                 assert hasattr(opt, "name")

--- a/vunit/sim_if/ghdl.py
+++ b/vunit/sim_if/ghdl.py
@@ -438,10 +438,7 @@ class GHDLInterface(SimulatorInterface):  # pylint: disable=too-many-instance-at
         # Add compile-time .gcno files as well, they are needed or the report
         if file_exists(dir_name):
             for library in self._project.get_libraries():
-                lib_dir_path = Path(library.directory)
-                if lib_dir_path.exists():
-                    gcno_files = lib_dir_path.glob("*.gcno")
-                    for gcno_file in gcno_files:
+                for gcno_file in Path(library.directory).glob("*.gcno"):
                         # gcda files are output to the the coverage directory, but within subdirectories
                         # taken directly from where the command was run, so appdn cwd to output here
                         shutil.copy(gcno_file, gcda_dir)

--- a/vunit/sim_if/ghdl.py
+++ b/vunit/sim_if/ghdl.py
@@ -164,11 +164,18 @@ class GHDLInterface(SimulatorInterface):
     @classmethod
     def supports_vhpi(cls):
         """
-        Return if the simulator supports VHPI
+        Returns True when the simulator supports VHPI
         """
         return (cls.determine_backend(cls.find_prefix_from_path()) != "mcode") or (
             cls.determine_version(cls.find_prefix_from_path()) > 0.36
         )
+
+    @classmethod
+    def supports_coverage(cls):
+        """
+        Returns True when the simulator supports coverage
+        """
+        return cls.determine_backend(cls.find_prefix_from_path()) == "gcc"
 
     def _has_output_flag(self):
         """

--- a/vunit/sim_if/ghdl.py
+++ b/vunit/sim_if/ghdl.py
@@ -263,6 +263,12 @@ class GHDLInterface(SimulatorInterface):  # pylint: disable=too-many-instance-at
             a_flags += flags
 
         cmd += a_flags
+
+        if source_file.compile_options.get("enable_coverage", False):
+            # Add gcc compilation flags for coverage
+            #   -ftest-coverages creates .gcno notes files needed by gcov
+            #   -fprofile-arcs creates branch profiling in .gcda database files
+            cmd += ["-fprofile-arcs", "-ftest-coverage"]
         cmd += [source_file.name]
         return cmd
 
@@ -291,6 +297,9 @@ class GHDLInterface(SimulatorInterface):  # pylint: disable=too-many-instance-at
         if self._has_output_flag():
             cmd += ["-o", bin_path]
         cmd += config.sim_options.get("ghdl.elab_flags", [])
+        if config.sim_options.get("enable_coverage", False):
+            # Enable coverage in linker
+            cmd += ["-Wl,-lgcov"]
         cmd += [config.entity_name, config.architecture_name]
 
         sim = config.sim_options.get("ghdl.sim_flags", [])

--- a/vunit/sim_if/ghdl.py
+++ b/vunit/sim_if/ghdl.py
@@ -272,7 +272,9 @@ class GHDLInterface(SimulatorInterface):  # pylint: disable=too-many-instance-at
         cmd += [source_file.name]
         return cmd
 
-    def _get_command(self, config, output_path, elaborate_only, ghdl_e, wave_file):
+    def _get_command(  # pylint: disable=too-many-branches
+        self, config, output_path, elaborate_only, ghdl_e, wave_file
+    ):
         """
         Return GHDL simulation command
         """

--- a/vunit/sim_if/ghdl.py
+++ b/vunit/sim_if/ghdl.py
@@ -357,10 +357,10 @@ class GHDLInterface(SimulatorInterface):  # pylint: disable=too-many-instance-at
 
         status = True
 
-        gcov_env = os.environ.copy()
+        gcov_env = environ.copy()
         if config.sim_options.get("enable_coverage", False):
             # Set environment variable to put the coverage output in the test_output folder
-            coverage_dir = join(output_path, "coverage")
+            coverage_dir = str(Path(output_path) / "coverage")
             gcov_env["GCOV_PREFIX"] = coverage_dir
             self._coverage_dirs.add(coverage_dir)
 
@@ -390,9 +390,11 @@ class GHDLInterface(SimulatorInterface):  # pylint: disable=too-many-instance-at
 
         # GCOV gcno files are output to where the command is run,
         # move it back to the compilation folder
-        gcno_file = os.path.splitext(os.path.basename(source_file.name))[0] + ".gcno"
-        if os.path.exists(gcno_file):
-            os.rename(gcno_file, os.path.join(source_file.library.directory, gcno_file))
+        source_path = Path(source_file.name)
+        gcno_file = Path(source_path.stem + ".gcno")
+        if Path(gcno_file).exists():
+            new_path = Path(source_file.library.directory) / gcno_file
+            gcno_file.rename(new_path)
 
         return compilation_ok
 
@@ -436,8 +438,8 @@ class GHDLInterface(SimulatorInterface):  # pylint: disable=too-many-instance-at
         # Add compile-time .gcno files as well, they are needed or the report
         if file_exists(dir_name):
             for library in self._project.get_libraries():
-                if exists(library.directory):
-                    lib_dir_path = Path(library.directory)
+                lib_dir_path = Path(library.directory)
+                if lib_dir_path.exists():
                     gcno_files = lib_dir_path.glob("*.gcno")
                     for gcno_file in gcno_files:
                         # gcda files are output to the the coverage directory, but within subdirectories

--- a/vunit/sim_if/ghdl.py
+++ b/vunit/sim_if/ghdl.py
@@ -435,7 +435,7 @@ class GHDLInterface(SimulatorInterface):  # pylint: disable=too-many-instance-at
         assert len(gcda_dirs) == 1, "Expected exactly one folder with gcda files"
         gcda_dir = str(gcda_dirs.pop())
 
-        # Add compile-time .gcno files as well, they are needed or the report
+        # Add compile-time .gcno files as well, they are needed for the report
         if file_exists(dir_name):
             for library in self._project.get_libraries():
                 for gcno_file in Path(library.directory).glob("*.gcno"):

--- a/vunit/sim_if/ghdl.py
+++ b/vunit/sim_if/ghdl.py
@@ -354,6 +354,10 @@ class GHDLInterface(SimulatorInterface):
         )
 
         status = True
+
+        # Set environment variable to put the coverage output in the test_output folder
+        os.environ["GCOV_PREFIX"] = os.path.join(output_path, "coverage")
+
         try:
             proc = Process(cmd)
             proc.consume_output()
@@ -371,3 +375,17 @@ class GHDLInterface(SimulatorInterface):
             subprocess.call(cmd)
 
         return status
+
+    def _compile_source_file(self, source_file, printer):
+        """
+        Runs parent command for compilation, and moves the .gcno file (if any) to the compilation output folder
+        """
+        compilation_ok = super()._compile_source_file(source_file, printer)
+
+        # GCOV gcno files are output to where the command is run,
+        # move it back to the compilation folder
+        gcno_file = os.path.splitext(os.path.basename(source_file.name))[0] + ".gcno"
+        if os.path.exists(gcno_file):
+            os.rename(gcno_file, os.path.join(source_file.library.directory, gcno_file))
+
+        return compilation_ok

--- a/vunit/sim_if/ghdl.py
+++ b/vunit/sim_if/ghdl.py
@@ -355,11 +355,11 @@ class GHDLInterface(SimulatorInterface):
 
         status = True
 
-        # Set environment variable to put the coverage output in the test_output folder
-        os.environ["GCOV_PREFIX"] = os.path.join(output_path, "coverage")
-
         try:
-            proc = Process(cmd)
+            # Set environment variable to put the coverage output in the test_output folder
+            gcov_env = os.environ.copy()
+            gcov_env["GCOV_PREFIX"] = os.path.join(output_path, "coverage")
+            proc = Process(cmd, env=gcov_env)
             proc.consume_output()
         except Process.NonZeroExitCode:
             status = False

--- a/vunit/sim_if/modelsim.py
+++ b/vunit/sim_if/modelsim.py
@@ -81,6 +81,13 @@ class ModelSimInterface(
         """
         return True
 
+    @staticmethod
+    def supports_coverage():
+        """
+        Returns True when the simulator supports coverage
+        """
+        return True
+
     def __init__(self, prefix, output_path, persistent=False, gui=False):
         SimulatorInterface.__init__(self, output_path, gui)
         VsimSimulatorMixin.__init__(

--- a/vunit/sim_if/rivierapro.py
+++ b/vunit/sim_if/rivierapro.py
@@ -95,6 +95,13 @@ class RivieraProInterface(VsimSimulatorMixin, SimulatorInterface):
         """
         return True
 
+    @staticmethod
+    def supports_coverage():
+        """
+        Returns True when the simulator supports coverage
+        """
+        return True
+
     def __init__(self, prefix, output_path, persistent=False, gui=False):
         SimulatorInterface.__init__(self, output_path, gui)
         VsimSimulatorMixin.__init__(

--- a/vunit/ui/__init__.py
+++ b/vunit/ui/__init__.py
@@ -1102,7 +1102,7 @@ avoid location preprocessing of other functions sharing name with a VUnit log or
 
     def simulator_supports_coverage(self):
         """
-        Returns True if the simulator supports coverage
+        Returns True when the simulator supports coverage
 
         Will return None if no simulator was found.
         """

--- a/vunit/ui/__init__.py
+++ b/vunit/ui/__init__.py
@@ -1099,3 +1099,13 @@ avoid location preprocessing of other functions sharing name with a VUnit log or
         if self._simulator_class is None:
             return None
         return self._simulator_class.name
+
+    def simulator_supports_coverage(self):
+        """
+        Returns True if the simulator supports coverage
+
+        Will return None if no simulator was found.
+        """
+        if self._simulator_class is None:
+            return None
+        return self._simulator_class.supports_coverage


### PR DESCRIPTION
This adds:
* Handle for letting the user know if the version of ghdl supports coverage (i.e. if it uses the gcc back-end)
* Puts the compile-time gcno with the compiled .o-files, and run-time gcda folders within the output folder for each test

Each test case produces a separate .gcda file, and it is then left to the user to merge them as desired. This is in line with what is desired in issue #437.

This change will break the workflow of those who expect the output to just appear in the default location. For compilation these users would currently have problems with the gcno files not being updated at recompile (which is the main reason for this change). For simulation, maybe I should change the behaviour so that vunit only controls the run-time .gcda if the "enable_coverage" flag is set?

Feel free to bash on the code, I'm not a Python wizard and think it needs some feedback :-)