### PR TITLE
Issue 455

### DIFF
--- a/vunit/sim_if/tcl/aldec_if.tcl
+++ b/vunit/sim_if/tcl/aldec_if.tcl
@@ -1,0 +1,124 @@
+# Description:
+#   This script is the top level that can be used to easily add
+#   waveforms to activeHDL and RivieraPRO waveform viewer.
+#
+#   depth:
+#       This mode allows user to specify desired depth. The script
+#       will parse all signals and add every signal inside each hierarchy
+#       that is <= user specified depth
+
+# globals because unable to call each of these commands
+# within a procedure
+find -type signal -rec * {$>} ALL_SIGNALS
+find -type instance -rec * {$>} ALL_GROUPS
+find -type const -rec * {$>} ALL_CONSTANTS
+find -type variable -rec * {$>} ALL_VARIABLES
+
+
+# procedure::_filterList
+#    filters list passed to it for junk Aldec formats it with
+proc _filterList {list} {
+  # list of items to filter out
+  set list_to_filter \
+    {"Signals:" "Constants:" "Variables:" "Instances:" "Generics and parameters:"}
+  set filt_list {}
+  # re-format list created by Aldec
+  foreach item $list {
+    lappend filt_list [string map {" " ""} $item ]
+  }
+  # search for and remove all items matching filtered list
+  foreach filter $list_to_filter {
+    set idx [ lsearch -exact $filt_list $filter ]
+    set filt_list [ lreplace $filt_list $idx $idx ]
+  }
+  # if we find colon, need to only keep anything with a / as this is
+  # denoting the hierarchy (what we want) and will remove the crap formatting
+  # that Aldec gave to TCL. Aldec puts path before colon, so only keep these elements
+  if { [ lsearch -exact $filt_list : ] >= 0 } {
+    set tmp {}
+    # difficulty searching for /, so using colon instead
+    foreach idx [ lsearch -all $filt_list : ] {
+      lappend tmp [ lindex $filt_list [expr $idx-1] ]
+    }
+    set filt_list $tmp
+  }
+  return $filt_list
+}
+
+# procedure::_getAllGroups
+#    gets all groups (instance/hierarchy paths)
+proc _getAllGroups {} {
+  # tell proc to reference global name-space
+  global ALL_GROUPS
+  return [ _filterList $ALL_GROUPS ]
+}
+
+# procedure::_getAllSignals
+#    gets all signals
+proc _getAllSignals {} {
+  # tell proc to reference global name-space
+  global ALL_SIGNALS
+  return [ _filterList $ALL_SIGNALS ]
+}
+
+# procedure::_getAllConstants
+#    gets all constants
+proc _getAllConstants {} {
+  # tell proc to reference global name-space
+  global ALL_CONSTANTS
+  return [ _filterList $ALL_CONSTANTS ]
+}
+
+# procedure::_getAllVariables
+#    gets all variables
+proc _getAllVariables {} {
+  # tell proc to reference global name-space
+  global ALL_VARIABLES
+  return [ _filterList $ALL_VARIABLES ]
+}
+
+# procedure::_addNamedRow
+#    add named row to waveform viewer
+proc _addNamedRow {name} {
+  add wave -named_row $name -height 40 -color red
+}
+
+# procedure::_addWaves
+#    add all signals within a group to waveform viewer in the order in
+#    which they're declared
+proc _addWaves {groups} {
+  foreach group_name $groups {
+    set CMD "add wave -decl -virtual $group_name {$group_name/*}"
+    eval $CMD
+  }
+}
+
+# procedure::_addWave
+#    add all signals within a group to waveform viewer in the order in
+#    which they're declared
+proc _addWave {name} {
+  set CMD "add wave -decl $name"
+  eval $CMD
+}
+
+# procedure::addWavesByDepth
+#    adds signals in the hierarchy down to a certain depth
+proc addWavesByDepth { depth } {
+  # create dict key/val
+  set group_names {}
+
+  # parse list to grab groups we want to add to waveform viewer
+  foreach { path } [ _getAllGroups ] {
+    # split path and determine how many elements there are
+    set elements     [ split $path / ]
+
+    # determine number of elements
+    set num_elements [ llength $elements ]
+    incr num_elements -1
+
+    if {$num_elements <= $depth} {
+      lappend group_names $path
+    }
+  }
+  _addWaves $group_names
+}

--- a/vunit/sim_if/tcl/gtkwave_if.tcl
+++ b/vunit/sim_if/tcl/gtkwave_if.tcl
@@ -1,0 +1,93 @@
+# Description:
+#   This script is the top level that can be used to easily add
+#   waveforms to GTKWave waveform viewer.
+#
+#   depth:
+#       This mode allows user to specify desired depth. The script
+#       will parse all signals and add every signal inside each hierarchy
+#       that is <= user specified depth
+
+# procedure::_getAllWaves
+#
+proc _getAllWaves {} {
+  # init internals
+  set paths [list]
+
+  # get number of waves
+  set num_waves  [ gtkwave::getNumFacs ]
+
+  # search entire waveform list and remove duplicates
+  for {set idx 0} {$idx < $num_waves} {incr idx} {
+    lappend paths [ gtkwave::getFacName $idx ]
+  }
+  return $paths
+}
+
+# procedure::_displayWaves
+#
+proc _displayWaves { dictWaveGroups } {
+  set first 0
+
+  foreach {k v} $dictWaveGroups {
+    set add_wave [ gtkwave::addSignalsFromList $v ]
+
+    # GTK doesn't highlight the first set of signals added so nothing gets grouped
+    if {$first == 0} {
+      gtkwave::/Edit/Highlight_All
+    }
+    gtkwave::/Edit/Create_Group "$k"
+    #gtkwave::setLeftJustifySigs on
+    gtkwave::/Edit/Toggle_Group_Open|Close
+    gtkwave::/Edit/UnHighlight_All
+
+    # TODO: figure out how to determine signal type so we can set data format
+    #set flags [ gtkwave::getTraceFlagsFromName {$v} ]
+    #puts "$flags"
+    incr first
+  }
+  #gtkwave::/Edit/Set_Trace_Max_Hier 0
+  set filename [gtkwave::getSaveFileName]
+  puts "$filename"
+  # sort groups and update viewer
+  gtkwave::/Edit/Highlight_All
+  gtkwave::/Edit/Sort/Sigsort_All
+  gtkwave::/Edit/UnHighlight_All
+  gtkwave::nop
+}
+
+
+# procedure::addWavesByDepth
+#
+proc addWavesByDepth { depth } {
+  set dictGroup [ dict create ]
+  set old_path 1
+
+  foreach { path } [ _getAllWaves ] {
+    # split path and determine how many elements there are
+    set elements     [ split $path . ]
+    set num_elements [ llength $elements ]
+    incr num_elements -2
+
+    # remove first element because redundant and last because this is the signal name, then join for matching
+    set group_elements [ lreplace [ lreplace $elements 0 0 ] end end ]
+    set group_name     [ join $group_elements "." ]
+
+    # if we found match, append path to group key
+    if {$num_elements <= $depth} {
+      set elements [ split $path \[ ]
+
+      if { [ llength $elements ] > 1 } {
+        set var [ lreplace $elements end end ]
+        set path [ join $var \[ ]
+      }
+
+      if {$old_path ne $path} {
+        set key $group_name
+        set val $path
+        dict lappend dictGroup $key $val
+        set old_path $path
+      }
+    }
+  }
+  _displayWaves $dictGroup
+}

--- a/vunit/sim_if/tcl/modelsim_if.tcl
+++ b/vunit/sim_if/tcl/modelsim_if.tcl
@@ -1,0 +1,75 @@
+# Description:
+#   This script is the top level that can be used to easily add
+#   waveforms to GTKWave waveform viewer.
+#
+#   depth:
+#       This mode allows user to specify desired depth. The script
+#       will parse all signals and add every signal inside each hierarchy
+#       that is <= user specified depth
+
+# procedure::_setListUnique
+proc _setListUnique {list} {
+  array set included_arr [list]
+  set unique_list [list]
+  foreach item $list {
+    if { ![info exists included_arr($item)] } {
+      set included_arr($item) ""
+      lappend unique_list $item
+    }
+  }
+  unset included_arr
+  return $unique_list
+}
+
+
+# procedure::_sortList
+proc _sortList { names } {
+  return [ lsort -increasing [ _setListUnique $names ] ]
+}
+
+
+# procedure::_getAllSignals
+#
+proc _getAllSignals {} {
+  return [ find signals * -r ]
+}
+
+
+# procedure::_addWaves
+#
+proc _addWaves { groups } {
+  # organize list and remove duplicates
+  foreach { group_name } [ _sortList $groups ] {
+    set CMD "add wave -noupdate -group $group_name $group_name/*"
+    echo $CMD
+    eval $CMD
+    eval "config wave -signalnamewidth 1"
+  }
+}
+
+
+# procedure::addWavesByDepth
+#
+proc addWavesByDepth { depth } {
+  # create dict key/val
+  set group_names [ list ]
+
+  # parse list to grab groups we want to add to waveform viewer
+  foreach { path } [ _getAllSignals ] {
+    # split path and determine how many elements there are
+    set elements     [ split $path / ]
+
+    # remove first element because redundant and last because this is the signal name, then join for matching
+    set group_elements [ lreplace $elements end end ]
+    set group_name     [ join $group_elements "/" ]
+
+    # determine number of elements
+    set num_elements [ llength $group_elements ]
+    incr num_elements -1
+
+    if {$num_elements <= $depth} {
+      lappend group_names $group_name
+    }
+  }
+  _addWaves $group_names
+}

--- a/vunit/ui/__init__.py
+++ b/vunit/ui/__init__.py
@@ -735,6 +735,7 @@ avoid location preprocessing of other functions sharing name with a VUnit log or
         .. note::
            Only affects test benches added *before* the option is set.
         """
+        parent_path = Path(__file__).parent.parent.resolve()
         simulator = self._simulator_class.name
         output_path = str(Path(self._output_path) / simulator / "waves.tcl")
         tcl_sources = {
@@ -746,10 +747,7 @@ avoid location preprocessing of other functions sharing name with a VUnit log or
         # error check selected simulator and create path for TCL files
         # and simulator option
         if simulator in tcl_sources:
-            tcl_src_path = str(
-                Path(__file__).parent.parent.resolve() / "sim_if" / "tcl" / \
-                tcl_sources[simulator]
-            )
+            tcl_src_path = str(parent_path / "sim_if" / "tcl" / tcl_sources[simulator])
             sim_opt = f"{simulator}" + \
                 (".gtkwave_script.gui" if simulator == "ghdl" else ".init_file.gui")
         else:
@@ -757,7 +755,7 @@ avoid location preprocessing of other functions sharing name with a VUnit log or
                 f"Selected simulator ({simulator}) is not yet supported!"
             )
         # generate TCL commands and write to file
-        path = tcl_src_path.replace('\\', '/') # \ in f-string error
+        path = tcl_src_path.replace('\\', '/')  # \ in f-string error
         tcl_commands = [
             f"source {path}",
             f"addWavesByDepth {depth}"

--- a/vunit/ui/__init__.py
+++ b/vunit/ui/__init__.py
@@ -742,27 +742,23 @@ avoid location preprocessing of other functions sharing name with a VUnit log or
             "activehdl": "aldec_if.tcl",
             "ghdl": "gtkwave_if.tcl",
             "modelsim": "modelsim_if.tcl",
-            "rivierapro": "aldec_if.tcl"
+            "rivierapro": "aldec_if.tcl",
         }
         # error check selected simulator and create path for TCL files
         # and simulator option
         if simulator in tcl_sources:
             tcl_src_path = str(parent_path / "sim_if" / "tcl" / tcl_sources[simulator])
-            sim_opt = f"{simulator}" + \
-                (".gtkwave_script.gui" if simulator == "ghdl" else ".init_file.gui")
-        else:
-            raise ValueError(
-                f"Selected simulator ({simulator}) is not yet supported!"
+            sim_opt = f"{simulator}" + (
+                ".gtkwave_script.gui" if simulator == "ghdl" else ".init_file.gui"
             )
+        else:
+            raise ValueError(f"Selected simulator ({simulator}) is not yet supported!")
         # generate TCL commands and write to file
-        path = tcl_src_path.replace('\\', '/')  # \ in f-string error
-        tcl_commands = [
-            f"source {path}",
-            f"addWavesByDepth {depth}"
-        ]
+        path = tcl_src_path.replace("\\", "/")  # \ in f-string error
+        tcl_commands = [f"source {path}", f"addWavesByDepth {depth}"]
         with Path(output_path).open("w") as fptr:
             for cmd in tcl_commands:
-                fptr.write(cmd + '\n')
+                fptr.write(cmd + "\n")
         fptr.close()
         # call set_sim_option with option and GUI waves file
         self.set_sim_option(sim_opt, output_path)

--- a/vunit/ui/__init__.py
+++ b/vunit/ui/__init__.py
@@ -708,6 +708,67 @@ avoid location preprocessing of other functions sharing name with a VUnit log or
                 preprocessor.remove_subprogram(subprogram)
         self._location_preprocessor = preprocessor
 
+    def add_waves_by_depth(self, depth: int):
+        """
+        Adds all signals in all entities down to the specified depth. By
+        calling this method, it will create a TCL script that adds all
+        signals in all entities and group each entities signals by the
+        path name. Then, it will call `set_sim_option()` with the
+        correct GUI flags.
+
+        :param depth: Hierarchy depth to group and add all signals for \
+            each entity
+
+        :example:
+
+        .. code-block:: python
+
+           prj.add_waves_by_depth(depth=3)
+
+        Which would, for example, add waveforms to the waveform viewer
+        like so:
+        tb/*
+        tb/uut/*
+        tb/uut/ent1/*
+        tb/uut/ent2/*
+
+        .. note::
+           Only affects test benches added *before* the option is set.
+        """
+        simulator = self._simulator_class.name
+        output_path = str(Path(self._output_path) / simulator / "waves.tcl")
+        tcl_sources = {
+            "activehdl": "aldec_if.tcl",
+            "ghdl": "gtkwave_if.tcl",
+            "modelsim": "modelsim_if.tcl",
+            "rivierapro": "aldec_if.tcl"
+        }
+        # error check selected simulator and create path for TCL files
+        # and simulator option
+        if simulator in tcl_sources:
+            tcl_src_path = str(
+                Path(__file__).parent.parent.resolve() / "sim_if" / "tcl" / \
+                tcl_sources[simulator]
+            )
+            sim_opt = f"{simulator}" + \
+                (".gtkwave_script.gui" if simulator == "ghdl" else ".init_file.gui")
+        else:
+            raise ValueError(
+                f"Selected simulator ({simulator}) is not yet supported!"
+            )
+        # generate TCL commands and write to file
+        path = tcl_src_path.replace('\\', '/') # \ in f-string error
+        tcl_commands = [
+            f"source {path}",
+            f"addWavesByDepth {depth}"
+        ]
+        with Path(output_path).open("w") as fptr:
+            for cmd in tcl_commands:
+                fptr.write(cmd + '\n')
+        fptr.close()
+        # call set_sim_option with option and GUI waves file
+        self.set_sim_option(sim_opt, output_path)
+
     def enable_check_preprocessing(self):
         """
         Inserts error context information into VUnit check_relation calls


### PR DESCRIPTION
Identical to https://github.com/VUnit/vunit/pull/665 as I needed to fork for other development.

added add_waves_by_depth method and TCL scripts for modelsim, aldec, and ghdl

This is in primarily in relation to #455, but aligns with my comments in #615 . I avoided the #622 PR because it is pretty far behind master and @nfrancque appeared to mostly have stuff for the ModelSim save/load of wave files which is different than what I'm looking to add. I have some outstanding questions:

* Does it make sense to add waves as I have done with `add_waves_by_depth()` which calls `set_sim_option()` under the covers?
* do I need a unit test for `add_waves_by_depth()`? If so, how would I do this since the entire interface is creating a file and adding waves to the simulator?

This PR would close out #455, but the below feature requests are my vision for #615:

* JSON interface such that user can add hierarchy path to signals/variables/constants and some options and VUnit would take care of simulator specific TCL commands
* Add bools to `add_waves_by_depth()` so user can include constants and/or variables as well.
* Add command-line option to add by depth in cases where adding `add_waves_by_depth` to `run.py` doesn't always make sense
* Add simulator GUI option for adding waves by depth (gated by #622 being accepted and merged with master)