### PR TITLE
Added example Gitlab CI integration

### DIFF
--- a/examples/ci-integration/.gitlab-ci.yml
+++ b/examples/ci-integration/.gitlab-ci.yml
@@ -1,0 +1,19 @@
+image: ghdl/vunit:llvm
+stages:
+  - test
+
+before_script:
+  - cd $CI_PROJECT_DIR/src/tests
+
+test:
+  tags:
+    - linux-docker
+  stage: test
+  script:
+    - python3 ./run.py --xunit-xml ./test_output.xml
+  artifacts:
+    when: always
+    paths:
+      - $CI_PROJECT_DIR/src/tests/test_output.xml
+    reports:
+      junit: $CI_PROJECT_DIR/src/tests/test_output.xml


### PR DESCRIPTION
I integrated VUnit with Gitlab CI for one of my projects. Figured it makes sense to have a directory full of these examples for different CI tools such as Jenkins, Github Actions etc. 

