### PR TITLE
sim_if: continue after compilation failure if '--keep-compiling' is True

### DIFF
--- a/docs/news.d/742.breaking.rst
+++ b/docs/news.d/742.breaking.rst
@@ -1,0 +1,1 @@
+Continue after compilation failure if ``--keep-compiling`` is ``True``.

--- a/tests/unit/test_simulator_interface.py
+++ b/tests/unit/test_simulator_interface.py
@@ -117,13 +117,7 @@ Compile passed
         with mock.patch("vunit.sim_if.check_output", autospec=True) as check_output:
             check_output.side_effect = check_output_side_effect
             printer = MockPrinter()
-            self.assertRaises(
-                CompileError,
-                simif.compile_source_files,
-                project,
-                printer=printer,
-                continue_on_error=True,
-            )
+            simif.compile_source_files(project, printer=printer, continue_on_error=True)
             self.assertEqual(
                 printer.output,
                 """\

--- a/vunit/sim_if/__init__.py
+++ b/vunit/sim_if/__init__.py
@@ -301,6 +301,8 @@ class SimulatorInterface(object):  # pylint: disable=too-many-public-methods
 
         if failures:
             printer.write("Compile failed\n", fg="ri")
+            if continue_on_error:
+                return
             raise CompileError
 
         if source_files:


### PR DESCRIPTION
Currently, option `--keep-compiling` will raise an exception/error after all files are compiled. That is, it allows to continue while compilation failures are produced, but it does not allow to run the tests (those whose sources were successfully compiled, at least).
This PR changes it, so that execution continues after compilation when `-k` is used.