### PR TITLE
examples/vhdl/user_guide: add VHDL 1993 variant

### DIFF
--- a/examples/vhdl/user_guide/vhdl1993/run.py
+++ b/examples/vhdl/user_guide/vhdl1993/run.py
@@ -1,0 +1,20 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+# Copyright (c) 2014-2021, Lars Asplund lars.anders.asplund@gmail.com
+
+"""
+VHDL User Guide
+---------------
+
+The most minimal VUnit VHDL project covering the basics of the :ref:`User Guide <user_guide>`,
+adapted to be used with simulators that don't support VHDL 2008.
+"""
+
+from pathlib import Path
+from vunit import VUnit
+
+VU = VUnit.from_argv(vhdl_standard="93")
+VU.add_library("lib").add_source_files(Path(__file__).parent / "*.vhd")
+VU.main()

--- a/examples/vhdl/user_guide/vhdl1993/tb_example.vhd
+++ b/examples/vhdl/user_guide/vhdl1993/tb_example.vhd
@@ -1,0 +1,48 @@
+-- This Source Code Form is subject to the terms of the Mozilla Public
+-- License, v. 2.0. If a copy of the MPL was not distributed with this file,
+-- You can obtain one at http://mozilla.org/MPL/2.0/.
+--
+-- Copyright (c) 2014-2021, Lars Asplund lars.anders.asplund@gmail.com
+
+library vunit_lib;
+
+use vunit_lib.types_pkg.all;
+use vunit_lib.integer_vector_ptr_pkg.all;
+use vunit_lib.integer_vector_ptr_pool_pkg.all;
+use vunit_lib.integer_array_pkg.all;
+use vunit_lib.queue_pkg.all;
+use vunit_lib.queue_pool_pkg.all;
+use vunit_lib.string_ptr_pkg.all;
+use vunit_lib.string_ptr_pool_pkg.all;
+use vunit_lib.byte_vector_ptr_pkg.all;
+use vunit_lib.dict_pkg.all;
+
+use vunit_lib.string_ops.all;
+use vunit_lib.dictionary.all;
+use vunit_lib.path.all;
+use vunit_lib.print_pkg.all;
+use vunit_lib.log_levels_pkg.all;
+use vunit_lib.logger_pkg.all;
+use vunit_lib.log_handler_pkg.all;
+use vunit_lib.log_deprecated_pkg.all;
+use vunit_lib.ansi_pkg.all;
+use vunit_lib.checker_pkg.all;
+use vunit_lib.check_pkg.all;
+use vunit_lib.check_deprecated_pkg.all;
+use vunit_lib.run_types_pkg.all;
+use vunit_lib.run_pkg.all;
+use vunit_lib.run_deprecated_pkg.all;
+
+entity tb_example is
+  generic (runner_cfg : string);
+end entity;
+
+architecture tb of tb_example is
+begin
+  main : process
+  begin
+    test_runner_setup(runner, runner_cfg);
+    report "Hello world!";
+    test_runner_cleanup(runner); -- Simulation ends here
+  end process;
+end architecture;

--- a/examples/vhdl/user_guide/vhdl1993/tb_example.vhd
+++ b/examples/vhdl/user_guide/vhdl1993/tb_example.vhd
@@ -5,33 +5,7 @@
 -- Copyright (c) 2014-2021, Lars Asplund lars.anders.asplund@gmail.com
 
 library vunit_lib;
-
-use vunit_lib.types_pkg.all;
-use vunit_lib.integer_vector_ptr_pkg.all;
-use vunit_lib.integer_vector_ptr_pool_pkg.all;
-use vunit_lib.integer_array_pkg.all;
-use vunit_lib.queue_pkg.all;
-use vunit_lib.queue_pool_pkg.all;
-use vunit_lib.string_ptr_pkg.all;
-use vunit_lib.string_ptr_pool_pkg.all;
-use vunit_lib.byte_vector_ptr_pkg.all;
-use vunit_lib.dict_pkg.all;
-
-use vunit_lib.string_ops.all;
-use vunit_lib.dictionary.all;
-use vunit_lib.path.all;
-use vunit_lib.print_pkg.all;
-use vunit_lib.log_levels_pkg.all;
-use vunit_lib.logger_pkg.all;
-use vunit_lib.log_handler_pkg.all;
-use vunit_lib.log_deprecated_pkg.all;
-use vunit_lib.ansi_pkg.all;
-use vunit_lib.checker_pkg.all;
-use vunit_lib.check_pkg.all;
-use vunit_lib.check_deprecated_pkg.all;
-use vunit_lib.run_types_pkg.all;
 use vunit_lib.run_pkg.all;
-use vunit_lib.run_deprecated_pkg.all;
 
 entity tb_example is
   generic (runner_cfg : string);

--- a/examples/vhdl/user_guide/vhdl1993/tb_example_many.vhd
+++ b/examples/vhdl/user_guide/vhdl1993/tb_example_many.vhd
@@ -1,0 +1,59 @@
+-- This Source Code Form is subject to the terms of the Mozilla Public
+-- License, v. 2.0. If a copy of the MPL was not distributed with this file,
+-- You can obtain one at http://mozilla.org/MPL/2.0/.
+--
+-- Copyright (c) 2014-2021, Lars Asplund lars.anders.asplund@gmail.com
+
+library vunit_lib;
+
+use vunit_lib.types_pkg.all;
+use vunit_lib.integer_vector_ptr_pkg.all;
+use vunit_lib.integer_vector_ptr_pool_pkg.all;
+use vunit_lib.integer_array_pkg.all;
+use vunit_lib.queue_pkg.all;
+use vunit_lib.queue_pool_pkg.all;
+use vunit_lib.string_ptr_pkg.all;
+use vunit_lib.string_ptr_pool_pkg.all;
+use vunit_lib.byte_vector_ptr_pkg.all;
+use vunit_lib.dict_pkg.all;
+
+use vunit_lib.string_ops.all;
+use vunit_lib.dictionary.all;
+use vunit_lib.path.all;
+use vunit_lib.print_pkg.all;
+use vunit_lib.log_levels_pkg.all;
+use vunit_lib.logger_pkg.all;
+use vunit_lib.log_handler_pkg.all;
+use vunit_lib.log_deprecated_pkg.all;
+use vunit_lib.ansi_pkg.all;
+use vunit_lib.checker_pkg.all;
+use vunit_lib.check_pkg.all;
+use vunit_lib.check_deprecated_pkg.all;
+use vunit_lib.run_types_pkg.all;
+use vunit_lib.run_pkg.all;
+use vunit_lib.run_deprecated_pkg.all;
+
+entity tb_example_many is
+  generic (runner_cfg : string);
+end entity;
+
+architecture tb of tb_example_many is
+begin
+  main : process
+  begin
+    test_runner_setup(runner, runner_cfg);
+
+    while test_suite loop
+
+      if run("test_pass") then
+        report "This will pass";
+
+      elsif run("test_fail") then
+        assert false report "It fails";
+
+      end if;
+    end loop;
+
+    test_runner_cleanup(runner);
+  end process;
+end architecture;

--- a/examples/vhdl/user_guide/vhdl1993/tb_example_many.vhd
+++ b/examples/vhdl/user_guide/vhdl1993/tb_example_many.vhd
@@ -5,33 +5,7 @@
 -- Copyright (c) 2014-2021, Lars Asplund lars.anders.asplund@gmail.com
 
 library vunit_lib;
-
-use vunit_lib.types_pkg.all;
-use vunit_lib.integer_vector_ptr_pkg.all;
-use vunit_lib.integer_vector_ptr_pool_pkg.all;
-use vunit_lib.integer_array_pkg.all;
-use vunit_lib.queue_pkg.all;
-use vunit_lib.queue_pool_pkg.all;
-use vunit_lib.string_ptr_pkg.all;
-use vunit_lib.string_ptr_pool_pkg.all;
-use vunit_lib.byte_vector_ptr_pkg.all;
-use vunit_lib.dict_pkg.all;
-
-use vunit_lib.string_ops.all;
-use vunit_lib.dictionary.all;
-use vunit_lib.path.all;
-use vunit_lib.print_pkg.all;
-use vunit_lib.log_levels_pkg.all;
-use vunit_lib.logger_pkg.all;
-use vunit_lib.log_handler_pkg.all;
-use vunit_lib.log_deprecated_pkg.all;
-use vunit_lib.ansi_pkg.all;
-use vunit_lib.checker_pkg.all;
-use vunit_lib.check_pkg.all;
-use vunit_lib.check_deprecated_pkg.all;
-use vunit_lib.run_types_pkg.all;
 use vunit_lib.run_pkg.all;
-use vunit_lib.run_deprecated_pkg.all;
 
 entity tb_example_many is
   generic (runner_cfg : string);

--- a/tests/acceptance/test_external_run_scripts.py
+++ b/tests/acceptance/test_external_run_scripts.py
@@ -183,6 +183,20 @@ class TestExternalRunScripts(unittest.TestCase):
             ],
         )
 
+    def test_vhdl_user_guide_93_example_project(self):
+        self.check(
+            str(ROOT / "examples" / "vhdl" / "user_guide" / "vhdl1993" / "run.py"),
+            exit_code=1,
+        )
+        check_report(
+            self.report_file,
+            [
+                ("passed", "lib.tb_example.all"),
+                ("passed", "lib.tb_example_many.test_pass"),
+                ("failed", "lib.tb_example_many.test_fail"),
+            ],
+        )
+
     @unittest.skipUnless(simulator_supports_verilog(), "Verilog")
     def test_verilog_user_guide_example_project(self):
         self.check(str(ROOT / "examples" / "verilog" / "user_guide" / "run.py"), exit_code=1)

--- a/tests/acceptance/test_external_run_scripts.py
+++ b/tests/acceptance/test_external_run_scripts.py
@@ -168,6 +168,10 @@ class TestExternalRunScripts(unittest.TestCase):
     def test_vhdl_axi_dma_example_project(self):
         self.check(str(ROOT / "examples" / "vhdl" / "axi_dma" / "run.py"))
 
+    @unittest.skipIf(
+        simulator_check(lambda simclass: not simclass.supports_vhdl_contexts()),
+        "This simulator/backend does not support VHDL contexts",
+    )
     def test_vhdl_user_guide_example_project(self):
         self.check(str(ROOT / "examples" / "vhdl" / "user_guide" / "run.py"), exit_code=1)
         check_report(


### PR DESCRIPTION
I was chatting with @rodrigomelo9, as it seems that the usage of the user guide with simulators which don't support 2008 completely is unclear.

In this PR, subdir `vhdl1993` is added to `examples/vhdl/user_guide`, and the sources are adapted to use VHDL 1993. Precisely, the optional `vhdl_standard` argument is used when calling `from_argv`, and the `context` in VHDL sources is replaced with use statements.

By the way, an skipIf decorator is added to the 2008 version in the acceptance tests, so that it is skipped with simulators that don't support contexts.

/cc @rodrigomelo9