### PR TITLE
Add shebang to example run scripts

### DIFF
--- a/examples/verilog/uart/run.py
+++ b/examples/verilog/uart/run.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this file,
 # You can obtain one at http://mozilla.org/MPL/2.0/.

--- a/examples/verilog/user_guide/run.py
+++ b/examples/verilog/user_guide/run.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this file,
 # You can obtain one at http://mozilla.org/MPL/2.0/.

--- a/examples/verilog/verilog_ams/run.py
+++ b/examples/verilog/verilog_ams/run.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this file,
 # You can obtain one at http://mozilla.org/MPL/2.0/.

--- a/examples/vhdl/array/run.py
+++ b/examples/vhdl/array/run.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this file,
 # You can obtain one at http://mozilla.org/MPL/2.0/.

--- a/examples/vhdl/array_axis_vcs/run.py
+++ b/examples/vhdl/array_axis_vcs/run.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this file,
 # You can obtain one at http://mozilla.org/MPL/2.0/.

--- a/examples/vhdl/axi_dma/run.py
+++ b/examples/vhdl/axi_dma/run.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this file,
 # You can obtain one at http://mozilla.org/MPL/2.0/.

--- a/examples/vhdl/check/run.py
+++ b/examples/vhdl/check/run.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this file,
 # You can obtain one at http://mozilla.org/MPL/2.0/.

--- a/examples/vhdl/com/run.py
+++ b/examples/vhdl/com/run.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this file,
 # You can obtain one at http://mozilla.org/MPL/2.0/.

--- a/examples/vhdl/composite_generics/run.py
+++ b/examples/vhdl/composite_generics/run.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this file,
 # You can obtain one at http://mozilla.org/MPL/2.0/.

--- a/examples/vhdl/coverage/run.py
+++ b/examples/vhdl/coverage/run.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this file,
 # You can obtain one at http://mozilla.org/MPL/2.0/.

--- a/examples/vhdl/generate_tests/run.py
+++ b/examples/vhdl/generate_tests/run.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this file,
 # You can obtain one at http://mozilla.org/MPL/2.0/.

--- a/examples/vhdl/json4vhdl/run.py
+++ b/examples/vhdl/json4vhdl/run.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this file,
 # You can obtain one at http://mozilla.org/MPL/2.0/.

--- a/examples/vhdl/logging/run.py
+++ b/examples/vhdl/logging/run.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this file,
 # You can obtain one at http://mozilla.org/MPL/2.0/.

--- a/examples/vhdl/run/run.py
+++ b/examples/vhdl/run/run.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this file,
 # You can obtain one at http://mozilla.org/MPL/2.0/.

--- a/examples/vhdl/third_party_integration/run.py
+++ b/examples/vhdl/third_party_integration/run.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this file,
 # You can obtain one at http://mozilla.org/MPL/2.0/.

--- a/examples/vhdl/uart/run.py
+++ b/examples/vhdl/uart/run.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this file,
 # You can obtain one at http://mozilla.org/MPL/2.0/.

--- a/examples/vhdl/user_guide/run.py
+++ b/examples/vhdl/user_guide/run.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this file,
 # You can obtain one at http://mozilla.org/MPL/2.0/.

--- a/examples/vhdl/user_guide/vhdl1993/run.py
+++ b/examples/vhdl/user_guide/vhdl1993/run.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this file,
 # You can obtain one at http://mozilla.org/MPL/2.0/.


### PR DESCRIPTION
~This PR is based on #737, so I'll keep it as a draft until that one is merged.~

Add shebang (`#!/usr/bin/env python3`) to all the example run scripts. That allows users to execute `./run.py` as an alternative to `python3 run.py`.