### PR TITLE
codec: fix "prefix of array attribute must be an object name"

### DIFF
--- a/vunit/com/codec_vhdl_array_type.py
+++ b/vunit/com/codec_vhdl_array_type.py
@@ -172,7 +172,7 @@ class ArrayCodecTemplate(DatatypeCodecTemplate):
   function encode (
     constant data : $type)
     return string is
-    constant length : positive := get_length(encode(data(data'left)));
+    constant length : positive := get_encoded_length(encode(data(data'left)));
     variable index : positive := 1;
     variable ret_val : string(1 to data'length * length);
   begin
@@ -233,7 +233,7 @@ class ArrayCodecTemplate(DatatypeCodecTemplate):
   function encode (
     constant data : $type)
     return string is
-    constant length : positive := get_length(encode(data(data'left(1), data'left(2))));
+    constant length : positive := get_encoded_length(encode(data(data'left(1), data'left(2))));
     variable index : positive := 1;
     variable ret_val : string(1 to data'length(1) * data'length(2) * length);
   begin
@@ -305,11 +305,11 @@ class ArrayCodecTemplate(DatatypeCodecTemplate):
       if data'length = 0 then
         return 0;
       else
-        return get_length(encode(data(data'left)));
+        return get_encoded_length(encode(data(data'left)));
       end if;
     end;
     constant length : natural := element_length(data);
-    constant range_length : positive := get_length(encode(data'left));
+    constant range_length : positive := get_encoded_length(encode(data'left));
     variable index : positive := 2 + 2 * range_length;
     variable ret_val : string(1 to 1 + 2 * range_length + data'length * length);
   begin
@@ -328,7 +328,7 @@ class ArrayCodecTemplate(DatatypeCodecTemplate):
     constant code   : string;
     variable index : inout   positive;
     variable result : out $array_type) is
-    constant range_length : positive := get_length(encode($range_type'left));
+    constant range_length : positive := get_encoded_length(encode($range_type'left));
   begin
     index := index + 1 + 2 * range_length;
     for i in result'range loop
@@ -339,7 +339,7 @@ class ArrayCodecTemplate(DatatypeCodecTemplate):
   function decode (
     constant code : string)
     return $array_type is
-    constant range_length : positive := get_length(encode($range_type'left));
+    constant range_length : positive := get_encoded_length(encode($range_type'left));
     function ret_val_range (
       constant code : string)
       return $array_type is
@@ -401,12 +401,12 @@ class ArrayCodecTemplate(DatatypeCodecTemplate):
       if data'length(1) * data'length(2) = 0 then
         return 0;
       else
-        return get_length(encode(data(data'left(1), data'left(2))));
+        return get_encoded_length(encode(data(data'left(1), data'left(2))));
       end if;
     end;
     constant length : natural := element_length(data);
-    constant range1_length : positive := get_length(encode(data'left(1)));
-    constant range2_length : positive := get_length(encode(data'left(2)));
+    constant range1_length : positive := get_encoded_length(encode(data'left(1)));
+    constant range2_length : positive := get_encoded_length(encode(data'left(2)));
     variable index : positive := 3 + 2 * range1_length + 2 * range2_length;
     variable ret_val : string(1 to 2 + 2 * range1_length + 2 * range2_length +
                                    data'length(1) * data'length(2) * length);
@@ -428,8 +428,8 @@ class ArrayCodecTemplate(DatatypeCodecTemplate):
     constant code   : string;
     variable index : inout   positive;
     variable result : out $array_type) is
-    constant range1_length : positive := get_length(encode($range_type1'left));
-    constant range2_length : positive := get_length(encode($range_type2'left));
+    constant range1_length : positive := get_encoded_length(encode($range_type1'left));
+    constant range2_length : positive := get_encoded_length(encode($range_type2'left));
   begin
     index := index + 2 + 2 * range1_length + 2 * range2_length;
     for i in result'range(1) loop
@@ -442,8 +442,8 @@ class ArrayCodecTemplate(DatatypeCodecTemplate):
   function decode (
     constant code : string)
     return $array_type is
-    constant range1_length : positive := get_length(encode($range_type1'left));
-    constant range2_length : positive := get_length(encode($range_type2'left));
+    constant range1_length : positive := get_encoded_length(encode($range_type1'left));
+    constant range2_length : positive := get_encoded_length(encode($range_type2'left));
     function ret_val_range (
       constant code : string)
       return $array_type is

--- a/vunit/com/codec_vhdl_array_type.py
+++ b/vunit/com/codec_vhdl_array_type.py
@@ -172,7 +172,7 @@ class ArrayCodecTemplate(DatatypeCodecTemplate):
   function encode (
     constant data : $type)
     return string is
-    constant length : positive := encode(data(data'left))'length;
+    constant length : positive := get_length(encode(data(data'left)));
     variable index : positive := 1;
     variable ret_val : string(1 to data'length * length);
   begin
@@ -233,7 +233,7 @@ class ArrayCodecTemplate(DatatypeCodecTemplate):
   function encode (
     constant data : $type)
     return string is
-    constant length : positive := encode(data(data'left(1), data'left(2)))'length;
+    constant length : positive := get_length(encode(data(data'left(1), data'left(2))));
     variable index : positive := 1;
     variable ret_val : string(1 to data'length(1) * data'length(2) * length);
   begin
@@ -305,11 +305,11 @@ class ArrayCodecTemplate(DatatypeCodecTemplate):
       if data'length = 0 then
         return 0;
       else
-        return encode(data(data'left))'length;
+        return get_length(encode(data(data'left)));
       end if;
     end;
     constant length : natural := element_length(data);
-    constant range_length : positive := encode(data'left)'length;
+    constant range_length : positive := get_length(encode(data'left));
     variable index : positive := 2 + 2 * range_length;
     variable ret_val : string(1 to 1 + 2 * range_length + data'length * length);
   begin
@@ -328,7 +328,7 @@ class ArrayCodecTemplate(DatatypeCodecTemplate):
     constant code   : string;
     variable index : inout   positive;
     variable result : out $array_type) is
-    constant range_length : positive := encode($range_type'left)'length;
+    constant range_length : positive := get_length(encode($range_type'left));
   begin
     index := index + 1 + 2 * range_length;
     for i in result'range loop
@@ -339,7 +339,7 @@ class ArrayCodecTemplate(DatatypeCodecTemplate):
   function decode (
     constant code : string)
     return $array_type is
-    constant range_length : positive := encode($range_type'left)'length;
+    constant range_length : positive := get_length(encode($range_type'left));
     function ret_val_range (
       constant code : string)
       return $array_type is
@@ -401,12 +401,12 @@ class ArrayCodecTemplate(DatatypeCodecTemplate):
       if data'length(1) * data'length(2) = 0 then
         return 0;
       else
-        return encode(data(data'left(1), data'left(2)))'length;
+        return get_length(encode(data(data'left(1), data'left(2))));
       end if;
     end;
     constant length : natural := element_length(data);
-    constant range1_length : positive := encode(data'left(1))'length;
-    constant range2_length : positive := encode(data'left(2))'length;
+    constant range1_length : positive := get_length(encode(data'left(1)));
+    constant range2_length : positive := get_length(encode(data'left(2)));
     variable index : positive := 3 + 2 * range1_length + 2 * range2_length;
     variable ret_val : string(1 to 2 + 2 * range1_length + 2 * range2_length +
                                    data'length(1) * data'length(2) * length);
@@ -428,8 +428,8 @@ class ArrayCodecTemplate(DatatypeCodecTemplate):
     constant code   : string;
     variable index : inout   positive;
     variable result : out $array_type) is
-    constant range1_length : positive := encode($range_type1'left)'length;
-    constant range2_length : positive := encode($range_type2'left)'length;
+    constant range1_length : positive := get_length(encode($range_type1'left));
+    constant range2_length : positive := get_length(encode($range_type2'left));
   begin
     index := index + 2 + 2 * range1_length + 2 * range2_length;
     for i in result'range(1) loop
@@ -442,8 +442,8 @@ class ArrayCodecTemplate(DatatypeCodecTemplate):
   function decode (
     constant code : string)
     return $array_type is
-    constant range1_length : positive := encode($range_type1'left)'length;
-    constant range2_length : positive := encode($range_type2'left)'length;
+    constant range1_length : positive := get_length(encode($range_type1'left));
+    constant range2_length : positive := get_length(encode($range_type2'left));
     function ret_val_range (
       constant code : string)
       return $array_type is

--- a/vunit/com/codec_vhdl_package.py
+++ b/vunit/com/codec_vhdl_package.py
@@ -130,7 +130,7 @@ class CodecVHDLPackage(VHDLPackage):
         declarations = ""
         definitions = """
   -- Helper function to make tests pass GHDL v0.37
-  function get_length ( constant vec: string ) return integer is
+  function get_encoded_length ( constant vec: string ) return integer is
   begin return vec'length; end;
 
 """

--- a/vunit/com/codec_vhdl_package.py
+++ b/vunit/com/codec_vhdl_package.py
@@ -128,7 +128,12 @@ class CodecVHDLPackage(VHDLPackage):
         """Generate codecs and to_string functions for all array data types."""
 
         declarations = ""
-        definitions = ""
+        definitions = """
+  -- Helper function to make tests pass GHDL v0.37
+  function get_length ( constant vec: string ) return integer is
+  begin return vec'length; end;
+
+"""
         for array in self.array_types:
             (
                 new_declarations,

--- a/vunit/vhdl/data_types/test/tb_codec-2008p.vhd
+++ b/vunit/vhdl/data_types/test/tb_codec-2008p.vhd
@@ -57,28 +57,28 @@ begin
     variable range_left, range_right : integer;
 
     -- Helper functions to make tests pass GHDL v0.37
-    function get_range_left ( constant vec: boolean_vector ) return integer is
+    function get_decoded_range_left ( constant vec: boolean_vector ) return integer is
     begin return vec'left; end;
 
-    function get_range_right ( constant vec: boolean_vector ) return integer is
+    function get_decoded_range_right ( constant vec: boolean_vector ) return integer is
     begin return vec'right; end;
 
-    function get_range_left ( constant vec: integer_vector ) return integer is
+    function get_decoded_range_left ( constant vec: integer_vector ) return integer is
     begin return vec'left; end;
 
-    function get_range_right ( constant vec: integer_vector ) return integer is
+    function get_decoded_range_right ( constant vec: integer_vector ) return integer is
     begin return vec'right; end;
 
-    function get_range_left ( constant vec: real_vector ) return integer is
+    function get_decoded_range_left ( constant vec: real_vector ) return integer is
     begin return vec'left; end;
 
-    function get_range_right ( constant vec: real_vector ) return integer is
+    function get_decoded_range_right ( constant vec: real_vector ) return integer is
     begin return vec'right; end;
 
-    function get_range_left ( constant vec: time_vector ) return integer is
+    function get_decoded_range_left ( constant vec: time_vector ) return integer is
     begin return vec'left; end;
 
-    function get_range_right ( constant vec: time_vector ) return integer is
+    function get_decoded_range_right ( constant vec: time_vector ) return integer is
     begin return vec'right; end;
 
   begin
@@ -91,8 +91,8 @@ begin
         check_relation(decode_boolean_vector(encode_boolean_vector((0         => true))) = boolean_vector'(0 => true));
         check_relation(decode_boolean_vector(encode_boolean_vector(null_boolean_vector)) = null_boolean_vector);
         check_relation(decode_boolean_vector(encode_boolean_vector(boolean_vector_5_downto_3)) = boolean_vector'(true, false, true));
-        range_left := get_range_left(decode_boolean_vector(encode_boolean_vector(boolean_vector_5_downto_3)));
-        range_right := get_range_right(decode_boolean_vector(encode_boolean_vector(boolean_vector_5_downto_3)));
+        range_left := get_decoded_range_left(decode_boolean_vector(encode_boolean_vector(boolean_vector_5_downto_3)));
+        range_right := get_decoded_range_right(decode_boolean_vector(encode_boolean_vector(boolean_vector_5_downto_3)));
         check_relation(range_left = 5);
         check_relation(range_right = 3);
       elsif run("Test that integer_vector can be encoded and decoded") then
@@ -102,8 +102,8 @@ begin
         check_relation(decode_integer_vector(encode_integer_vector((0   => -42))) = integer_vector'(0 => -42));
         check_relation(decode_integer_vector(encode_integer_vector(null_integer_vector)) = null_integer_vector);
         check_relation(decode_integer_vector(encode_integer_vector(integer_vector_5_downto_3)) = integer_vector'(-42, 0, 17));
-        range_left := get_range_left(decode_integer_vector(encode_integer_vector(integer_vector_5_downto_3)));
-        range_right := get_range_right(decode_integer_vector(encode_integer_vector(integer_vector_5_downto_3)));
+        range_left := get_decoded_range_left(decode_integer_vector(encode_integer_vector(integer_vector_5_downto_3)));
+        range_right := get_decoded_range_right(decode_integer_vector(encode_integer_vector(integer_vector_5_downto_3)));
         check_relation(range_left = 5);
         check_relation(range_right = 3);
       elsif run("Test that real_vector can be encoded and decoded") then
@@ -112,8 +112,8 @@ begin
         check_relation(decode_real_vector(encode_real_vector((0          => -42.42))) = real_vector'(0 => -42.42));
         check_relation(decode_real_vector(encode_real_vector(null_real_vector)) = null_real_vector);
         check_relation(decode_real_vector(encode_real_vector(real_vector_5_downto_3)) = real_vector'(-42.42, 0.001, 17.17));
-        range_left := get_range_left(decode_real_vector(encode_real_vector(real_vector_5_downto_3)));
-        range_right := get_range_right(decode_real_vector(encode_real_vector(real_vector_5_downto_3)));
+        range_left := get_decoded_range_left(decode_real_vector(encode_real_vector(real_vector_5_downto_3)));
+        range_right := get_decoded_range_right(decode_real_vector(encode_real_vector(real_vector_5_downto_3)));
         check_relation(range_left = 5);
         check_relation(range_right = 3);
       elsif run("Test that time_vector can be encoded and decoded") then
@@ -122,8 +122,8 @@ begin
         check_relation(decode_time_vector(encode_time_vector((0           => -42 ms))) = time_vector'(0 => -42 ms));
         check_relation(decode_time_vector(encode_time_vector(null_time_vector)) = null_time_vector);
         check_relation(decode_time_vector(encode_time_vector(time_vector_5_downto_3)) = time_vector'(-42 ms, 0 sec, 17 min));
-        range_left := get_range_left(decode_time_vector(encode_time_vector(time_vector_5_downto_3)));
-        range_right := get_range_right(decode_time_vector(encode_time_vector(time_vector_5_downto_3)));
+        range_left := get_decoded_range_left(decode_time_vector(encode_time_vector(time_vector_5_downto_3)));
+        range_right := get_decoded_range_right(decode_time_vector(encode_time_vector(time_vector_5_downto_3)));
         check_relation(range_left = 5);
         check_relation(range_right = 3);
       elsif run("Test that ufixed can be encoded and decoded") then

--- a/vunit/vhdl/data_types/test/tb_codec-2008p.vhd
+++ b/vunit/vhdl/data_types/test/tb_codec-2008p.vhd
@@ -53,8 +53,33 @@ begin
     variable real_vector_5_downto_3 : real_vector(5 downto 3);
     variable time_vector_5_downto_3 : time_vector(5 downto 3);
 
-    -- Temp variables to make test case pass Riviera-PRO 2016.10
+    -- Temp variables to make tests pass Riviera-PRO 2016.10
     variable range_left, range_right : integer;
+
+    -- Helper functions to make tests pass GHDL v0.37
+    function get_range_left ( constant vec: boolean_vector ) return integer is
+    begin return vec'left; end;
+
+    function get_range_right ( constant vec: boolean_vector ) return integer is
+    begin return vec'right; end;
+
+    function get_range_left ( constant vec: integer_vector ) return integer is
+    begin return vec'left; end;
+
+    function get_range_right ( constant vec: integer_vector ) return integer is
+    begin return vec'right; end;
+
+    function get_range_left ( constant vec: real_vector ) return integer is
+    begin return vec'left; end;
+
+    function get_range_right ( constant vec: real_vector ) return integer is
+    begin return vec'right; end;
+
+    function get_range_left ( constant vec: time_vector ) return integer is
+    begin return vec'left; end;
+
+    function get_range_right ( constant vec: time_vector ) return integer is
+    begin return vec'right; end;
 
   begin
     test_runner_setup(runner, runner_cfg);
@@ -63,22 +88,22 @@ begin
       if run("Test that boolean_vector can be encoded and decoded") then
         boolean_vector_5_downto_3 := (true, false, true);
         check_relation(decode_boolean_vector(encode_boolean_vector((true, false, true))) = boolean_vector'(true, false, true));
-        check_relation(decode_boolean_vector(encode_boolean_vector((0          => true))) = boolean_vector'(0 => true));
+        check_relation(decode_boolean_vector(encode_boolean_vector((0         => true))) = boolean_vector'(0 => true));
         check_relation(decode_boolean_vector(encode_boolean_vector(null_boolean_vector)) = null_boolean_vector);
         check_relation(decode_boolean_vector(encode_boolean_vector(boolean_vector_5_downto_3)) = boolean_vector'(true, false, true));
-        range_left := decode_boolean_vector(encode_boolean_vector(boolean_vector_5_downto_3))'left;
-        range_right := decode_boolean_vector(encode_boolean_vector(boolean_vector_5_downto_3))'right;
+        range_left := get_range_left(decode_boolean_vector(encode_boolean_vector(boolean_vector_5_downto_3)));
+        range_right := get_range_right(decode_boolean_vector(encode_boolean_vector(boolean_vector_5_downto_3)));
         check_relation(range_left = 5);
         check_relation(range_right = 3);
       elsif run("Test that integer_vector can be encoded and decoded") then
         integer_vector_5_downto_3 := (-42, 0, 17);
         check_relation(decode_integer_vector(encode_integer_vector((-2147483648, -2147483648, -2147483648))) = integer_vector'(-2147483648, -2147483648, -2147483648));
         check_relation(decode_integer_vector(encode_integer_vector((-42, 0, 17))) = integer_vector'(-42, 0, 17));
-        check_relation(decode_integer_vector(encode_integer_vector((0          => -42))) = integer_vector'(0 => -42));
+        check_relation(decode_integer_vector(encode_integer_vector((0   => -42))) = integer_vector'(0 => -42));
         check_relation(decode_integer_vector(encode_integer_vector(null_integer_vector)) = null_integer_vector);
         check_relation(decode_integer_vector(encode_integer_vector(integer_vector_5_downto_3)) = integer_vector'(-42, 0, 17));
-        range_left := decode_integer_vector(encode_integer_vector(integer_vector_5_downto_3))'left;
-        range_right := decode_integer_vector(encode_integer_vector(integer_vector_5_downto_3))'right;
+        range_left := get_range_left(decode_integer_vector(encode_integer_vector(integer_vector_5_downto_3)));
+        range_right := get_range_right(decode_integer_vector(encode_integer_vector(integer_vector_5_downto_3)));
         check_relation(range_left = 5);
         check_relation(range_right = 3);
       elsif run("Test that real_vector can be encoded and decoded") then
@@ -87,33 +112,33 @@ begin
         check_relation(decode_real_vector(encode_real_vector((0          => -42.42))) = real_vector'(0 => -42.42));
         check_relation(decode_real_vector(encode_real_vector(null_real_vector)) = null_real_vector);
         check_relation(decode_real_vector(encode_real_vector(real_vector_5_downto_3)) = real_vector'(-42.42, 0.001, 17.17));
-        range_left := decode_real_vector(encode_real_vector(real_vector_5_downto_3))'left;
-        range_right := decode_real_vector(encode_real_vector(real_vector_5_downto_3))'right;
+        range_left := get_range_left(decode_real_vector(encode_real_vector(real_vector_5_downto_3)));
+        range_right := get_range_right(decode_real_vector(encode_real_vector(real_vector_5_downto_3)));
         check_relation(range_left = 5);
         check_relation(range_right = 3);
       elsif run("Test that time_vector can be encoded and decoded") then
         time_vector_5_downto_3 := (-42 ms, 0 sec, 17 min);
         check_relation(decode_time_vector(encode_time_vector((-42 ms, 0 sec, 17 min))) = time_vector'(-42 ms, 0 sec, 17 min));
-        check_relation(decode_time_vector(encode_time_vector((0          => -42 ms))) = time_vector'(0 => -42 ms));
+        check_relation(decode_time_vector(encode_time_vector((0           => -42 ms))) = time_vector'(0 => -42 ms));
         check_relation(decode_time_vector(encode_time_vector(null_time_vector)) = null_time_vector);
         check_relation(decode_time_vector(encode_time_vector(time_vector_5_downto_3)) = time_vector'(-42 ms, 0 sec, 17 min));
-        range_left := decode_time_vector(encode_time_vector(time_vector_5_downto_3))'left;
-        range_right := decode_time_vector(encode_time_vector(time_vector_5_downto_3))'right;
+        range_left := get_range_left(decode_time_vector(encode_time_vector(time_vector_5_downto_3)));
+        range_right := get_range_right(decode_time_vector(encode_time_vector(time_vector_5_downto_3)));
         check_relation(range_left = 5);
         check_relation(range_right = 3);
       elsif run("Test that ufixed can be encoded and decoded") then
-        check_relation(decode_ufixed(encode_ufixed(to_ufixed(6.5, 3, -3))) = to_ufixed(6.5, 3, -3));
-        check_relation(decode_ufixed(encode_ufixed(to_ufixed(8.0, 3, 1))) = to_ufixed(8.0, 3, 1));
+        check_relation(decode_ufixed(encode_ufixed(to_ufixed( 6.5,  3, -3))) = to_ufixed(6.5, 3, -3));
+        check_relation(decode_ufixed(encode_ufixed(to_ufixed( 8.0,  3,  1))) = to_ufixed(8.0, 3, 1));
         check_relation(decode_ufixed(encode_ufixed(to_ufixed(0.25, -2, -4))) = to_ufixed(0.25, -2, -4));
       elsif run("Test that sfixed can be encoded and decoded") then
-        check_relation(decode_sfixed(encode_sfixed(to_sfixed(6.5, 3, -3))) = to_sfixed(6.5, 3, -3));
-        check_relation(decode_sfixed(encode_sfixed(to_sfixed(8.0, 4, 1))) = to_sfixed(8.0, 4, 1));
-        check_relation(decode_sfixed(encode_sfixed(to_sfixed(0.25, -1, -4))) = to_sfixed(0.25, -1, -4));
-        check_relation(decode_sfixed(encode_sfixed(to_sfixed(-6.5, 3, -3))) = to_sfixed(-6.5, 3, -3));
-        check_relation(decode_sfixed(encode_sfixed(to_sfixed(-8.0, 4, 1))) = to_sfixed(-8.0, 4, 1));
+        check_relation(decode_sfixed(encode_sfixed(to_sfixed( 6.5,   3, -3))) = to_sfixed(6.5, 3, -3));
+        check_relation(decode_sfixed(encode_sfixed(to_sfixed( 8.0,   4,  1))) = to_sfixed(8.0, 4, 1));
+        check_relation(decode_sfixed(encode_sfixed(to_sfixed(0.25,  -1, -4))) = to_sfixed(0.25, -1, -4));
+        check_relation(decode_sfixed(encode_sfixed(to_sfixed(-6.5,   3, -3))) = to_sfixed(-6.5, 3, -3));
+        check_relation(decode_sfixed(encode_sfixed(to_sfixed(-8.0,   4,  1))) = to_sfixed(-8.0, 4, 1));
         check_relation(decode_sfixed(encode_sfixed(to_sfixed(-0.25, -1, -4))) = to_sfixed(-0.25, -1, -4));
       elsif run("Test that float can be encoded and decoded") then
-        check_relation(decode_float(encode_float(to_float(real'low, 11, 52))) = to_float(real'low, 11, 52));
+        check_relation(decode_float(encode_float(to_float(real'low,  11, 52))) = to_float(real'low, 11, 52));
         check_relation(decode_float(encode_float(to_float(real'high, 11, 52))) = to_float(real'high, 11, 52));
 
         check_relation(to_string(decode_float(encode_float(positive_zero))) = to_string(positive_zero));

--- a/vunit/vhdl/data_types/test/tb_codec-2008p.vhd
+++ b/vunit/vhdl/data_types/test/tb_codec-2008p.vhd
@@ -53,10 +53,7 @@ begin
     variable real_vector_5_downto_3 : real_vector(5 downto 3);
     variable time_vector_5_downto_3 : time_vector(5 downto 3);
 
-    -- Temp variables to make tests pass Riviera-PRO 2016.10
-    variable range_left, range_right : integer;
-
-    -- Helper functions to make tests pass GHDL v0.37
+    -- Helper functions to make tests pass GHDL v0.37 and Riviera-PRO 2016.10
     function get_decoded_range_left ( constant vec: boolean_vector ) return integer is
     begin return vec'left; end;
 
@@ -91,10 +88,8 @@ begin
         check_relation(decode_boolean_vector(encode_boolean_vector((0         => true))) = boolean_vector'(0 => true));
         check_relation(decode_boolean_vector(encode_boolean_vector(null_boolean_vector)) = null_boolean_vector);
         check_relation(decode_boolean_vector(encode_boolean_vector(boolean_vector_5_downto_3)) = boolean_vector'(true, false, true));
-        range_left := get_decoded_range_left(decode_boolean_vector(encode_boolean_vector(boolean_vector_5_downto_3)));
-        range_right := get_decoded_range_right(decode_boolean_vector(encode_boolean_vector(boolean_vector_5_downto_3)));
-        check_relation(range_left = 5);
-        check_relation(range_right = 3);
+        check_relation(get_decoded_range_left(decode_boolean_vector(encode_boolean_vector(boolean_vector_5_downto_3))) = 5);
+        check_relation(get_decoded_range_right(decode_boolean_vector(encode_boolean_vector(boolean_vector_5_downto_3))) = 3);
       elsif run("Test that integer_vector can be encoded and decoded") then
         integer_vector_5_downto_3 := (-42, 0, 17);
         check_relation(decode_integer_vector(encode_integer_vector((-2147483648, -2147483648, -2147483648))) = integer_vector'(-2147483648, -2147483648, -2147483648));
@@ -102,30 +97,24 @@ begin
         check_relation(decode_integer_vector(encode_integer_vector((0   => -42))) = integer_vector'(0 => -42));
         check_relation(decode_integer_vector(encode_integer_vector(null_integer_vector)) = null_integer_vector);
         check_relation(decode_integer_vector(encode_integer_vector(integer_vector_5_downto_3)) = integer_vector'(-42, 0, 17));
-        range_left := get_decoded_range_left(decode_integer_vector(encode_integer_vector(integer_vector_5_downto_3)));
-        range_right := get_decoded_range_right(decode_integer_vector(encode_integer_vector(integer_vector_5_downto_3)));
-        check_relation(range_left = 5);
-        check_relation(range_right = 3);
+        check_relation(get_decoded_range_left(decode_integer_vector(encode_integer_vector(integer_vector_5_downto_3))) = 5);
+        check_relation(get_decoded_range_right(decode_integer_vector(encode_integer_vector(integer_vector_5_downto_3))) = 3);
       elsif run("Test that real_vector can be encoded and decoded") then
         real_vector_5_downto_3 := (-42.42, 0.001, 17.17);
         check_relation(decode_real_vector(encode_real_vector((-42.42, 0.001, 17.17))) = real_vector'(-42.42, 0.001, 17.17));
         check_relation(decode_real_vector(encode_real_vector((0          => -42.42))) = real_vector'(0 => -42.42));
         check_relation(decode_real_vector(encode_real_vector(null_real_vector)) = null_real_vector);
         check_relation(decode_real_vector(encode_real_vector(real_vector_5_downto_3)) = real_vector'(-42.42, 0.001, 17.17));
-        range_left := get_decoded_range_left(decode_real_vector(encode_real_vector(real_vector_5_downto_3)));
-        range_right := get_decoded_range_right(decode_real_vector(encode_real_vector(real_vector_5_downto_3)));
-        check_relation(range_left = 5);
-        check_relation(range_right = 3);
+        check_relation(get_decoded_range_left(decode_real_vector(encode_real_vector(real_vector_5_downto_3))) = 5);
+        check_relation(get_decoded_range_right(decode_real_vector(encode_real_vector(real_vector_5_downto_3))) = 3);
       elsif run("Test that time_vector can be encoded and decoded") then
         time_vector_5_downto_3 := (-42 ms, 0 sec, 17 min);
         check_relation(decode_time_vector(encode_time_vector((-42 ms, 0 sec, 17 min))) = time_vector'(-42 ms, 0 sec, 17 min));
         check_relation(decode_time_vector(encode_time_vector((0           => -42 ms))) = time_vector'(0 => -42 ms));
         check_relation(decode_time_vector(encode_time_vector(null_time_vector)) = null_time_vector);
         check_relation(decode_time_vector(encode_time_vector(time_vector_5_downto_3)) = time_vector'(-42 ms, 0 sec, 17 min));
-        range_left := get_decoded_range_left(decode_time_vector(encode_time_vector(time_vector_5_downto_3)));
-        range_right := get_decoded_range_right(decode_time_vector(encode_time_vector(time_vector_5_downto_3)));
-        check_relation(range_left = 5);
-        check_relation(range_right = 3);
+        check_relation(get_decoded_range_left(decode_time_vector(encode_time_vector(time_vector_5_downto_3))) = 5);
+        check_relation(get_decoded_range_right(decode_time_vector(encode_time_vector(time_vector_5_downto_3))) = 3);
       elsif run("Test that ufixed can be encoded and decoded") then
         check_relation(decode_ufixed(encode_ufixed(to_ufixed( 6.5,  3, -3))) = to_ufixed(6.5, 3, -3));
         check_relation(decode_ufixed(encode_ufixed(to_ufixed( 8.0,  3,  1))) = to_ufixed(8.0, 3, 1));

--- a/vunit/vhdl/data_types/test/tb_codec.vhd
+++ b/vunit/vhdl/data_types/test/tb_codec.vhd
@@ -105,46 +105,46 @@ begin
     variable range_left, range_right : integer;
 
     -- Helper functions to make tests pass GHDL v0.37
-    function get_range_left ( constant vec: string ) return integer is
+    function get_decoded_range_left ( constant vec: string ) return integer is
     begin return vec'left; end;
 
-    function get_range_right ( constant vec: string ) return integer is
+    function get_decoded_range_right ( constant vec: string ) return integer is
     begin return vec'right; end;
 
-    function get_range_left ( constant vec: bit_vector ) return integer is
+    function get_decoded_range_left ( constant vec: bit_vector ) return integer is
     begin return vec'left; end;
 
-    function get_range_right ( constant vec: bit_vector ) return integer is
+    function get_decoded_range_right ( constant vec: bit_vector ) return integer is
     begin return vec'right; end;
 
-    function get_range_left ( constant vec: std_ulogic_vector ) return integer is
+    function get_decoded_range_left ( constant vec: std_ulogic_vector ) return integer is
     begin return vec'left; end;
 
-    function get_range_right ( constant vec: std_ulogic_vector ) return integer is
+    function get_decoded_range_right ( constant vec: std_ulogic_vector ) return integer is
     begin return vec'right; end;
 
-    function get_range_left ( constant vec: ieee.numeric_bit.unsigned ) return integer is
+    function get_decoded_range_left ( constant vec: ieee.numeric_bit.unsigned ) return integer is
     begin return vec'left; end;
 
-    function get_range_right ( constant vec: ieee.numeric_bit.unsigned ) return integer is
+    function get_decoded_range_right ( constant vec: ieee.numeric_bit.unsigned ) return integer is
     begin return vec'right; end;
 
-    function get_range_left ( constant vec: ieee.numeric_bit.signed ) return integer is
+    function get_decoded_range_left ( constant vec: ieee.numeric_bit.signed ) return integer is
     begin return vec'left; end;
 
-    function get_range_right ( constant vec: ieee.numeric_bit.signed ) return integer is
+    function get_decoded_range_right ( constant vec: ieee.numeric_bit.signed ) return integer is
     begin return vec'right; end;
 
-    function get_range_left ( constant vec: ieee.numeric_std.unsigned ) return integer is
+    function get_decoded_range_left ( constant vec: ieee.numeric_std.unsigned ) return integer is
     begin return vec'left; end;
 
-    function get_range_right ( constant vec: ieee.numeric_std.unsigned ) return integer is
+    function get_decoded_range_right ( constant vec: ieee.numeric_std.unsigned ) return integer is
     begin return vec'right; end;
 
-    function get_range_left ( constant vec: ieee.numeric_std.signed ) return integer is
+    function get_decoded_range_left ( constant vec: ieee.numeric_std.signed ) return integer is
     begin return vec'left; end;
 
-    function get_range_right ( constant vec: ieee.numeric_std.signed ) return integer is
+    function get_decoded_range_right ( constant vec: ieee.numeric_std.signed ) return integer is
     begin return vec'right; end;
 
   begin
@@ -217,13 +217,13 @@ begin
         string_15_downto_4 := "Hello world!";
         check_relation(decode_string(encode_string("The quick brown fox jumps over the lazy dog")) = string'("The quick brown fox jumps over the lazy dog"));
         check_relation(decode_string(encode_string(special_chars)) = string'(special_chars));
-        range_left := get_range_left(decode_string(encode_string(null_string)));
-        range_right := get_range_right(decode_string(encode_string(null_string)));
+        range_left := get_decoded_range_left(decode_string(encode_string(null_string)));
+        range_right := get_decoded_range_right(decode_string(encode_string(null_string)));
         check_relation(range_left = 10);
         check_relation(range_right = 9);
         check_relation(decode_string(encode_string(string_15_downto_4)) = string'("Hello world!"));
-        range_left := get_range_left(decode_string(encode_string(string_15_downto_4)));
-        range_right := get_range_right(decode_string(encode_string(string_15_downto_4)));
+        range_left := get_decoded_range_left(decode_string(encode_string(string_15_downto_4)));
+        range_right := get_decoded_range_right(decode_string(encode_string(string_15_downto_4)));
         check_relation(range_left = 15);
         check_relation(range_right = 4);
       elsif run("Test that bit_vector can be encoded and decoded") then
@@ -232,8 +232,8 @@ begin
         check_relation(decode_bit_vector(encode_bit_vector("1")) = bit_vector'("1"));
         check_relation(decode_bit_vector(encode_bit_vector("")) = bit_vector'(""));
         check_relation(decode_bit_vector(encode_bit_vector(bit_vector_5_downto_3)) = bit_vector'("101"));
-        range_left := get_range_left(decode_bit_vector(encode_bit_vector(bit_vector_5_downto_3)));
-        range_right := get_range_right(decode_bit_vector(encode_bit_vector(bit_vector_5_downto_3)));
+        range_left := get_decoded_range_left(decode_bit_vector(encode_bit_vector(bit_vector_5_downto_3)));
+        range_right := get_decoded_range_right(decode_bit_vector(encode_bit_vector(bit_vector_5_downto_3)));
         check_relation(range_left = 5);
         check_relation(range_right = 3);
       elsif run("Test that std_ulogic_vector can be encoded and decoded") then
@@ -242,8 +242,8 @@ begin
         check_relation(decode_std_ulogic_vector(encode_std_ulogic_vector("X")) = std_ulogic_vector'("X"));
         check_relation(decode_std_ulogic_vector(encode_std_ulogic_vector("")) = std_ulogic_vector'(""));
         check_relation(decode_std_ulogic_vector(encode_std_ulogic_vector(std_ulogic_vector_5_downto_3)) = std_ulogic_vector'("XU1"));
-        range_left := get_range_left(decode_std_ulogic_vector(encode_std_ulogic_vector(std_ulogic_vector_5_downto_3)));
-        range_right := get_range_right(decode_std_ulogic_vector(encode_std_ulogic_vector(std_ulogic_vector_5_downto_3)));
+        range_left := get_decoded_range_left(decode_std_ulogic_vector(encode_std_ulogic_vector(std_ulogic_vector_5_downto_3)));
+        range_right := get_decoded_range_right(decode_std_ulogic_vector(encode_std_ulogic_vector(std_ulogic_vector_5_downto_3)));
         check_relation(range_left = 5);
         check_relation(range_right = 3);
       elsif run("Test that complex can be encoded and decoded") then
@@ -256,8 +256,8 @@ begin
         check_relation(decode_numeric_bit_unsigned(encode_numeric_bit_unsigned("1")) = ieee.numeric_bit.unsigned'("1"));
         check_relation(decode_numeric_bit_unsigned(encode_numeric_bit_unsigned("")) = ieee.numeric_bit.unsigned'(""));
         check_relation(decode_numeric_bit_unsigned(encode_numeric_bit_unsigned(numeric_bit_unsigned_5_downto_3)) = ieee.numeric_bit.unsigned'("101"));
-        range_left := get_range_left(decode_numeric_bit_unsigned(encode_numeric_bit_unsigned(numeric_bit_unsigned_5_downto_3)));
-        range_right := get_range_right(decode_numeric_bit_unsigned(encode_numeric_bit_unsigned(numeric_bit_unsigned_5_downto_3)));
+        range_left := get_decoded_range_left(decode_numeric_bit_unsigned(encode_numeric_bit_unsigned(numeric_bit_unsigned_5_downto_3)));
+        range_right := get_decoded_range_right(decode_numeric_bit_unsigned(encode_numeric_bit_unsigned(numeric_bit_unsigned_5_downto_3)));
         check_relation(range_left = 5);
         check_relation(range_right = 3);
       elsif run("Test that signed from numeric_bit can be encoded and decoded") then
@@ -266,8 +266,8 @@ begin
         check_relation(decode_numeric_bit_signed(encode_numeric_bit_signed("1")) = ieee.numeric_bit.signed'("1"));
         check_relation(decode_numeric_bit_signed(encode_numeric_bit_signed("")) = ieee.numeric_bit.signed'(""));
         check_relation(decode_numeric_bit_signed(encode_numeric_bit_signed(numeric_bit_signed_5_downto_3)) = ieee.numeric_bit.signed'("101"));
-        range_left := get_range_left(decode_numeric_bit_signed(encode_numeric_bit_signed(numeric_bit_signed_5_downto_3)));
-        range_right := get_range_right(decode_numeric_bit_signed(encode_numeric_bit_signed(numeric_bit_signed_5_downto_3)));
+        range_left := get_decoded_range_left(decode_numeric_bit_signed(encode_numeric_bit_signed(numeric_bit_signed_5_downto_3)));
+        range_right := get_decoded_range_right(decode_numeric_bit_signed(encode_numeric_bit_signed(numeric_bit_signed_5_downto_3)));
         check_relation(range_left = 5);
         check_relation(range_right = 3);
       elsif run("Test that unsigned from numeric_std can be encoded and decoded") then
@@ -276,8 +276,8 @@ begin
         check_relation(decode_numeric_std_unsigned(encode_numeric_std_unsigned("1")) = ieee.numeric_std.unsigned'("1"));
         check_relation(decode_numeric_std_unsigned(encode_numeric_std_unsigned("")) = ieee.numeric_std.unsigned'(""));
         check_relation(decode_numeric_std_unsigned(encode_numeric_std_unsigned(numeric_std_unsigned_5_downto_3)) = ieee.numeric_std.unsigned'("101"));
-        range_left := get_range_left(decode_numeric_std_unsigned(encode_numeric_std_unsigned(numeric_std_unsigned_5_downto_3)));
-        range_right := get_range_right(decode_numeric_std_unsigned(encode_numeric_std_unsigned(numeric_std_unsigned_5_downto_3)));
+        range_left := get_decoded_range_left(decode_numeric_std_unsigned(encode_numeric_std_unsigned(numeric_std_unsigned_5_downto_3)));
+        range_right := get_decoded_range_right(decode_numeric_std_unsigned(encode_numeric_std_unsigned(numeric_std_unsigned_5_downto_3)));
         check_relation(range_left = 5);
         check_relation(range_right = 3);
       elsif run("Test that signed from numeric_std can be encoded and decoded") then
@@ -286,8 +286,8 @@ begin
         check_relation(decode_numeric_std_signed(encode_numeric_std_signed("1")) = ieee.numeric_std.signed'("1"));
         check_relation(decode_numeric_std_signed(encode_numeric_std_signed("")) = ieee.numeric_std.signed'(""));
         check_relation(decode_numeric_std_signed(encode_numeric_std_signed(numeric_std_signed_5_downto_3)) = ieee.numeric_std.signed'("101"));
-        range_left := get_range_left(decode_numeric_std_signed(encode_numeric_std_signed(numeric_std_signed_5_downto_3)));
-        range_right := get_range_right(decode_numeric_std_signed(encode_numeric_std_signed(numeric_std_signed_5_downto_3)));
+        range_left := get_decoded_range_left(decode_numeric_std_signed(encode_numeric_std_signed(numeric_std_signed_5_downto_3)));
+        range_right := get_decoded_range_right(decode_numeric_std_signed(encode_numeric_std_signed(numeric_std_signed_5_downto_3)));
         check_relation(range_left = 5);
         check_relation(range_right = 3);
       end if;

--- a/vunit/vhdl/data_types/test/tb_codec.vhd
+++ b/vunit/vhdl/data_types/test/tb_codec.vhd
@@ -101,10 +101,7 @@ begin
     variable numeric_std_unsigned_5_downto_3 : ieee.numeric_std.unsigned(5 downto 3);
     variable numeric_std_signed_5_downto_3 : ieee.numeric_std.signed(5 downto 3);
 
-    -- Temp variables to make tests pass Riviera-PRO 2016.10
-    variable range_left, range_right : integer;
-
-    -- Helper functions to make tests pass GHDL v0.37
+    -- Helper functions to make tests pass GHDL v0.37 and Riviera-PRO 2016.10
     function get_decoded_range_left ( constant vec: string ) return integer is
     begin return vec'left; end;
 
@@ -217,35 +214,27 @@ begin
         string_15_downto_4 := "Hello world!";
         check_relation(decode_string(encode_string("The quick brown fox jumps over the lazy dog")) = string'("The quick brown fox jumps over the lazy dog"));
         check_relation(decode_string(encode_string(special_chars)) = string'(special_chars));
-        range_left := get_decoded_range_left(decode_string(encode_string(null_string)));
-        range_right := get_decoded_range_right(decode_string(encode_string(null_string)));
-        check_relation(range_left = 10);
-        check_relation(range_right = 9);
+        check_relation(get_decoded_range_left(decode_string(encode_string(null_string))) = 10);
+        check_relation(get_decoded_range_right(decode_string(encode_string(null_string))) = 9);
         check_relation(decode_string(encode_string(string_15_downto_4)) = string'("Hello world!"));
-        range_left := get_decoded_range_left(decode_string(encode_string(string_15_downto_4)));
-        range_right := get_decoded_range_right(decode_string(encode_string(string_15_downto_4)));
-        check_relation(range_left = 15);
-        check_relation(range_right = 4);
+        check_relation(get_decoded_range_left(decode_string(encode_string(string_15_downto_4))) = 15);
+        check_relation(get_decoded_range_right(decode_string(encode_string(string_15_downto_4))) = 4);
       elsif run("Test that bit_vector can be encoded and decoded") then
         bit_vector_5_downto_3 := "101";
         check_relation(decode_bit_vector(encode_bit_vector("101")) = bit_vector'("101"));
         check_relation(decode_bit_vector(encode_bit_vector("1")) = bit_vector'("1"));
         check_relation(decode_bit_vector(encode_bit_vector("")) = bit_vector'(""));
         check_relation(decode_bit_vector(encode_bit_vector(bit_vector_5_downto_3)) = bit_vector'("101"));
-        range_left := get_decoded_range_left(decode_bit_vector(encode_bit_vector(bit_vector_5_downto_3)));
-        range_right := get_decoded_range_right(decode_bit_vector(encode_bit_vector(bit_vector_5_downto_3)));
-        check_relation(range_left = 5);
-        check_relation(range_right = 3);
+        check_relation(get_decoded_range_left(decode_bit_vector(encode_bit_vector(bit_vector_5_downto_3))) = 5);
+        check_relation(get_decoded_range_right(decode_bit_vector(encode_bit_vector(bit_vector_5_downto_3))) = 3);
       elsif run("Test that std_ulogic_vector can be encoded and decoded") then
         std_ulogic_vector_5_downto_3 := "XU1";
         check_relation(decode_std_ulogic_vector(encode_std_ulogic_vector("XU1")) = std_ulogic_vector'("XU1"));
         check_relation(decode_std_ulogic_vector(encode_std_ulogic_vector("X")) = std_ulogic_vector'("X"));
         check_relation(decode_std_ulogic_vector(encode_std_ulogic_vector("")) = std_ulogic_vector'(""));
         check_relation(decode_std_ulogic_vector(encode_std_ulogic_vector(std_ulogic_vector_5_downto_3)) = std_ulogic_vector'("XU1"));
-        range_left := get_decoded_range_left(decode_std_ulogic_vector(encode_std_ulogic_vector(std_ulogic_vector_5_downto_3)));
-        range_right := get_decoded_range_right(decode_std_ulogic_vector(encode_std_ulogic_vector(std_ulogic_vector_5_downto_3)));
-        check_relation(range_left = 5);
-        check_relation(range_right = 3);
+        check_relation(get_decoded_range_left(decode_std_ulogic_vector(encode_std_ulogic_vector(std_ulogic_vector_5_downto_3))) = 5);
+        check_relation(get_decoded_range_right(decode_std_ulogic_vector(encode_std_ulogic_vector(std_ulogic_vector_5_downto_3))) = 3);
       elsif run("Test that complex can be encoded and decoded") then
         check_relation(decode_complex(encode_complex((-17.17, 42.42))) = complex'(-17.17, 42.42));
       elsif run("Test that complex_polar can be encoded and decoded") then
@@ -256,40 +245,32 @@ begin
         check_relation(decode_numeric_bit_unsigned(encode_numeric_bit_unsigned("1")) = ieee.numeric_bit.unsigned'("1"));
         check_relation(decode_numeric_bit_unsigned(encode_numeric_bit_unsigned("")) = ieee.numeric_bit.unsigned'(""));
         check_relation(decode_numeric_bit_unsigned(encode_numeric_bit_unsigned(numeric_bit_unsigned_5_downto_3)) = ieee.numeric_bit.unsigned'("101"));
-        range_left := get_decoded_range_left(decode_numeric_bit_unsigned(encode_numeric_bit_unsigned(numeric_bit_unsigned_5_downto_3)));
-        range_right := get_decoded_range_right(decode_numeric_bit_unsigned(encode_numeric_bit_unsigned(numeric_bit_unsigned_5_downto_3)));
-        check_relation(range_left = 5);
-        check_relation(range_right = 3);
+        check_relation(get_decoded_range_left(decode_numeric_bit_unsigned(encode_numeric_bit_unsigned(numeric_bit_unsigned_5_downto_3))) = 5);
+        check_relation(get_decoded_range_right(decode_numeric_bit_unsigned(encode_numeric_bit_unsigned(numeric_bit_unsigned_5_downto_3))) = 3);
       elsif run("Test that signed from numeric_bit can be encoded and decoded") then
         numeric_bit_signed_5_downto_3 := "101";
         check_relation(decode_numeric_bit_signed(encode_numeric_bit_signed("101")) = ieee.numeric_bit.signed'("101"));
         check_relation(decode_numeric_bit_signed(encode_numeric_bit_signed("1")) = ieee.numeric_bit.signed'("1"));
         check_relation(decode_numeric_bit_signed(encode_numeric_bit_signed("")) = ieee.numeric_bit.signed'(""));
         check_relation(decode_numeric_bit_signed(encode_numeric_bit_signed(numeric_bit_signed_5_downto_3)) = ieee.numeric_bit.signed'("101"));
-        range_left := get_decoded_range_left(decode_numeric_bit_signed(encode_numeric_bit_signed(numeric_bit_signed_5_downto_3)));
-        range_right := get_decoded_range_right(decode_numeric_bit_signed(encode_numeric_bit_signed(numeric_bit_signed_5_downto_3)));
-        check_relation(range_left = 5);
-        check_relation(range_right = 3);
+        check_relation(get_decoded_range_left(decode_numeric_bit_signed(encode_numeric_bit_signed(numeric_bit_signed_5_downto_3))) = 5);
+        check_relation(get_decoded_range_right(decode_numeric_bit_signed(encode_numeric_bit_signed(numeric_bit_signed_5_downto_3))) = 3);
       elsif run("Test that unsigned from numeric_std can be encoded and decoded") then
         numeric_std_unsigned_5_downto_3 := "101";
         check_relation(decode_numeric_std_unsigned(encode_numeric_std_unsigned("101")) = ieee.numeric_std.unsigned'("101"));
         check_relation(decode_numeric_std_unsigned(encode_numeric_std_unsigned("1")) = ieee.numeric_std.unsigned'("1"));
         check_relation(decode_numeric_std_unsigned(encode_numeric_std_unsigned("")) = ieee.numeric_std.unsigned'(""));
         check_relation(decode_numeric_std_unsigned(encode_numeric_std_unsigned(numeric_std_unsigned_5_downto_3)) = ieee.numeric_std.unsigned'("101"));
-        range_left := get_decoded_range_left(decode_numeric_std_unsigned(encode_numeric_std_unsigned(numeric_std_unsigned_5_downto_3)));
-        range_right := get_decoded_range_right(decode_numeric_std_unsigned(encode_numeric_std_unsigned(numeric_std_unsigned_5_downto_3)));
-        check_relation(range_left = 5);
-        check_relation(range_right = 3);
+        check_relation(get_decoded_range_left(decode_numeric_std_unsigned(encode_numeric_std_unsigned(numeric_std_unsigned_5_downto_3))) = 5);
+        check_relation(get_decoded_range_right(decode_numeric_std_unsigned(encode_numeric_std_unsigned(numeric_std_unsigned_5_downto_3))) = 3);
       elsif run("Test that signed from numeric_std can be encoded and decoded") then
         numeric_std_signed_5_downto_3 := "101";
         check_relation(decode_numeric_std_signed(encode_numeric_std_signed("101")) = ieee.numeric_std.signed'("101"));
         check_relation(decode_numeric_std_signed(encode_numeric_std_signed("1")) = ieee.numeric_std.signed'("1"));
         check_relation(decode_numeric_std_signed(encode_numeric_std_signed("")) = ieee.numeric_std.signed'(""));
         check_relation(decode_numeric_std_signed(encode_numeric_std_signed(numeric_std_signed_5_downto_3)) = ieee.numeric_std.signed'("101"));
-        range_left := get_decoded_range_left(decode_numeric_std_signed(encode_numeric_std_signed(numeric_std_signed_5_downto_3)));
-        range_right := get_decoded_range_right(decode_numeric_std_signed(encode_numeric_std_signed(numeric_std_signed_5_downto_3)));
-        check_relation(range_left = 5);
-        check_relation(range_right = 3);
+        check_relation(get_decoded_range_left(decode_numeric_std_signed(encode_numeric_std_signed(numeric_std_signed_5_downto_3))) = 5);
+        check_relation(get_decoded_range_right(decode_numeric_std_signed(encode_numeric_std_signed(numeric_std_signed_5_downto_3))) = 3);
       end if;
     end loop;
 

--- a/vunit/vhdl/data_types/test/tb_codec.vhd
+++ b/vunit/vhdl/data_types/test/tb_codec.vhd
@@ -101,8 +101,51 @@ begin
     variable numeric_std_unsigned_5_downto_3 : ieee.numeric_std.unsigned(5 downto 3);
     variable numeric_std_signed_5_downto_3 : ieee.numeric_std.signed(5 downto 3);
 
-    -- Temp variables to make test case pass Riviera-PRO 2016.10
+    -- Temp variables to make tests pass Riviera-PRO 2016.10
     variable range_left, range_right : integer;
+
+    -- Helper functions to make tests pass GHDL v0.37
+    function get_range_left ( constant vec: string ) return integer is
+    begin return vec'left; end;
+
+    function get_range_right ( constant vec: string ) return integer is
+    begin return vec'right; end;
+
+    function get_range_left ( constant vec: bit_vector ) return integer is
+    begin return vec'left; end;
+
+    function get_range_right ( constant vec: bit_vector ) return integer is
+    begin return vec'right; end;
+
+    function get_range_left ( constant vec: std_ulogic_vector ) return integer is
+    begin return vec'left; end;
+
+    function get_range_right ( constant vec: std_ulogic_vector ) return integer is
+    begin return vec'right; end;
+
+    function get_range_left ( constant vec: ieee.numeric_bit.unsigned ) return integer is
+    begin return vec'left; end;
+
+    function get_range_right ( constant vec: ieee.numeric_bit.unsigned ) return integer is
+    begin return vec'right; end;
+
+    function get_range_left ( constant vec: ieee.numeric_bit.signed ) return integer is
+    begin return vec'left; end;
+
+    function get_range_right ( constant vec: ieee.numeric_bit.signed ) return integer is
+    begin return vec'right; end;
+
+    function get_range_left ( constant vec: ieee.numeric_std.unsigned ) return integer is
+    begin return vec'left; end;
+
+    function get_range_right ( constant vec: ieee.numeric_std.unsigned ) return integer is
+    begin return vec'right; end;
+
+    function get_range_left ( constant vec: ieee.numeric_std.signed ) return integer is
+    begin return vec'left; end;
+
+    function get_range_right ( constant vec: ieee.numeric_std.signed ) return integer is
+    begin return vec'right; end;
 
   begin
     test_runner_setup(runner, runner_cfg);
@@ -174,13 +217,13 @@ begin
         string_15_downto_4 := "Hello world!";
         check_relation(decode_string(encode_string("The quick brown fox jumps over the lazy dog")) = string'("The quick brown fox jumps over the lazy dog"));
         check_relation(decode_string(encode_string(special_chars)) = string'(special_chars));
-        range_left := decode_string(encode_string(null_string))'left;
-        range_right := decode_string(encode_string(null_string))'right;
+        range_left := get_range_left(decode_string(encode_string(null_string)));
+        range_right := get_range_right(decode_string(encode_string(null_string)));
         check_relation(range_left = 10);
         check_relation(range_right = 9);
         check_relation(decode_string(encode_string(string_15_downto_4)) = string'("Hello world!"));
-        range_left := decode_string(encode_string(string_15_downto_4))'left;
-        range_right := decode_string(encode_string(string_15_downto_4))'right;
+        range_left := get_range_left(decode_string(encode_string(string_15_downto_4)));
+        range_right := get_range_right(decode_string(encode_string(string_15_downto_4)));
         check_relation(range_left = 15);
         check_relation(range_right = 4);
       elsif run("Test that bit_vector can be encoded and decoded") then
@@ -189,8 +232,8 @@ begin
         check_relation(decode_bit_vector(encode_bit_vector("1")) = bit_vector'("1"));
         check_relation(decode_bit_vector(encode_bit_vector("")) = bit_vector'(""));
         check_relation(decode_bit_vector(encode_bit_vector(bit_vector_5_downto_3)) = bit_vector'("101"));
-        range_left := decode_bit_vector(encode_bit_vector(bit_vector_5_downto_3))'left;
-        range_right := decode_bit_vector(encode_bit_vector(bit_vector_5_downto_3))'right;
+        range_left := get_range_left(decode_bit_vector(encode_bit_vector(bit_vector_5_downto_3)));
+        range_right := get_range_right(decode_bit_vector(encode_bit_vector(bit_vector_5_downto_3)));
         check_relation(range_left = 5);
         check_relation(range_right = 3);
       elsif run("Test that std_ulogic_vector can be encoded and decoded") then
@@ -199,8 +242,8 @@ begin
         check_relation(decode_std_ulogic_vector(encode_std_ulogic_vector("X")) = std_ulogic_vector'("X"));
         check_relation(decode_std_ulogic_vector(encode_std_ulogic_vector("")) = std_ulogic_vector'(""));
         check_relation(decode_std_ulogic_vector(encode_std_ulogic_vector(std_ulogic_vector_5_downto_3)) = std_ulogic_vector'("XU1"));
-        range_left := decode_std_ulogic_vector(encode_std_ulogic_vector(std_ulogic_vector_5_downto_3))'left;
-        range_right := decode_std_ulogic_vector(encode_std_ulogic_vector(std_ulogic_vector_5_downto_3))'right;
+        range_left := get_range_left(decode_std_ulogic_vector(encode_std_ulogic_vector(std_ulogic_vector_5_downto_3)));
+        range_right := get_range_right(decode_std_ulogic_vector(encode_std_ulogic_vector(std_ulogic_vector_5_downto_3)));
         check_relation(range_left = 5);
         check_relation(range_right = 3);
       elsif run("Test that complex can be encoded and decoded") then
@@ -213,8 +256,8 @@ begin
         check_relation(decode_numeric_bit_unsigned(encode_numeric_bit_unsigned("1")) = ieee.numeric_bit.unsigned'("1"));
         check_relation(decode_numeric_bit_unsigned(encode_numeric_bit_unsigned("")) = ieee.numeric_bit.unsigned'(""));
         check_relation(decode_numeric_bit_unsigned(encode_numeric_bit_unsigned(numeric_bit_unsigned_5_downto_3)) = ieee.numeric_bit.unsigned'("101"));
-        range_left := decode_numeric_bit_unsigned(encode_numeric_bit_unsigned(numeric_bit_unsigned_5_downto_3))'left;
-        range_right := decode_numeric_bit_unsigned(encode_numeric_bit_unsigned(numeric_bit_unsigned_5_downto_3))'right;
+        range_left := get_range_left(decode_numeric_bit_unsigned(encode_numeric_bit_unsigned(numeric_bit_unsigned_5_downto_3)));
+        range_right := get_range_right(decode_numeric_bit_unsigned(encode_numeric_bit_unsigned(numeric_bit_unsigned_5_downto_3)));
         check_relation(range_left = 5);
         check_relation(range_right = 3);
       elsif run("Test that signed from numeric_bit can be encoded and decoded") then
@@ -223,8 +266,8 @@ begin
         check_relation(decode_numeric_bit_signed(encode_numeric_bit_signed("1")) = ieee.numeric_bit.signed'("1"));
         check_relation(decode_numeric_bit_signed(encode_numeric_bit_signed("")) = ieee.numeric_bit.signed'(""));
         check_relation(decode_numeric_bit_signed(encode_numeric_bit_signed(numeric_bit_signed_5_downto_3)) = ieee.numeric_bit.signed'("101"));
-        range_left := decode_numeric_bit_signed(encode_numeric_bit_signed(numeric_bit_signed_5_downto_3))'left;
-        range_right := decode_numeric_bit_signed(encode_numeric_bit_signed(numeric_bit_signed_5_downto_3))'right;
+        range_left := get_range_left(decode_numeric_bit_signed(encode_numeric_bit_signed(numeric_bit_signed_5_downto_3)));
+        range_right := get_range_right(decode_numeric_bit_signed(encode_numeric_bit_signed(numeric_bit_signed_5_downto_3)));
         check_relation(range_left = 5);
         check_relation(range_right = 3);
       elsif run("Test that unsigned from numeric_std can be encoded and decoded") then
@@ -233,8 +276,8 @@ begin
         check_relation(decode_numeric_std_unsigned(encode_numeric_std_unsigned("1")) = ieee.numeric_std.unsigned'("1"));
         check_relation(decode_numeric_std_unsigned(encode_numeric_std_unsigned("")) = ieee.numeric_std.unsigned'(""));
         check_relation(decode_numeric_std_unsigned(encode_numeric_std_unsigned(numeric_std_unsigned_5_downto_3)) = ieee.numeric_std.unsigned'("101"));
-        range_left := decode_numeric_std_unsigned(encode_numeric_std_unsigned(numeric_std_unsigned_5_downto_3))'left;
-        range_right := decode_numeric_std_unsigned(encode_numeric_std_unsigned(numeric_std_unsigned_5_downto_3))'right;
+        range_left := get_range_left(decode_numeric_std_unsigned(encode_numeric_std_unsigned(numeric_std_unsigned_5_downto_3)));
+        range_right := get_range_right(decode_numeric_std_unsigned(encode_numeric_std_unsigned(numeric_std_unsigned_5_downto_3)));
         check_relation(range_left = 5);
         check_relation(range_right = 3);
       elsif run("Test that signed from numeric_std can be encoded and decoded") then
@@ -243,8 +286,8 @@ begin
         check_relation(decode_numeric_std_signed(encode_numeric_std_signed("1")) = ieee.numeric_std.signed'("1"));
         check_relation(decode_numeric_std_signed(encode_numeric_std_signed("")) = ieee.numeric_std.signed'(""));
         check_relation(decode_numeric_std_signed(encode_numeric_std_signed(numeric_std_signed_5_downto_3)) = ieee.numeric_std.signed'("101"));
-        range_left := decode_numeric_std_signed(encode_numeric_std_signed(numeric_std_signed_5_downto_3))'left;
-        range_right := decode_numeric_std_signed(encode_numeric_std_signed(numeric_std_signed_5_downto_3))'right;
+        range_left := get_range_left(decode_numeric_std_signed(encode_numeric_std_signed(numeric_std_signed_5_downto_3)));
+        range_right := get_range_right(decode_numeric_std_signed(encode_numeric_std_signed(numeric_std_signed_5_downto_3)));
         check_relation(range_left = 5);
         check_relation(range_right = 3);
       end if;


### PR DESCRIPTION
A change in v0.37 made some of the tests in VUnit fail. #631 fixed some of them, but four are still failing:

```
tests/acceptance/test_external_run_scripts.py::TestExternalRunScripts::test_com_vhdl_2008
tests/acceptance/test_external_run_scripts.py::TestExternalRunScripts::test_data_types_vhdl_2002
tests/acceptance/test_external_run_scripts.py::TestExternalRunScripts::test_data_types_vhdl_2008
tests/acceptance/test_external_run_scripts.py::TestExternalRunScripts::test_data_types_vhdl_93
```

According to ghdl/ghdl#1152, this is something that needs to be fixed in VUnit's codebase.

In this PR, helper functions `get_encoded_length`, `get_decoded_range_right` and `get_decoded_range_left` are added. These replace existing helper vars `range_left` and `range_right` that were used for RivieraPRO.

To do:

- [ ] Should these helper functions be defined elsewhere?
- [x] Do tests pass in RivieraPRO?