### PR TITLE
Fix GHDL "prefix of array attribute must be an object name"

### DIFF
--- a/vunit/vhdl/data_types/src/codec-2008p.vhd
+++ b/vunit/vhdl/data_types/src/codec-2008p.vhd
@@ -110,7 +110,8 @@ package body codec_2008p_pkg is
   function decode (
     constant code : string)
     return boolean_vector is
-    variable ret_val : boolean_vector(get_range(code)'range) := (others => false);
+    constant ret_range : range_t := get_range(code);
+    variable ret_val : boolean_vector(ret_range'range) := (others => false);
     variable index   : positive := code'left;
   begin
     decode(code, index, ret_val);
@@ -136,7 +137,8 @@ package body codec_2008p_pkg is
   function decode (
     constant code : string)
     return integer_vector is
-    variable ret_val : integer_vector(get_range(code)'range) := (others => integer'left);
+    constant ret_range : range_t := get_range(code);
+    variable ret_val : integer_vector(ret_range'range) := (others => integer'left);
     variable index   : positive := code'left;
   begin
     decode(code, index, ret_val);
@@ -162,7 +164,8 @@ package body codec_2008p_pkg is
   function decode (
     constant code : string)
     return real_vector is
-    variable ret_val : real_vector(get_range(code)'range) := (others => real'left);
+    constant ret_range : range_t := get_range(code);
+    variable ret_val : real_vector(ret_range'range) := (others => real'left);
     variable index   : positive := code'left;
   begin
     decode(code, index, ret_val);
@@ -188,7 +191,8 @@ package body codec_2008p_pkg is
   function decode (
     constant code : string)
     return time_vector is
-    variable ret_val : time_vector(get_range(code)'range) := (others => time'left);
+    constant ret_range : range_t := get_range(code);
+    variable ret_val : time_vector(ret_range'range) := (others => time'left);
     variable index   : positive := code'left;
   begin
     decode(code, index, ret_val);
@@ -206,7 +210,8 @@ package body codec_2008p_pkg is
   function decode (
     constant code : string)
     return ufixed is
-    variable ret_val : ufixed(get_range(code)'range);
+    constant ret_range : range_t := get_range(code);
+    variable ret_val : ufixed(ret_range'range);
     variable index   : positive := code'left;
   begin
     decode(code, index, ret_val);
@@ -224,7 +229,8 @@ package body codec_2008p_pkg is
   function decode (
     constant code : string)
     return sfixed is
-    variable ret_val : sfixed(get_range(code)'range);
+    constant ret_range : range_t := get_range(code);
+    variable ret_val : sfixed(ret_range'range);
     variable index   : positive := code'left;
   begin
     decode(code, index, ret_val);
@@ -242,7 +248,8 @@ package body codec_2008p_pkg is
   function decode (
     constant code : string)
     return float is
-    variable ret_val : float(get_range(code)'range);
+    constant ret_range : range_t := get_range(code);
+    variable ret_val : float(ret_range'range);
     variable index   : positive := code'left;
   begin
     decode(code, index, ret_val);

--- a/vunit/vhdl/data_types/src/codec.vhd
+++ b/vunit/vhdl/data_types/src/codec.vhd
@@ -517,7 +517,8 @@ package body codec_pkg is
   function decode (
     constant code : string)
     return string is
-    variable ret_val : string(get_range(code)'range) := (others => NUL);
+    constant ret_range : range_t := get_range(code);
+    variable ret_val : string(ret_range'range) := (others => NUL);
     variable index   : positive := code'left;
   begin
     decode(code, index, ret_val);
@@ -542,7 +543,8 @@ package body codec_pkg is
   function decode (
     constant code : string)
     return bit_vector is
-    variable ret_val : bit_vector(get_range(code)'range) := (others => '0');
+    constant ret_range : range_t := get_range(code);
+    variable ret_val : bit_vector(ret_range'range) := (others => '0');
     variable index   : positive := code'left;
   begin
     decode(code, index, ret_val);
@@ -560,7 +562,8 @@ package body codec_pkg is
   function decode (
     constant code : string)
     return std_ulogic_vector is
-    variable ret_val : std_ulogic_vector(get_range(code)'range) := (others => 'U');
+    constant ret_range : range_t := get_range(code);
+    variable ret_val : std_ulogic_vector(ret_range'range) := (others => 'U');
     variable index   : positive := code'left;
   begin
     decode(code, index, ret_val);
@@ -614,7 +617,8 @@ package body codec_pkg is
   function decode (
     constant code : string)
     return ieee.numeric_bit.unsigned is
-    variable ret_val : ieee.numeric_bit.unsigned(get_range(code)'range) := (others => '0');
+    constant ret_range : range_t := get_range(code);
+    variable ret_val : ieee.numeric_bit.unsigned(ret_range'range) := (others => '0');
     variable index   : positive := code'left;
   begin
     decode(code, index, ret_val);
@@ -632,7 +636,8 @@ package body codec_pkg is
   function decode (
     constant code : string)
     return ieee.numeric_bit.signed is
-    variable ret_val : ieee.numeric_bit.signed(get_range(code)'range) := (others => '0');
+    constant ret_range : range_t := get_range(code);
+    variable ret_val : ieee.numeric_bit.signed(ret_range'range) := (others => '0');
     variable index   : positive := code'left;
   begin
     decode(code, index, ret_val);
@@ -650,7 +655,8 @@ package body codec_pkg is
   function decode (
     constant code : string)
     return ieee.numeric_std.unsigned is
-    variable ret_val : ieee.numeric_std.unsigned(get_range(code)'range) := (others => 'U');
+    constant ret_range : range_t := get_range(code);
+    variable ret_val : ieee.numeric_std.unsigned(ret_range'range) := (others => 'U');
     variable index   : positive := code'left;
   begin
     decode(code, index, ret_val);
@@ -668,7 +674,8 @@ package body codec_pkg is
   function decode (
     constant code : string)
     return ieee.numeric_std.signed is
-    variable ret_val : ieee.numeric_std.signed(get_range(code)'range) := (others => 'U');
+    constant ret_range : range_t := get_range(code);
+    variable ret_val : ieee.numeric_std.signed(ret_range'range) := (others => 'U');
     variable index   : positive := code'left;
   begin
     decode(code, index, ret_val);

--- a/vunit/vhdl/logging/src/logger_pkg-body.vhd
+++ b/vunit/vhdl/logging/src/logger_pkg-body.vhd
@@ -92,12 +92,13 @@ package body logger_pkg is
   procedure p_set_log_handlers(logger : logger_t;
                                log_handlers : log_handler_vec_t) is
     constant handlers : integer_vector_ptr_t := to_integer_vector_ptr(get(logger.p_data, handlers_idx));
+    constant full_logger_name : string := get_full_name(logger);
   begin
     resize(handlers, log_handlers'length);
 
     for i in log_handlers'range loop
       set(handlers, i, to_integer(log_handlers(i).p_data));
-      update_max_logger_name_length(log_handlers(i), get_full_name(logger)'length);
+      update_max_logger_name_length(log_handlers(i), full_logger_name'length);
     end loop;
   end;
 
@@ -262,11 +263,12 @@ package body logger_pkg is
   end;
 
   impure function get_max_name_length(logger : logger_t) return natural is
+    constant full_name : string := get_full_name(logger);
     variable result : natural := 0;
     variable child_result : natural;
   begin
     if num_children(logger) = 0 then
-      return get_full_name(logger)'length;
+      return full_name'length;
     end if;
 
     for i in 0 to num_children(logger)-1 loop


### PR DESCRIPTION
Since a couple of days ago, new VUnit version and new GHDL version gives errors like

`/usr/local/lib/python3.8/site-packages/vunit_hdl-4.3.1rc0-py3.8.egg/vunit/vhdl/data_types/src/codec.vhd:520:47: prefix of array attribute must be an object name`

during compilation. This PR fixes these so that compile passes.