### PR TITLE
Make runner.create_output_path a member of TestRunner class

### DIFF
--- a/tests/unit/test_test_runner.py
+++ b/tests/unit/test_test_runner.py
@@ -37,9 +37,9 @@ class TestTestRunner(unittest.TestCase):
         test_list.add_test(test_case2)
         test_list.add_test(test_case3)
         runner.run(test_list)
-        self.assertEqual(test_case1.output_path, runner._create_output_path("test1"))
-        self.assertEqual(test_case2.output_path, runner._create_output_path("test2"))
-        self.assertEqual(test_case3.output_path, runner._create_output_path("test3"))
+        self.assertEqual(test_case1.output_path, runner._get_output_path("test1"))
+        self.assertEqual(test_case2.output_path, runner._get_output_path("test2"))
+        self.assertEqual(test_case3.output_path, runner._get_output_path("test3"))
         self.assertEqual(order, ["test1", "test2", "test3"])
         self.assertTrue(report.result_of("test1").passed)
         self.assertTrue(report.result_of("test2").failed)
@@ -62,8 +62,8 @@ class TestTestRunner(unittest.TestCase):
             runner.run(test_list)
         except KeyboardInterrupt:
             pass
-        self.assertEqual(test_case1.output_path, runner._create_output_path("test1"))
-        self.assertEqual(test_case2.output_path, runner._create_output_path("test2"))
+        self.assertEqual(test_case1.output_path, runner._get_output_path("test1"))
+        self.assertEqual(test_case2.output_path, runner._get_output_path("test2"))
         self.assertEqual(test_case3.called, False)
         self.assertEqual(order, ["test1", "test2"])
         self.assertTrue(report.result_of("test1").passed)
@@ -135,7 +135,7 @@ class TestTestRunner(unittest.TestCase):
         self.assertTrue(report.result_of("test").passed)
         self.assertEqual(report.result_of("test").output, "out1out2out3out4out5")
 
-    def test_create_output_path_on_linux(self):
+    def test_get_output_path_on_linux(self):
         output_path = "output_path"
         report = TestReport()
         runner = TestRunner(report, output_path)
@@ -143,7 +143,7 @@ class TestTestRunner(unittest.TestCase):
         with mock.patch("sys.platform", new="linux"):
             with mock.patch("os.environ", new={}):
                 test_name = "_" * 400
-                test_output = runner._create_output_path(test_name)
+                test_output = runner._get_output_path(test_name)
                 self.assertEqual(
                     test_output,
                     str(
@@ -154,7 +154,7 @@ class TestTestRunner(unittest.TestCase):
 
                 output_path = "output_path"
                 test_name = "123._-+"
-                test_output = runner._create_output_path(test_name)
+                test_output = runner._get_output_path(test_name)
                 self.assertEqual(
                     test_output,
                     str(
@@ -166,7 +166,7 @@ class TestTestRunner(unittest.TestCase):
                 output_path = "output_path"
                 test_name = "#<>:"
                 safe_name = "____"
-                test_output = runner._create_output_path(test_name)
+                test_output = runner._get_output_path(test_name)
                 self.assertEqual(
                     test_output,
                     str(
@@ -175,7 +175,7 @@ class TestTestRunner(unittest.TestCase):
                     ),
                 )
 
-    def test_create_output_path_on_windows(self):
+    def test_get_output_path_on_windows(self):
         output_path = "output_path"
         report = TestReport()
         runner = TestRunner(report, output_path)
@@ -183,7 +183,7 @@ class TestTestRunner(unittest.TestCase):
         with mock.patch("sys.platform", new="win32"):
             with mock.patch("os.environ", new={}):
                 test_name = "_" * 400
-                test_output = runner._create_output_path(test_name)
+                test_output = runner._get_output_path(test_name)
                 self.assertEqual(len(test_output), 260 - 100 + 1)
 
             with mock.patch(
@@ -191,7 +191,7 @@ class TestTestRunner(unittest.TestCase):
             ):
                 output_path = "output_path"
                 test_name = "_" * 400
-                test_output = runner._create_output_path(test_name)
+                test_output = runner._get_output_path(test_name)
                 self.assertEqual(
                     test_output,
                     str(
@@ -203,7 +203,7 @@ class TestTestRunner(unittest.TestCase):
             with mock.patch("os.environ", new={"VUNIT_SHORT_TEST_OUTPUT_PATHS": ""}):
                 output_path = "output_path"
                 test_name = "_" * 400
-                test_output = runner._create_output_path(test_name)
+                test_output = runner._get_output_path(test_name)
                 self.assertEqual(
                     test_output,
                     str(Path(output_path).resolve() / hash_string(test_name)),

--- a/tests/unit/test_test_runner.py
+++ b/tests/unit/test_test_runner.py
@@ -13,7 +13,7 @@ import unittest
 from unittest import mock
 from tests.common import with_tempdir
 from vunit.hashing import hash_string
-from vunit.test.runner import TestRunner, create_output_path
+from vunit.test.runner import TestRunner
 from vunit.test.report import TestReport
 from vunit.test.list import TestList
 
@@ -37,9 +37,9 @@ class TestTestRunner(unittest.TestCase):
         test_list.add_test(test_case2)
         test_list.add_test(test_case3)
         runner.run(test_list)
-        self.assertEqual(test_case1.output_path, create_output_path(tempdir, "test1"))
-        self.assertEqual(test_case2.output_path, create_output_path(tempdir, "test2"))
-        self.assertEqual(test_case3.output_path, create_output_path(tempdir, "test3"))
+        self.assertEqual(test_case1.output_path, runner._create_output_path("test1"))
+        self.assertEqual(test_case2.output_path, runner._create_output_path("test2"))
+        self.assertEqual(test_case3.output_path, runner._create_output_path("test3"))
         self.assertEqual(order, ["test1", "test2", "test3"])
         self.assertTrue(report.result_of("test1").passed)
         self.assertTrue(report.result_of("test2").failed)
@@ -62,8 +62,8 @@ class TestTestRunner(unittest.TestCase):
             runner.run(test_list)
         except KeyboardInterrupt:
             pass
-        self.assertEqual(test_case1.output_path, create_output_path(tempdir, "test1"))
-        self.assertEqual(test_case2.output_path, create_output_path(tempdir, "test2"))
+        self.assertEqual(test_case1.output_path, runner._create_output_path("test1"))
+        self.assertEqual(test_case2.output_path, runner._create_output_path("test2"))
         self.assertEqual(test_case3.called, False)
         self.assertEqual(order, ["test1", "test2"])
         self.assertTrue(report.result_of("test1").passed)
@@ -136,11 +136,14 @@ class TestTestRunner(unittest.TestCase):
         self.assertEqual(report.result_of("test").output, "out1out2out3out4out5")
 
     def test_create_output_path_on_linux(self):
+        output_path = "output_path"
+        report = TestReport()
+        runner = TestRunner(report, output_path)
+
         with mock.patch("sys.platform", new="linux"):
             with mock.patch("os.environ", new={}):
-                output_path = "output_path"
                 test_name = "_" * 400
-                test_output = create_output_path(output_path, test_name)
+                test_output = runner._create_output_path(test_name)
                 self.assertEqual(
                     test_output,
                     str(
@@ -151,7 +154,7 @@ class TestTestRunner(unittest.TestCase):
 
                 output_path = "output_path"
                 test_name = "123._-+"
-                test_output = create_output_path(output_path, test_name)
+                test_output = runner._create_output_path(test_name)
                 self.assertEqual(
                     test_output,
                     str(
@@ -163,7 +166,7 @@ class TestTestRunner(unittest.TestCase):
                 output_path = "output_path"
                 test_name = "#<>:"
                 safe_name = "____"
-                test_output = create_output_path(output_path, test_name)
+                test_output = runner._create_output_path(test_name)
                 self.assertEqual(
                     test_output,
                     str(
@@ -173,11 +176,14 @@ class TestTestRunner(unittest.TestCase):
                 )
 
     def test_create_output_path_on_windows(self):
+        output_path = "output_path"
+        report = TestReport()
+        runner = TestRunner(report, output_path)
+
         with mock.patch("sys.platform", new="win32"):
             with mock.patch("os.environ", new={}):
-                output_path = "output_path"
                 test_name = "_" * 400
-                test_output = create_output_path(output_path, test_name)
+                test_output = runner._create_output_path(test_name)
                 self.assertEqual(len(test_output), 260 - 100 + 1)
 
             with mock.patch(
@@ -185,7 +191,7 @@ class TestTestRunner(unittest.TestCase):
             ):
                 output_path = "output_path"
                 test_name = "_" * 400
-                test_output = create_output_path(output_path, test_name)
+                test_output = runner._create_output_path(test_name)
                 self.assertEqual(
                     test_output,
                     str(
@@ -197,7 +203,7 @@ class TestTestRunner(unittest.TestCase):
             with mock.patch("os.environ", new={"VUNIT_SHORT_TEST_OUTPUT_PATHS": ""}):
                 output_path = "output_path"
                 test_name = "_" * 400
-                test_output = create_output_path(output_path, test_name)
+                test_output = runner._create_output_path(test_name)
                 self.assertEqual(
                     test_output,
                     str(Path(output_path).resolve() / hash_string(test_name)),

--- a/vunit/test/runner.py
+++ b/vunit/test/runner.py
@@ -226,7 +226,7 @@ class TestRunner(object):  # pylint: disable=too-many-instance-attributes
         results = self._fail_suite(test_suite)
 
         try:
-            ostools.renew_path(output_path)
+            self._prepare_test_suite_output_path(output_path)
             output_file = wrap(open(output_file_name, "a+"), use_color=False)
             output_file.seek(0)
             output_file.truncate()
@@ -287,6 +287,13 @@ class TestRunner(object):  # pylint: disable=too-many-instance-attributes
 
             if self._fail_fast and any_not_passed:
                 self._abort = True
+
+    @staticmethod
+    def _prepare_test_suite_output_path(output_path):
+        """
+        Make sure the directory exists and is empty before running test.
+        """
+        ostools.renew_path(output_path)
 
     def _create_test_mapping_file(self, test_suites):
         """

--- a/vunit/test/runner.py
+++ b/vunit/test/runner.py
@@ -144,7 +144,7 @@ class TestRunner(object):  # pylint: disable=too-many-instance-attributes
             try:
                 test_suite = scheduler.next()
 
-                output_path = create_output_path(self._output_path, test_suite.name)
+                output_path = self._create_output_path(test_suite.name)
                 output_file_name = str(Path(output_path) / "output.txt")
 
                 with self._stdout_lock():
@@ -170,6 +170,36 @@ class TestRunner(object):  # pylint: disable=too-many-instance-attributes
             finally:
                 if test_suite is not None:
                     scheduler.test_done()
+
+    def _create_output_path(self, test_suite_name):
+        """
+        Create the full output path of a test case.
+        Ensure no bad characters and no long path names.
+        """
+        output_path = str(Path(self._output_path).resolve())
+        safe_name = (
+            "".join(char if _is_legal(char) else "_" for char in test_suite_name) + "_"
+        )
+        hash_name = hash_string(test_suite_name)
+
+        if "VUNIT_SHORT_TEST_OUTPUT_PATHS" in os.environ:
+            full_name = hash_name
+        elif sys.platform == "win32":
+            max_path = 260
+            margin = int(os.environ.get("VUNIT_TEST_OUTPUT_PATH_MARGIN", "100"))
+            prefix_len = len(output_path)
+            full_name = (
+                safe_name[
+                    : min(
+                        max_path - margin - prefix_len - len(hash_name), len(safe_name)
+                    )
+                ]
+                + hash_name
+            )
+        else:
+            full_name = safe_name + hash_name
+
+        return str(Path(output_path) / full_name)
 
     def _add_skipped_tests(
         self, test_suite, results, start_time, num_tests, output_file_name
@@ -276,7 +306,7 @@ class TestRunner(object):  # pylint: disable=too-many-instance-attributes
             mapping = set()
 
         for test_suite in test_suites:
-            test_output = create_output_path(self._output_path, test_suite.name)
+            test_output = self._create_output_path(test_suite.name)
             mapping.add("%s %s" % (Path(test_output).name, test_suite.name))
 
         # Sort by everything except hash
@@ -428,35 +458,6 @@ def _is_legal(char):
     Return true if the character is legal to have in a file name
     """
     return (char in LEGAL_CHARS) and (char not in ILLEGAL_CHARS)
-
-
-def create_output_path(output_path, test_suite_name):
-    """
-    Create the full output path of a test case.
-    Ensure no bad characters and no long path names.
-    """
-    output_path = str(Path(output_path).resolve())
-    safe_name = (
-        "".join(char if _is_legal(char) else "_" for char in test_suite_name) + "_"
-    )
-    hash_name = hash_string(test_suite_name)
-
-    if "VUNIT_SHORT_TEST_OUTPUT_PATHS" in os.environ:
-        full_name = hash_name
-    elif sys.platform == "win32":
-        max_path = 260
-        margin = int(os.environ.get("VUNIT_TEST_OUTPUT_PATH_MARGIN", "100"))
-        prefix_len = len(output_path)
-        full_name = (
-            safe_name[
-                : min(max_path - margin - prefix_len - len(hash_name), len(safe_name))
-            ]
-            + hash_name
-        )
-    else:
-        full_name = safe_name + hash_name
-
-    return str(Path(output_path) / full_name)
 
 
 def wrap(file_obj, use_color=True):

--- a/vunit/test/runner.py
+++ b/vunit/test/runner.py
@@ -144,7 +144,7 @@ class TestRunner(object):  # pylint: disable=too-many-instance-attributes
             try:
                 test_suite = scheduler.next()
 
-                output_path = self._create_output_path(test_suite.name)
+                output_path = self._get_output_path(test_suite.name)
                 output_file_name = str(Path(output_path) / "output.txt")
 
                 with self._stdout_lock():
@@ -171,9 +171,9 @@ class TestRunner(object):  # pylint: disable=too-many-instance-attributes
                 if test_suite is not None:
                     scheduler.test_done()
 
-    def _create_output_path(self, test_suite_name):
+    def _get_output_path(self, test_suite_name):
         """
-        Create the full output path of a test case.
+        Construct the full output path of a test case.
         Ensure no bad characters and no long path names.
         """
         output_path = str(Path(self._output_path).resolve())
@@ -306,7 +306,7 @@ class TestRunner(object):  # pylint: disable=too-many-instance-attributes
             mapping = set()
 
         for test_suite in test_suites:
-            test_output = self._create_output_path(test_suite.name)
+            test_output = self._get_output_path(test_suite.name)
             mapping.add("%s %s" % (Path(test_output).name, test_suite.name))
 
         # Sort by everything except hash


### PR DESCRIPTION
**Background**: I am working on a multi-threaded build runner for vivado and formal (symbiyosys) projects. Since e.g. Vivado will realistically probably only use about four threads, parallelization of builds is desired. The idea is to re-use the VUnit test runner code, which is robust and tested, but with different "test" objects. However I wish to modify some of the behavior, namely in this case the hashing of test output folder names. To do this I inherit the ``TestRunner`` class and override the methods who's behavior I want to change. In this case however, the ``create_output_path`` function is not a member of the class, but a bare function.

This PR makes the ``create_output_path`` a private member of the ``TestRunner`` class. That enables my use case, and is also in my opinion more logical given how it is used by ``TestRunner``. There is no functional change for VUnit.

The second commit changes the name from ``create_output_path`` to ``get_output_path``. In my mind, "create" as a verb implies that the directory is created on disk, which is is not.