### PR TITLE
initial values on outgoing ram_master ports

### DIFF
--- a/vunit/vhdl/verification_components/src/ram_master.vhd
+++ b/vunit/vhdl/verification_components/src/ram_master.vhd
@@ -22,9 +22,9 @@ entity ram_master is
   port (
     clk : in std_logic;
     en : out std_logic := '0';
-    we : out std_logic_vector(byte_enable_length(bus_handle)-1 downto 0);
-    addr : out std_logic_vector(address_length(bus_handle)-1 downto 0);
-    wdata : out std_logic_vector(data_length(bus_handle)-1 downto 0);
+    we : out std_logic_vector(byte_enable_length(bus_handle)-1 downto 0) := (others => '0');
+    addr : out std_logic_vector(address_length(bus_handle)-1 downto 0) := (others => '0');
+    wdata : out std_logic_vector(data_length(bus_handle)-1 downto 0) := (others => '0');
     rdata : in std_logic_vector(data_length(bus_handle)-1 downto 0)
     );
 end entity;


### PR DESCRIPTION
Avoid undefined signals on outgoing ports of the ram interface.