### PR TITLE
fix riviera pro coverage merge error

### DIFF
--- a/vunit/sim_if/rivierapro.py
+++ b/vunit/sim_if/rivierapro.py
@@ -429,7 +429,7 @@ proc _vunit_sim_restart {} {
             str(Path(self._prefix) / "vsim"),
             "-c",
             "-do",
-            "source %s; quit;" % merge_script_name.replace("\\", "/"),
+            "source {%s}; quit;" % merge_script_name.replace("\\", "/"),
         ]
 
         print("Merging coverage files into %s..." % file_name)


### PR DESCRIPTION
Added braces around the acdb_merge.tcl file path for the case that the path contains spaces (e.g. `C:/Program Files (x86)/Jenkins/workspace/crown-fpga/fpga/projects/crown/sim/vunit_out/rivierapro/acdb_merge.tcl`).