### PR TITLE
call supports_coverage() rather than returning method object

### DIFF
--- a/vunit/ui/__init__.py
+++ b/vunit/ui/__init__.py
@@ -1108,4 +1108,4 @@ avoid location preprocessing of other functions sharing name with a VUnit log or
         """
         if self._simulator_class is None:
             return None
-        return self._simulator_class.supports_coverage
+        return self._simulator_class.supports_coverage()


### PR DESCRIPTION
Previously the method was returned rather than a boolean. So doing 

```python
if vunit_proj.simulator_supports_coverage():
    ...
```

in run.py would always evaluate as True.

`supports_coverage` is a static method or a class method in all the simulator interfaces. Never a property.