### PR TITLE
Workaround for empty macro issue in Riviera-PRO

### DIFF
--- a/vunit/sim_if/rivierapro.py
+++ b/vunit/sim_if/rivierapro.py
@@ -210,7 +210,10 @@ class RivieraProInterface(VsimSimulatorMixin, SimulatorInterface):
         for include_dir in source_file.include_dirs:
             args += ["+incdir+%s" % include_dir]
         for key, value in source_file.defines.items():
-            args += ["+define+%s=%s" % (key, value)]
+            if value != "":
+               args += ["+define+%s=%s" % (key, value)]
+            else:
+               args += ["+define+%s" % (key)]
         return args
 
     def create_library(self, library_name, path, mapped_libraries=None):

--- a/vunit/sim_if/rivierapro.py
+++ b/vunit/sim_if/rivierapro.py
@@ -210,10 +210,9 @@ class RivieraProInterface(VsimSimulatorMixin, SimulatorInterface):
         for include_dir in source_file.include_dirs:
             args += ["+incdir+%s" % include_dir]
         for key, value in source_file.defines.items():
-            if value != "":
-               args += ["+define+%s=%s" % (key, value)]
-            else:
-               args += ["+define+%s" % (key)]
+            args += ["+define+%s" % key]
+            if value:
+                args[-1] += "=%s" % value
         return args
 
     def create_library(self, library_name, path, mapped_libraries=None):


### PR DESCRIPTION
When you add sources and create empty macro like following:
`VU.add_library("tb_uart_lib").add_source_files(SRC_PATH / "test" / "*.sv", defines={"EMPTY_MACRO" : ""})`

It adds to vlog command a following switch:
`vlog +define+EMPTY_MACRO=`

However in Riviera-PRO it ends with following error:
`ERROR VCP0501 "Missing option argument in command line. Option -dv requires an argument."`

To workaround this you need to remove '=' operator when macro has no value.

