### PR TITLE
update example 'vhdl/array_axis_vcs'

### DIFF
--- a/examples/vhdl/array_axis_vcs/src/fifo.vhd
+++ b/examples/vhdl/array_axis_vcs/src/fifo.vhd
@@ -35,27 +35,17 @@ architecture arch of fifo is
 
 begin
 
--- Assertions
-  process(clkw, clkr)
+  PslChecks : block is
     constant dx : std_logic_vector(d'left downto 0) := (others => 'X');
     constant du : std_logic_vector(d'left downto 0) := (others => 'U');
   begin
-    if rising_edge(clkw) then
-      if ( wr and ( d?=dx or d?=du ) ) then
-        assert false report "wrote X|U to fIfO" severity failure;
-      end if;
-      if (f and wr) then
-        assert false report "wrote to fIfO while full" severity failure;
-      end if;
-    end if;
-    if rising_edge(clkr) then
-      if (e and rd) then
-        assert false report "Read from fIfO while empty" severity failure;
-      end if;
-    end if;
-  end process;
-
---
+    assert always (not rst and wr -> not (d ?= dx or d ?= du))@rising_edge(clkw)
+      report "wrote X|U to FIFO";
+    assert always (not rst and f -> not wr)@rising_edge(clkw)
+      report "Wrote to FIFO while full";
+    assert always (not rst and e -> not rd)@rising_edge(clkr)
+      report "Read from FIFO while empty";
+  end block PslChecks;
 
   process(clkw) begin
     if rising_edge(clkw) then

--- a/examples/vhdl/array_axis_vcs/src/test/tb_axis_loop.vhd
+++ b/examples/vhdl/array_axis_vcs/src/test/tb_axis_loop.vhd
@@ -39,11 +39,6 @@ architecture tb of tb_axis_loop is
   constant master_axi_stream : axi_stream_master_t := new_axi_stream_master(data_length => data_width);
   constant slave_axi_stream  : axi_stream_slave_t  := new_axi_stream_slave(data_length => data_width);
 
-  -- Signals to/from the UUT from/to the verification components
-
-  signal m_valid, m_ready, m_last, s_valid, s_ready, s_last : std_logic;
-  signal m_data, s_data : std_logic_vector(data_length(master_axi_stream)-1 downto 0);
-
   -- tb signals and variables
 
   signal clk, rst, rstn : std_logic := '0';
@@ -134,53 +129,15 @@ begin
 
 --
 
-  vunit_axism: entity vunit_lib.axi_stream_master
+  uut_vc: entity work.vc_axis
   generic map (
-    master => master_axi_stream
+    m_axis => master_axi_stream,
+    s_axis => slave_axi_stream,
+    data_width => data_width
   )
   port map (
-    aclk   => clk,
-    tvalid => m_valid,
-    tready => m_ready,
-    tdata  => m_data,
-    tlast  => m_last
-  );
-
-  vunit_axiss: entity vunit_lib.axi_stream_slave
-  generic map (
-    slave => slave_axi_stream
-  )
-  port map (
-    aclk   => clk,
-    tvalid => s_valid,
-    tready => s_ready,
-    tdata  => s_data,
-    tlast  => s_last
-  );
-
---
-
-  uut: entity work.axis_buffer
-  generic map (
-    data_width => data_width,
-    fifo_depth => 4
-  )
-  port map (
-    s_axis_clk   => clk,
-    s_axis_rstn  => rstn,
-    s_axis_rdy   => m_ready,
-    s_axis_data  => m_data,
-    s_axis_valid => m_valid,
-    s_axis_strb  => "1111",
-    s_axis_last  => m_last,
-
-    m_axis_clk   => clk,
-    m_axis_rstn  => rstn,
-    m_axis_valid => s_valid,
-    m_axis_data  => s_data,
-    m_axis_rdy   => s_ready,
-    m_axis_strb  => open,
-    m_axis_last  => s_last
+    clk  => clk,
+    rstn => rstn
   );
 
 end architecture;

--- a/examples/vhdl/array_axis_vcs/src/test/vc_axis.vhd
+++ b/examples/vhdl/array_axis_vcs/src/test/vc_axis.vhd
@@ -1,0 +1,82 @@
+-- This Source Code Form is subject to the terms of the Mozilla Public
+-- License, v. 2.0. If a copy of the MPL was not distributed with this file,
+-- You can obtain one at http://mozilla.org/MPL/2.0/.
+--
+-- Copyright (c) 2014-2020, Lars Asplund lars.anders.asplund@gmail.com
+
+library ieee;
+context ieee.ieee_std_context;
+
+library vunit_lib;
+context vunit_lib.vunit_context;
+context vunit_lib.vc_context;
+
+entity vc_axis is
+  generic (
+    m_axis : axi_stream_master_t;
+    s_axis : axi_stream_slave_t;
+    data_width : natural := 32;
+    fifo_depth : natural := 4
+  );
+  port (
+    clk, rstn: in std_logic
+  );
+end entity;
+
+architecture arch of vc_axis is
+
+  signal m_valid, m_ready, m_last, s_valid, s_ready, s_last : std_logic;
+  signal m_data, s_data : std_logic_vector(data_length(m_axis)-1 downto 0);
+
+begin
+
+  vunit_axism: entity vunit_lib.axi_stream_master
+  generic map (
+    master => m_axis
+  )
+  port map (
+    aclk   => clk,
+    tvalid => m_valid,
+    tready => m_ready,
+    tdata  => m_data,
+    tlast  => m_last
+  );
+
+  vunit_axiss: entity vunit_lib.axi_stream_slave
+  generic map (
+    slave => s_axis
+  )
+  port map (
+    aclk   => clk,
+    tvalid => s_valid,
+    tready => s_ready,
+    tdata  => s_data,
+    tlast  => s_last
+  );
+
+--
+
+  uut: entity work.axis_buffer
+  generic map (
+    data_width => data_width,
+    fifo_depth => fifo_depth
+  )
+  port map (
+    s_axis_clk   => clk,
+    s_axis_rstn  => rstn,
+    s_axis_rdy   => m_ready,
+    s_axis_data  => m_data,
+    s_axis_valid => m_valid,
+    s_axis_strb  => "1111",
+    s_axis_last  => m_last,
+
+    m_axis_clk   => clk,
+    m_axis_rstn  => rstn,
+    m_axis_valid => s_valid,
+    m_axis_data  => s_data,
+    m_axis_rdy   => s_ready,
+    m_axis_strb  => open,
+    m_axis_last  => s_last
+  );
+
+end architecture;


### PR DESCRIPTION
In this PR, example `array_axis_vcs` is enhanced with some ideas from https://github.com/ghdl/ghdl-cosim/tree/master/vhpidirect/arrays/matrices/vunit_axis_vcs (see also https://ghdl.github.io/ghdl-cosim/vhpidirect/examples/arrays.html#array-and-axi4-stream-verification-components).

On the one hand, PSL checks are used instead of plain assertions (contributed by @tmeissner). On the other hand, a file is used to wrap the UUT and the verification components, so that the testbench is cleaner.