### PR TITLE
Use f-strings for formatting strings

### DIFF
--- a/tools/create_release_notes.py
+++ b/tools/create_release_notes.py
@@ -38,7 +38,7 @@ def create_release_notes():
 
     with (source_path / "release_notes.rst").open("w") as fptr:
         fptr.write(
-            """
+            f"""
 .. _release_notes:
 
 Release notes
@@ -46,10 +46,9 @@ Release notes
 
 .. NOTE:: For installation instructions read :ref:`this <installing>`.
 
-`Commits since last release <https://github.com/VUnit/vunit/compare/%s...master>`__
+`Commits since last release <https://github.com/VUnit/vunit/compare/{latest_release.tag!s}...master>`__
 
 """
-            % latest_release.tag
         )
 
         fptr.write("\n\n")
@@ -60,27 +59,23 @@ Release notes
             if release.is_latest:
                 fptr.write(".. _latest_release:\n\n")
 
-            title = ":vunit_commit:`%s <%s>` - %s" % (
-                release.name,
-                release.tag,
-                release.date.strftime("%Y-%m-%d"),
-            )
+            title = f":vunit_commit:`{release.name!s} <{release.tag!s}>` - {release.date.strftime('%Y-%m-%d')!s}"
             if release.is_latest:
                 title += " (latest)"
             fptr.write(title + "\n")
             fptr.write("-" * len(title) + "\n\n")
 
-            fptr.write("\n`Download from PyPI <https://pypi.python.org/pypi/vunit_hdl/%s/>`__" % release.name)
+            fptr.write(f"\n`Download from PyPI <https://pypi.python.org/pypi/vunit_hdl/{release.name!s}/>`__")
 
             if not is_last:
                 fptr.write(
-                    " | `Commits since previous release <https://github.com/VUnit/vunit/compare/%s...%s>`__"
-                    % (releases[idx + 1].tag, release.tag)
+                    f" | `Commits since previous release "
+                    f"<https://github.com/VUnit/vunit/compare/{releases[idx + 1].tag!s}...{release.tag!s}>`__"
                 )
 
             fptr.write("\n\n")
 
-            fptr.write(".. include:: %s\n" % relpath(release.file_name, source_path))
+            fptr.write(f".. include:: {relpath(release.file_name, source_path)!s}\n")
 
 
 class Release(object):
@@ -100,7 +95,7 @@ class Release(object):
         except CalledProcessError:
             if self.is_latest:
                 # Release tag for latest release not yet created, assume HEAD will become release
-                print("Release tag %s not created yet, use HEAD for date" % self.tag)
+                print(f"Release tag {self.tag!s} not created yet, use HEAD for date")
                 self.date = _get_date("HEAD")
             else:
                 raise

--- a/tools/docs_utils.py
+++ b/tools/docs_utils.py
@@ -33,7 +33,7 @@ def examples():
             if loc.is_dir():
                 _data = _get_eg_doc(
                     loc,
-                    "https://github.com/VUnit/vunit/tree/master/examples/%s/%s" % (subdir, item),
+                    f"https://github.com/VUnit/vunit/tree/master/examples/{subdir!s}/{item!s}",
                 )
                 if _data:
                     egs_fptr.write(_data)
@@ -68,7 +68,7 @@ def _get_eg_doc(location: Path, ref):
         print("WARNING: 'run.py' file in example subdir '" + nstr + "' does not contain a docstring. Skipping...")
         return ""
 
-    title = "`%s <%s/>`_" % (eg_doc.split("---", 1)[0][0:-1], ref)
+    title = f"`{eg_doc.split('---', 1)[0][0:-1]!s} <{ref!s}/>`_"
     return "\n".join([title, "-" * len(title), eg_doc.split("---\n", 1)[1], "\n"])
 
 

--- a/tools/release.py
+++ b/tools/release.py
@@ -30,19 +30,19 @@ def main():
         version = args.version[0]
         major, minor, patch = parse_version(version)
 
-        print("Attempting to create new release %s" % version)
+        print(f"Attempting to create new release {version!s}")
         set_version(version)
         validate_new_release(version, pre_tag=True)
         make_release_commit(version)
 
-        new_version = "%i.%i.%irc0" % (major, minor, patch + 1)
+        new_version = f"{major:d}.{minor:d}.{patch + 1:d}rc0"
         set_version(new_version)
         make_next_pre_release_commit(new_version)
 
     elif args.cmd == "validate":
         version = get_local_version()
         validate_new_release(version, pre_tag=False)
-        print("Release %s is validated for publishing" % version)
+        print(f"Release {version!s} is validated for publishing")
 
 
 def parse_args():
@@ -69,8 +69,8 @@ def make_release_commit(version):
     """
     run(["git", "add", str(release_note_file_name(version))])
     run(["git", "add", str(ABOUT_PY)])
-    run(["git", "commit", "-m", "Release %s" % version])
-    run(["git", "tag", "v%s" % version, "-a", "-m", "release %s" % version])
+    run(["git", "commit", "-m", f"Release {version!s}"])
+    run(["git", "tag", f"v{version!s}", "-a", "-m", f"release {version!s}"])
 
 
 def make_next_pre_release_commit(version):
@@ -78,7 +78,7 @@ def make_next_pre_release_commit(version):
     Add release notes and make the release commit
     """
     run(["git", "add", str(ABOUT_PY)])
-    run(["git", "commit", "-m", "Start of next release candidate %s" % version])
+    run(["git", "commit", "-m", f"Start of next release candidate {version!s}"])
 
 
 def validate_new_release(version, pre_tag):
@@ -88,27 +88,27 @@ def validate_new_release(version, pre_tag):
 
     release_note = release_note_file_name(version)
     if not release_note.exists():
-        print("Not releasing version %s since release note %s does not exist" % (version, str(release_note)))
+        print(f"Not releasing version {version!s} since release note {release_note!s} does not exist")
         sys.exit(1)
 
     with release_note.open("r") as fptr:
         if not fptr.read():
-            print("Not releasing version %s since release note %s is empty" % (version, str(release_note)))
+            print(f"Not releasing version {version!s} since release note {release_note!s} is empty")
             sys.exit(1)
 
     if pre_tag and check_tag(version):
-        print("Not creating new release %s since tag v%s already exist" % (version, version))
+        print(f"Not creating new release {version!s} since tag v{version!s} already exist")
         sys.exit(1)
 
     if not pre_tag and not check_tag(version):
-        print("Not releasing version %s since tag v%s does not exist" % (version, version))
+        print(f"Not releasing version {version!s} since tag v{version!s} does not exist")
         sys.exit(1)
 
     with urlopen("https://pypi.python.org/pypi/vunit_hdl/json") as fptr:
         info = json.load(fptr)
 
     if version in info["releases"].keys():
-        print("Version %s has already been released" % version)
+        print(f"Version {version!s} has already been released")
         sys.exit(1)
 
 
@@ -127,8 +127,8 @@ def set_version(version):
     with ABOUT_PY.open("r") as fptr:
         content = fptr.read()
 
-    print("Set local version to %s" % version)
-    content = content.replace('VERSION = "%s"' % get_local_version(), 'VERSION = "%s"' % version)
+    print(f"Set local version to {version!s}")
+    content = content.replace(f'VERSION = "{get_local_version()!s}"', f'VERSION = "{version!s}"')
 
     with ABOUT_PY.open("w") as fptr:
         fptr.write(content)

--- a/vunit/builtins.py
+++ b/vunit/builtins.py
@@ -31,7 +31,7 @@ class Builtins(object):
         self._builtins_adder = BuiltinsAdder()
 
         def add(name, deps=tuple()):
-            self._builtins_adder.add_type(name, getattr(self, "_add_%s" % name), deps)
+            self._builtins_adder.add_type(name, getattr(self, f"_add_{name!s}"), deps)
 
         add("array_util")
         add("com")
@@ -84,7 +84,7 @@ class Builtins(object):
 
         for key in ["string", "integer_vector"]:
             self._add_files(
-                pattern=str(VHDL_PATH / "data_types" / "src" / "api" / ("external_%s_pkg.vhd" % key))
+                pattern=str(VHDL_PATH / "data_types" / "src" / "api" / f"external_{key!s}_pkg.vhd")
                 if external is None or key not in external or not external[key] or external[key] is True
                 else external[key],
                 allow_empty=False,
@@ -272,7 +272,7 @@ class BuiltinsAdder(object):
         old_args = self._already_added[name]
         if args != old_args:
             raise RuntimeError(
-                "Optional builtin %r added with arguments %r has already been added with arguments %r"
-                % (name, args, old_args)
+                f"Optional builtin {name!r} added with arguments {args!r} "
+                f"has already been added with arguments {old_args!r}"
             )
         return True

--- a/vunit/cached.py
+++ b/vunit/cached.py
@@ -23,7 +23,7 @@ def cached(key, function, file_name, encoding, database=None, newline=None):
         content = read_file(file_name, encoding=encoding, newline=newline)
         return function(content)
 
-    function_key = ("%s(%s, newline=%s)" % (key, file_name, newline)).encode()
+    function_key = f"{key!s}({file_name!s}, newline={newline!s})".encode()
     content, content_hash = _file_content_hash(file_name, encoding, database, newline=newline)
 
     if function_key not in database:
@@ -71,7 +71,7 @@ def _file_content_hash(file_name, encoding, database=None, newline=None):
         content = read_file(file_name, encoding=encoding, newline=newline)
         return content, hash_string(content)
 
-    key = ("cached._file_content_hash(%s, newline=%s)" % (file_name, newline)).encode()
+    key = f"cached._file_content_hash({file_name!s}, newline={newline!s})".encode()
 
     if key not in database:
         content = read_file(file_name, encoding=encoding, newline=newline)

--- a/vunit/check_preprocessor.py
+++ b/vunit/check_preprocessor.py
@@ -39,7 +39,7 @@ class CheckPreprocessor(object):
                 offset_to_point_before_closing_paranthesis,
             ) = self._extract_relation(code, match)
             if relation:
-                context_msg_parameter = ", context_msg => %s" % relation.make_context_msg()
+                context_msg_parameter = f", context_msg => {relation.make_context_msg()!s}"
                 code = (
                     code[: match.end("parameters") + offset_to_point_before_closing_paranthesis]
                     + context_msg_parameter
@@ -81,7 +81,7 @@ class CheckPreprocessor(object):
 
         if not relation:
             raise SyntaxError(
-                "Failed to find relation in %s" % code[check.start("call") : check.end("parameters") + index]
+                f"Failed to find relation in {(code[check.start('call') : check.end('parameters') + index])!s}"
             )
 
         return relation, index - 1
@@ -221,10 +221,10 @@ class Relation(object):
         self._right = right
 
     def make_context_msg(self):
-        return '"Expected %s %s %s. Left is " & to_string(%s) & ". Right is " & to_string(%s) & "."' % (
-            self._left.replace('"', '""'),
-            self._operand,
-            self._right.replace('"', '""'),
-            self._left,
-            self._right,
+        eleft = self._left.replace('"', '""')
+        eright = self._right.replace('"', '""')
+        return (
+            f'"Expected {eleft!s} {self._operand!s} {eright!s}. '
+            f'Left is " & to_string({self._left!s}) & ". '
+            f'Right is " & to_string({self._right!s}) & "."'
         )

--- a/vunit/com/codec_generator.py
+++ b/vunit/com/codec_generator.py
@@ -42,9 +42,9 @@ def generate_codecs(
         if "." in used_package:
             if used_package.split(".")[0] not in libraries:
                 libraries.append(used_package.split(".")[0])
-            use_clauses += "use %s.all;\n" % used_package
+            use_clauses += f"use {used_package!s}.all;\n"
         else:
-            use_clauses += "use work.%s.all;\n" % used_package
+            use_clauses += f"use work.{used_package!s}.all;\n"
     if libraries:
         use_clauses = "library " + ";\nlibrary ".join(libraries) + ";\n" + use_clauses
 

--- a/vunit/com/codec_vhdl_package.py
+++ b/vunit/com/codec_vhdl_package.py
@@ -222,13 +222,11 @@ class CodecVHDLPackage(VHDLPackage):
                 for element in record.elements:
                     for identifier in element.identifier_list:
                         if identifier != "msg_type":
-                            parameter_list.append(
-                                "    constant %s : %s" % (identifier, element.subtype_indication.code)
-                            )
+                            parameter_list.append(f"    constant {identifier!s} : {element.subtype_indication.code!s}")
                             parameter_type_list.append(element.subtype_indication.type_mark)
-                            encoding_list.append("encode(%s)" % identifier)
+                            encoding_list.append(f"encode({identifier!s})")
                         else:
-                            encoding_list.append("encode(%s'(%s))" % (element.subtype_indication.code, value))
+                            encoding_list.append(f"encode({element.subtype_indication.code!s}'({value!s}))")
 
                 if parameter_list == []:
                     parameter_part = ""

--- a/vunit/com/codec_vhdl_record_type.py
+++ b/vunit/com/codec_vhdl_record_type.py
@@ -30,8 +30,8 @@ class CodecVHDLRecordType(VHDLRecordType):
         num_of_elements = 0
         for element in self.elements:
             for i in element.identifier_list:
-                element_encoding_list.append("encode(data.%s)" % i)
-                element_decoding_list.append("decode(code, index, result.%s);" % i)
+                element_encoding_list.append(f"encode(data.{i!s})")
+                element_decoding_list.append(f"decode(code, index, result.{i!s});")
 
                 num_of_elements += 1
         element_encodings = " & ".join(element_encoding_list)

--- a/vunit/configuration.py
+++ b/vunit/configuration.py
@@ -50,7 +50,7 @@ class Configuration(object):  # pylint: disable=too-many-instance-attributes
 
         # Fill in tb_path generic with location of test bench
         if "tb_path" in design_unit.generic_names:
-            self.generics["tb_path"] = "%s/" % self.tb_path.replace("\\", "/")
+            self.generics["tb_path"] = str(self.tb_path.replace("\\", "/")) + "/"
 
         self.pre_config = pre_config
         self.post_check = post_check
@@ -114,7 +114,7 @@ class Configuration(object):  # pylint: disable=too-many-instance-attributes
                 "entity" if self._design_unit.is_entity else "module",
                 self._design_unit.library_name,
                 self._design_unit.name,
-                ", ".join("%s" % gname for gname in self._design_unit.generic_names),
+                ", ".join(str(gname) for gname in self._design_unit.generic_names),
             )
         else:
             self.generics[name] = value
@@ -255,11 +255,11 @@ class ConfigurationVisitor(object):
         self._check_enabled()
 
         if name in (DEFAULT_NAME, ""):
-            raise ValueError("Illegal configuration name %r. Must be non-empty string" % name)
+            raise ValueError(f"Illegal configuration name {name!r}. Must be non-empty string")
 
         for configs in self.get_configuration_dicts():
             if name in configs:
-                raise RuntimeError("Configuration name %s already defined" % name)
+                raise RuntimeError(f"Configuration name {name!s} already defined")
 
             # Copy default configuration
             config = configs[DEFAULT_NAME].copy()

--- a/vunit/dependency_graph.py
+++ b/vunit/dependency_graph.py
@@ -135,4 +135,4 @@ class CircularDependencyException(Exception):
         self.path = path
 
     def __repr__(self):
-        return "CircularDependencyException(%r)" % self.path
+        return f"CircularDependencyException({self.path!r})"

--- a/vunit/library.py
+++ b/vunit/library.py
@@ -55,7 +55,7 @@ class Library(object):  # pylint: disable=too-many-instance-attributes
         if source_file.name in self._source_files:
             old_source_file = self._source_files[source_file.name]
             if old_source_file.content_hash != source_file.content_hash:
-                raise RuntimeError("%s already added to library %s" % (source_file.name, self.name))
+                raise RuntimeError(f"{source_file.name!s} already added to library {self.name!s}")
 
             LOGGER.info(
                 "Ignoring duplicate file %s added to library %s due to identical contents",

--- a/vunit/location_preprocessor.py
+++ b/vunit/location_preprocessor.py
@@ -84,7 +84,7 @@ class LocationPreprocessor(object):
         Remove a subprogram name from the list of known names to preprocess
         """
         if subprogram not in self._subprograms_without_arguments + self._subprograms_with_arguments:
-            raise RuntimeError("Unable to remove unknown subprogram %s" % subprogram)
+            raise RuntimeError(f"Unable to remove unknown subprogram {subprogram!s}")
 
         if subprogram in self._subprograms_without_arguments:
             self._subprograms_without_arguments.remove(subprogram)

--- a/vunit/parsing/verilog/parser.py
+++ b/vunit/parsing/verilog/parser.py
@@ -94,7 +94,7 @@ class VerilogParser(object):
         """
         Returns the database key for parse results of file_name
         """
-        return ("CachedVerilogParser.parse(%s)" % str(Path(file_name).resolve)).encode()
+        return f"CachedVerilogParser.parse({str(Path(file_name).resolve)})".encode()
 
     def _store_result(self, file_name, result, included_files, defines):
         """

--- a/vunit/parsing/verilog/preprocess.py
+++ b/vunit/parsing/verilog/preprocess.py
@@ -111,7 +111,7 @@ class VerilogPreprocessor(object):
                     included_files=included_files,
                 )
             except EOFException as exe:
-                raise LocationException.warning("EOF reached when parsing `%s" % token.value, token.location) from exe
+                raise LocationException.warning(f"EOF reached when parsing `{token.value!s}", token.location) from exe
 
         elif token.value in ("celldefine", "endcelldefine", "nounconnected_drive"):
             # Ignored
@@ -175,7 +175,7 @@ class VerilogPreprocessor(object):
         )
         if macro_point in self._macro_trace:
             raise LocationException.error(
-                "Circular macro expansion of %s detected" % macro_token.value,
+                f"Circular macro expansion of {macro_token.value!s} detected",
                 macro_token.location,
             )
         self._macro_trace.add(macro_point)
@@ -199,7 +199,7 @@ class VerilogPreprocessor(object):
             Check the define argument of an if statement
             """
             if arg.kind != IDENTIFIER:
-                raise LocationException.warning("Bad argument to `%s" % if_token.value, arg.location)
+                raise LocationException.warning(f"Bad argument to `{if_token.value!s}", arg.location)
             stream.skip_while(NEWLINE)
 
         def determine_if_taken(if_token, arg):
@@ -212,7 +212,7 @@ class VerilogPreprocessor(object):
             if if_token.value == "ifndef":
                 return arg.value not in defines
 
-            raise ValueError("Invalid if token %r" % if_token.value)
+            raise ValueError(f"Invalid if token {if_token.value!r}")
 
         result = []
         stream.skip_while(WHITESPACE)
@@ -275,7 +275,7 @@ class VerilogPreprocessor(object):
             # pylint crashes when trying to fix the warning below
             if len(expanded_tokens) == 0:  # pylint: disable=len-as-condition
                 raise LocationException.warning(
-                    "Verilog `include has bad argument, empty define `%s" % macro.name,
+                    f"Verilog `include has bad argument, empty define `{macro.name!s}",
                     tok.location,
                 )
 
@@ -294,7 +294,7 @@ class VerilogPreprocessor(object):
         if included_file is None:
             # Is debug message since there are so many builtin includes in tools
             raise LocationException.debug(
-                "Could not find `include file %s" % file_name_tok.value,
+                f"Could not find `include file {file_name_tok.value!s}",
                 file_name_tok.location,
             )
 
@@ -304,7 +304,7 @@ class VerilogPreprocessor(object):
         )
         if include_point in self._include_trace:
             raise LocationException.error(
-                "Circular `include of %s detected" % file_name_tok.value,
+                f"Circular `include of {file_name_tok.value!s} detected",
                 file_name_tok.location,
             )
         self._include_trace.add(include_point)
@@ -424,12 +424,7 @@ class Macro(object):
         return len(self.args)
 
     def __repr__(self):
-        return "Macro(%r, %r %r, %r)" % (
-            self.name,
-            self.tokens,
-            self.args,
-            self.defaults,
-        )
+        return f"Macro({self.name!r}, {self.tokens!r} {self.args!r}, {self.defaults!r})"
 
     def expand(self, values, previous):
         """
@@ -475,11 +470,11 @@ class Macro(object):
                     if name in self.defaults:
                         values.append(self.defaults[name])
                     else:
-                        raise LocationException.warning("Missing value for argument %s" % name, token.location)
+                        raise LocationException.warning(f"Missing value for argument {name!s}", token.location)
 
             elif len(values) > len(self.args):
                 raise LocationException.warning(
-                    "Too many arguments got %i expected %i" % (len(values), len(self.args)),
+                    f"Too many arguments got {len(values):d} expected {len(self.args):d}",
                     token.location,
                 )
 

--- a/vunit/persistent_tcl_shell.py
+++ b/vunit/persistent_tcl_shell.py
@@ -67,7 +67,7 @@ class PersistentTclShell(object):
         Read a variable from the persistent TCL shell
         """
         process = self._process()
-        process.writeline("puts #VUNIT_READVAR=${%s}" % varname)
+        process.writeline(f"puts #VUNIT_READVAR=${varname!s}")
         consumer = ReadVarOutputConsumer()
         process.consume_output(consumer)
         return consumer.var

--- a/vunit/project.py
+++ b/vunit/project.py
@@ -65,13 +65,13 @@ class Project(object):  # pylint: disable=too-many-instance-attributes
             raise RuntimeError("Illegal library name 'work'")
 
         if library_name in self._libraries:
-            raise ValueError("Library %s already exists" % library_name)
+            raise ValueError(f"Library {library_name!s} already exists")
 
         lower_name = library_name.lower()
         if lower_name in self._lower_library_names_dict:
             raise RuntimeError(
-                "Library name %r not case-insensitive unique. Library name %r previously defined"
-                % (library_name, self._lower_library_names_dict[lower_name])
+                f"Library name {library_name!r} not case-insensitive unique. "
+                f"Library name {self._lower_library_names_dict[lower_name]!r} previously defined"
             )
 
     def add_builtin_library(self, logical_name):
@@ -98,10 +98,10 @@ class Project(object):  # pylint: disable=too-many-instance-attributes
 
         if is_external:
             if not dpath.exists():
-                raise ValueError("External library %r does not exist" % dstr)
+                raise ValueError(f"External library {dstr!r} does not exist")
 
             if not dpath.is_dir():
-                raise ValueError("External library must be a directory. Got %r" % dstr)
+                raise ValueError(f"External library must be a directory. Got {dstr!r}")
 
         library = Library(logical_name, dstr, vhdl_standard, is_external=is_external)
         LOGGER.debug("Adding library %s with path %s", logical_name, dstr)
@@ -126,7 +126,7 @@ class Project(object):  # pylint: disable=too-many-instance-attributes
         """
         fname = file_name if isinstance(file_name, Path) else Path(file_name)
         if not fname.exists():
-            raise ValueError("File %r does not exist" % str(fname))
+            raise ValueError(f"File {str(fname)!r} does not exist")
 
         LOGGER.debug("Adding source file %s to library %s", str(fname), library_name)
         library = self._libraries[library_name]

--- a/vunit/sim_if/__init__.py
+++ b/vunit/sim_if/__init__.py
@@ -223,7 +223,7 @@ class SimulatorInterface(object):  # pylint: disable=too-many-public-methods
             command = None
             printer.write("failed", fg="ri")
             printer.write("\n")
-            printer.write("File type not supported by %s simulator\n" % (self.name))
+            printer.write(f"File type not supported by {self.name!s} simulator\n")
 
             return False
 
@@ -236,9 +236,9 @@ class SimulatorInterface(object):  # pylint: disable=too-many-public-methods
         except subprocess.CalledProcessError as err:
             printer.write("failed", fg="ri")
             printer.write("\n")
-            printer.write("=== Command used: ===\n%s\n" % (subprocess.list2cmdline(command)))
+            printer.write(f"=== Command used: ===\n{subprocess.list2cmdline(command)!s}\n")
             printer.write("\n")
-            printer.write("=== Command output: ===\n%s\n" % err.output)
+            printer.write(f"=== Command output: ===\n{err.output!s}\n")
 
             return False
 
@@ -273,11 +273,8 @@ class SimulatorInterface(object):  # pylint: disable=too-many-public-methods
 
         for source_file in source_files:
             printer.write(
-                "Compiling into %s %s "
-                % (
-                    (source_file.library.name + ":").ljust(max_library_name + 1),
-                    simplify_path(source_file.name).ljust(max_source_file_name),
-                )
+                f"Compiling into {(source_file.library.name + ':').ljust(max_library_name + 1)!s} "
+                f"{simplify_path(source_file.name).ljust(max_source_file_name)!s} "
             )
             sys.stdout.flush()
 
@@ -359,7 +356,7 @@ class BooleanOption(Option):
 
     def validate(self, value):
         if value not in (True, False):
-            raise ValueError("Option %r must be a boolean. Got %r" % (self.name, value))
+            raise ValueError(f"Option {self.name!r} must be a boolean. Got {value!r}")
 
 
 class StringOption(Option):
@@ -369,7 +366,7 @@ class StringOption(Option):
 
     def validate(self, value):
         if not is_string_not_iterable(value):
-            raise ValueError("Option %r must be a string. Got %r" % (self.name, value))
+            raise ValueError(f"Option {self.name!r} must be a string. Got {value!r}")
 
 
 class ListOfStringOption(Option):
@@ -379,7 +376,7 @@ class ListOfStringOption(Option):
 
     def validate(self, value):
         def fail():
-            raise ValueError("Option %r must be a list of strings. Got %r" % (self.name, value))
+            raise ValueError(f"Option {self.name!r} must be a list of strings. Got {value!r}")
 
         if is_string_not_iterable(value):
             fail()
@@ -404,7 +401,7 @@ class VHDLAssertLevelOption(Option):
 
     def validate(self, value):
         if value not in self._legal_values:
-            raise ValueError("Option %r must be one of %s. Got %r" % (self.name, self._legal_values, value))
+            raise ValueError(f"Option {self.name!r} must be one of {self._legal_values!s}. Got {value!r}")
 
 
 def is_string_not_iterable(value):

--- a/vunit/source_file.py
+++ b/vunit/source_file.py
@@ -68,7 +68,7 @@ class SourceFile(object):
         return hash(self.to_tuple())
 
     def __repr__(self):
-        return "SourceFile(%s, %s)" % (self.name, self.library.name)
+        return f"SourceFile({self.name!s}, {self.library.name!s})"
 
     def set_compile_option(self, name, value):
         """
@@ -362,4 +362,4 @@ def file_type_of(file_name):
     if ext.lower() in SYSTEM_VERILOG_EXTENSIONS:
         return "systemverilog"
 
-    raise RuntimeError("Unknown file ending '%s' of %s" % (ext, file_name))
+    raise RuntimeError(f"Unknown file ending '{ext!s}' of {file_name!s}")

--- a/vunit/test/bench.py
+++ b/vunit/test/bench.py
@@ -73,7 +73,7 @@ class TestBench(ConfigurationVisitor):
         Get the default configuration of this test bench
         """
         if self._individual_tests:
-            raise RuntimeError("Test bench %s.%s has individually configured tests" % (self.library_name, self.name))
+            raise RuntimeError(f"Test bench {self.library_name!s}.{self.name!s} has individually configured tests")
         return self._configs[DEFAULT_NAME]
 
     @staticmethod
@@ -84,19 +84,14 @@ class TestBench(ConfigurationVisitor):
         """
         if design_unit.is_entity:
             if not design_unit.architecture_names:
-                raise RuntimeError("Test bench '%s' has no architecture." % design_unit.name)
+                raise RuntimeError(f"Test bench '{design_unit.name!s}' has no architecture.")
 
             if len(design_unit.architecture_names) > 1:
+                archs = ", ".join(
+                    f"{name!s}:{Path(fname).name!s}" for name, fname in sorted(design_unit.architecture_names.items())
+                )
                 raise RuntimeError(
-                    "Test bench not allowed to have multiple architectures. "
-                    "Entity %s has %s"
-                    % (
-                        design_unit.name,
-                        ", ".join(
-                            "%s:%s" % (name, str(Path(fname).name))
-                            for name, fname in sorted(design_unit.architecture_names.items())
-                        ),
-                    )
+                    "Test bench not allowed to have multiple architectures. " f"Entity {design_unit.name!s} has {archs}"
                 )
 
     def create_tests(self, simulator_if, elaborate_only, test_list=None):
@@ -176,7 +171,7 @@ class TestBench(ConfigurationVisitor):
         Scan file for test cases and attributes
         """
         if not file_exists(file_name):
-            raise ValueError("File %r does not exist" % file_name)
+            raise ValueError(f"File {file_name!r} does not exist")
 
         def parse(content):
             """
@@ -197,16 +192,16 @@ class TestBench(ConfigurationVisitor):
         for attr in attributes:
             if _is_user_attribute(attr.name):
                 raise RuntimeError(
-                    "File global attributes are not yet supported: %s in %s line %i"
-                    % (attr.name, file_name, attr.location.lineno)
+                    f"File global attributes are not yet supported: {attr.name!s} in "
+                    f"{file_name!s} line {attr.location.lineno:d}"
                 )
 
         for test in tests:
             for attr in test.attributes:
                 if attr.name in _VALID_ATTRIBUTES:
                     raise RuntimeError(
-                        "Attribute %s is global and cannot be associated with test %s: %s line %i"
-                        % (attr.name, test.name, file_name, attr.location.lineno)
+                        f"Attribute {attr.name!s} is global and cannot be associated with test {test.name!s}: "
+                        f"{file_name!s} line {attr.location.lineno:d}"
                     )
 
         attribute_names = [attr.name for attr in attributes]
@@ -501,18 +496,13 @@ def _check_duplicates(attrs, file_name, test_name=None):
     for attr in attrs:
         if attr.name in previous:
 
-            if test_name is None:
-                loc = "%s line %i" % (file_name, attr.location.lineno)
-            else:
-                loc = "test %s in %s line %i" % (
-                    test_name,
-                    file_name,
-                    attr.location.lineno,
-                )
+            loc = (
+                "" if test_name is None else f"test {test_name!s} in "
+            ) + f"{file_name!s} line {attr.location.lineno:d}"
 
             raise RuntimeError(
-                "Duplicate attribute %s of %s, previously defined on line %i"
-                % (attr.name, loc, previous[attr.name].location.lineno)
+                f"Duplicate attribute {attr.name!s} of {loc!s}, "
+                f"previously defined on line {previous[attr.name].location.lineno:d}"
             )
 
         previous[attr.name] = attr
@@ -606,7 +596,7 @@ def _find_attributes(code, file_name, line_offsets=None):
             location = FileLocation.from_match(file_name, match, "name", line_offsets)
 
             if not _is_user_attribute(name) and name not in _VALID_ATTRIBUTES:
-                raise RuntimeError("Invalid attribute '%s' in %s line %i" % (name, file_name, location.lineno))
+                raise RuntimeError(f"Invalid attribute '{name!s}' in {file_name!s} line {location.lineno:d}")
 
             attributes.append(attr_class(name, value=None, location=location))
 

--- a/vunit/test/report.py
+++ b/vunit/test/report.py
@@ -86,12 +86,12 @@ class TestReport(object):
             assert False
 
         args = []
-        args.append("P=%i" % len(passed))
-        args.append("S=%i" % len(skipped))
-        args.append("F=%i" % len(failed))
-        args.append("T=%i" % total_tests)
+        args.append(f"P={len(passed):d}")
+        args.append(f"S={len(skipped):d}")
+        args.append(f"F={len(failed):d}")
+        args.append(f"T={total_tests:d}")
 
-        self._printer.write(" (%s) %s (%.1f seconds)\n" % (" ".join(args), result.name, result.time))
+        self._printer.write(f" ({' '.join(args)!s}) {result.name!s} ({result.time:.1f} seconds)\n")
 
     def all_ok(self):
         """
@@ -120,33 +120,33 @@ class TestReport(object):
 
         prefix = "==== Summary "
         max_len = max(len(test.name) for test in all_tests)
-        self._printer.write("%s%s\n" % (prefix, "=" * (max(max_len - len(prefix) + 25, 0))))
+        self._printer.write(f"{prefix!s}{'=' * (max(max_len - len(prefix) + 25, 0))}\n")
         for test_result in all_tests:
             test_result.print_status(self._printer, padding=max_len)
 
-        self._printer.write("%s\n" % ("=" * (max(max_len + 25, 0))))
+        self._printer.write(("=" * (max(max_len + 25, 0))) + "\n")
         n_failed = len(failures)
         n_skipped = len(skipped)
         n_passed = len(passed)
         total = len(all_tests)
 
         self._printer.write("pass", fg="gi")
-        self._printer.write(" %i of %i\n" % (n_passed, total))
+        self._printer.write(f" {n_passed:d} of {total:d}\n")
 
         if n_skipped > 0:
             self._printer.write("skip", fg="rgi")
-            self._printer.write(" %i of %i\n" % (n_skipped, total))
+            self._printer.write(f" {n_skipped:d} of {total:d}\n")
 
         if n_failed > 0:
             self._printer.write("fail", fg="ri")
-            self._printer.write(" %i of %i\n" % (n_failed, total))
-        self._printer.write("%s\n" % ("=" * (max(max_len + 25, 0))))
+            self._printer.write(f" {n_failed:d} of {total:d}\n")
+        self._printer.write(("=" * (max(max_len + 25, 0))) + "\n")
 
         total_time = sum((result.time for result in self._test_results.values()))
-        self._printer.write("Total time was %.1f seconds\n" % total_time)
-        self._printer.write("Elapsed time was %.1f seconds\n" % self._real_total_time)
+        self._printer.write(f"Total time was {total_time:.1f} seconds\n")
+        self._printer.write(f"Elapsed time was {self._real_total_time:.1f} seconds\n")
 
-        self._printer.write("%s\n" % ("=" * (max(max_len + 25, 0))))
+        self._printer.write(("=" * (max(max_len + 25, 0))) + "\n")
 
         if n_failed > 0:
             self._printer.write("Some failed!", fg="ri")
@@ -159,8 +159,8 @@ class TestReport(object):
         assert len(all_tests) <= self._expected_num_tests
         if len(all_tests) < self._expected_num_tests:
             self._printer.write(
-                "WARNING: Test execution aborted after running %d out of %d tests"
-                % (len(all_tests), self._expected_num_tests),
+                f"WARNING: Test execution aborted after running "
+                f"{len(all_tests):d} out of {self._expected_num_tests:d} tests",
                 fg="rgi",
             )
             self._printer.write("\n")
@@ -219,7 +219,7 @@ class TestStatus(object):
         return isinstance(other, type(self)) and self.name == other.name
 
     def __repr__(self):
-        return "TestStatus(%r)" % self._name
+        return f"TestStatus({self._name!r})"
 
 
 PASSED = TestStatus("passed")
@@ -249,7 +249,7 @@ class TestResult(object):
         if file_exists and is_readable:
             return read_file(self._output_file_name)
 
-        return "Failed to read output file: %s" % self._output_file_name
+        return f"Failed to read output file: {self._output_file_name!s}"
 
     @property
     def passed(self):
@@ -279,7 +279,7 @@ class TestResult(object):
 
         my_padding = max(padding - len(self.name), 0)
 
-        printer.write("%s (%.1f seconds)\n" % (self.name + (" " * my_padding), self.time))
+        printer.write(f"{self.name + (' ' * my_padding)} ({self.time:.1f} seconds)\n")
 
     def to_xml(self, xunit_xml_format):
         """
@@ -292,7 +292,7 @@ class TestResult(object):
             test.attrib["name"] = match.group(2)
         else:
             test.attrib["name"] = self.name
-        test.attrib["time"] = "%.1f" % self.time
+        test.attrib["time"] = f"{self.time:.1f}"
 
         # By default the output is stored in system-out
         system_out = ElementTree.SubElement(test, "system-out")

--- a/vunit/test/runner.py
+++ b/vunit/test/runner.py
@@ -90,7 +90,7 @@ class TestRunner(object):  # pylint: disable=too-many-instance-attributes
                     print("Running test: " + test_name)
 
         if self._is_verbose:
-            print("Running %i tests" % num_tests)
+            print(f"Running {num_tests:d} tests")
             print()
 
         self._report.set_expected_num_tests(num_tests)
@@ -149,8 +149,8 @@ class TestRunner(object):  # pylint: disable=too-many-instance-attributes
 
                 with self._stdout_lock():
                     for test_name in test_suite.test_names:
-                        print("Starting %s" % test_name)
-                    print("Output file: %s" % output_file_name)
+                        print(f"Starting {test_name!s}")
+                    print(f"Output file: {output_file_name!s}")
 
                 self._run_test_suite(test_suite, write_stdout, num_tests, output_path, output_file_name)
 
@@ -294,7 +294,7 @@ class TestRunner(object):  # pylint: disable=too-many-instance-attributes
 
         for test_suite in test_suites:
             test_output = self._get_output_path(test_suite.name)
-            mapping.add("%s %s" % (Path(test_output).name, test_suite.name))
+            mapping.add(f"{Path(test_output).name!s} {test_suite.name!s}")
 
         # Sort by everything except hash
         mapping = sorted(mapping, key=lambda value: value[value.index(" ") :])

--- a/vunit/test/suites.py
+++ b/vunit/test/suites.py
@@ -19,7 +19,7 @@ class IndependentSimTestCase(object):
     """
 
     def __init__(self, test, config, simulator_if, elaborate_only=False):
-        self._name = "%s.%s" % (config.library_name, config.design_unit_name)
+        self._name = f"{config.library_name!s}.{config.design_unit_name!s}"
 
         if not config.is_default:
             self._name += "." + config.name
@@ -79,7 +79,7 @@ class SameSimTestSuite(object):
     """
 
     def __init__(self, tests, config, simulator_if, elaborate_only=False):
-        self._name = "%s.%s" % (config.library_name, config.design_unit_name)
+        self._name = f"{config.library_name!s}.{config.design_unit_name!s}"
 
         if not config.is_default:
             self._name += "." + config.name
@@ -219,7 +219,7 @@ class TestRun(object):
         config = self._config.copy()
 
         if "output_path" in config.generic_names and "output_path" not in config.generics:
-            config.generics["output_path"] = "%s/" % output_path.replace("\\", "/")
+            config.generics["output_path"] = str(output_path.replace("\\", "/")) + "/"
 
         runner_cfg = {
             "enabled_test_cases": ",".join(
@@ -284,7 +284,7 @@ class TestRun(object):
 
         for test_name in results:
             if test_name not in self._test_cases:
-                raise RuntimeError("Got unknown test case %s" % test_name)
+                raise RuntimeError(f"Got unknown test case {test_name!s}")
 
         return results
 
@@ -312,7 +312,7 @@ def encode_dict(dictionary):
     encoded = []
     for key in sorted(dictionary.keys()):
         value = dictionary[key]
-        encoded.append("%s : %s" % (escape(key), escape(encode_dict_value(value))))
+        encoded.append(f"{escape(key)!s} : {escape(encode_dict_value(value))!s}")
     return ",".join(encoded)
 
 

--- a/vunit/ui/__init__.py
+++ b/vunit/ui/__init__.py
@@ -291,7 +291,7 @@ class VUnit(object):  # pylint: disable=too-many-instance-attributes, too-many-p
         if not self._project.has_library(library_name):
             self._project.add_library(library_name, str(path.resolve()), standard)
         elif not allow_duplicate:
-            raise ValueError("Library %s already added. Use allow_duplicate to ignore this error." % library_name)
+            raise ValueError(f"Library {library_name!s} already added. Use allow_duplicate to ignore this error.")
         return self.library(library_name)
 
     def library(self, library_name: str):
@@ -446,12 +446,12 @@ class VUnit(object):  # pylint: disable=too-many-instance-attributes, too-many-p
 
         files = self.get_source_files(fstr, library_name, allow_empty=True)
         if len(files) > 1:
-            raise ValueError("Found file named '%s' in multiple-libraries, " "add explicit library_name." % fstr)
+            raise ValueError(f"Found file named '{fstr!s}' in multiple-libraries, " "add explicit library_name.")
         if not files:
             if library_name is None:
-                raise ValueError("Found no file named '%s'" % fstr)
+                raise ValueError(f"Found no file named '{fstr!s}'")
 
-            raise ValueError("Found no file named '%s' in library '%s'" % (fstr, library_name))
+            raise ValueError(f"Found no file named '{fstr!s}' in library '{library_name!s}'")
         return files[0]
 
     def get_source_files(
@@ -485,8 +485,8 @@ class VUnit(object):  # pylint: disable=too-many-instance-attributes, too-many-p
         check_not_empty(
             results,
             allow_empty,
-            ("Pattern %r did not match any file" % pattern)
-            + (("within library %s" % library_name) if library_name is not None else ""),
+            f"Pattern {pattern!r} did not match any file"
+            + (f"within library {library_name!s}" if library_name is not None else ""),
         )
 
         return SourceFileList(results)
@@ -614,7 +614,7 @@ class VUnit(object):  # pylint: disable=too-many-instance-attributes, too-many-p
             while ostools.file_exists(pp_file_name):
                 LOGGER.debug("Preprocessed file exists '%s', adding prefix", pp_file_name)
                 pp_file_name = str(
-                    Path(self._preprocessed_path) / library_name / ("%i_%s" % (idx, fname)),
+                    Path(self._preprocessed_path) / library_name / f"{idx}_{fname!s}",
                 )
                 idx += 1
 
@@ -775,7 +775,7 @@ avoid location preprocessing of other functions sharing name with a VUnit log or
         test_list = self._create_tests(simulator_if=None)
         for test_name in test_list.test_names:
             print(test_name)
-        print("Listed %i tests" % test_list.num_tests)
+        print(f"Listed {test_list.num_tests} tests")
         return True
 
     def _main_export_json(self, json_file_name: Union[str, Path]):  # pylint: disable=too-many-locals
@@ -839,8 +839,8 @@ avoid location preprocessing of other functions sharing name with a VUnit log or
         """
         files = self.get_compile_order()
         for source_file in files:
-            print("%s, %s" % (source_file.library.name, source_file.name))
-        print("Listed %i files" % len(files))
+            print(f"{source_file.library.name!s}, {source_file.name!s}")
+        print(f"Listed {len(files)} files")
         return True
 
     def _main_compile_only(self):

--- a/vunit/ui/common.py
+++ b/vunit/ui/common.py
@@ -70,7 +70,7 @@ def get_checked_file_names_from_globs(pattern, allow_empty):
         check_not_empty(
             new_file_names,
             allow_empty,
-            "Pattern %r did not match any file" % pattern_instance,
+            f"Pattern {pattern_instance!r} did not match any file",
         )
         file_names += new_file_names
 

--- a/vunit/ui/library.py
+++ b/vunit/ui/library.py
@@ -235,7 +235,7 @@ class Library(object):
         if file_type is None:
             file_type = file_type_of(file_name)
         elif file_type not in FILE_TYPES:
-            raise ValueError("file_type %r not in %r" % (file_type, FILE_TYPES))
+            raise ValueError(f"file_type {file_type!r} not in {FILE_TYPES!r}")
 
         if file_type in VERILOG_FILE_TYPES:
             include_dirs = include_dirs if include_dirs is not None else []
@@ -334,7 +334,7 @@ class Library(object):
         return check_not_empty(
             results,
             allow_empty,
-            "No test benches found within library %s" % self._library_name,
+            f"No test benches found within library {self._library_name!s}",
         )
 
     def _which_vhdl_standard(self, vhdl_standard: Optional[str]) -> VHDLStandard:

--- a/vunit/version_check.py
+++ b/vunit/version_check.py
@@ -24,9 +24,9 @@ def version_is_ok():
 
 if not version_is_ok():
     print(
-        "Your Python version (%i.%i) is too old for VUnit. "
-        "Please consider upgrading." % (sys.version_info[0], sys.version_info[1])
+        f"Your Python version ({sys.version_info[0]}.{sys.version_info[1]}) is too old for VUnit. "
+        "Please consider upgrading."
     )
     print("VUnit supports versions:")
-    print(" - Python %i.%i or higher" % (MAJOR, MINOR))
+    print(f" - Python {MAJOR}.{MINOR} or higher")
     sys.exit(1)

--- a/vunit/vhdl_parser.py
+++ b/vunit/vhdl_parser.py
@@ -1062,12 +1062,7 @@ class VHDLReference(object):
         self.name_within = name_within
 
     def __repr__(self):
-        return "VHDLReference(%r, %r, %r, %r)" % (
-            self.reference_type,
-            self.library,
-            self.design_unit,
-            self.name_within,
-        )
+        return f"VHDLReference({self.reference_type!r}, {self.library!r}, {self.design_unit!r}, {self.name_within!r})"
 
     def __eq__(self, other):
         return (

--- a/vunit/vhdl_standard.py
+++ b/vunit/vhdl_standard.py
@@ -28,7 +28,7 @@ class VHDLStandard(object):
                     self._standard = standard
                     break
             else:
-                raise ValueError("Unknown standard '%s'" % standard_name)
+                raise ValueError(f"Unknown standard '{standard_name!s}'")
 
     def __eq__(self, other):
         if isinstance(other, self.__class__):
@@ -45,7 +45,7 @@ class VHDLStandard(object):
         return self._standard
 
     def __repr__(self):
-        return "VHDLStandard(%r)" % self._standard
+        return f"VHDLStandard({self._standard!r})"
 
     def __hash__(self):
         return hash(self._standard)

--- a/vunit/vivado/vivado.py
+++ b/vunit/vivado/vivado.py
@@ -63,7 +63,7 @@ def create_compile_order_file(project_file, compile_order_file, vivado_path=None
     """
     Create compile file from Vivado project
     """
-    print("Generating Vivado project compile order into %s ..." % str(Path(compile_order_file).resolve()))
+    print(f"Generating Vivado project compile order into {str(Path(compile_order_file).resolve())} ...")
 
     fpath = Path(compile_order_file)
     if not fpath.parent.exists():
@@ -115,7 +115,7 @@ def run_vivado(tcl_file_name, tcl_args=None, cwd=None, vivado_path=None):
     Note: the shell=True is important in windows where Vivado is just a bat file.
     """
     vivado = "vivado" if vivado_path is None else str(Path(vivado_path).resolve() / "bin" / "vivado")
-    cmd = "{} -nojournal -nolog -notrace -mode batch -source {}".format(vivado, str(Path(tcl_file_name).resolve()))
+    cmd = f"{vivado} -nojournal -nolog -notrace -mode batch -source {str(Path(tcl_file_name).resolve())}"
     if tcl_args is not None:
         cmd += " -tclargs " + " ".join([str(val) for val in tcl_args])
 

--- a/vunit/vunit_cli.py
+++ b/vunit/vunit_cli.py
@@ -71,7 +71,7 @@ def _create_argument_parser(description=None, for_documentation=False):
     :returns: The created :mod:`argparse` parser object
     """
     if description is None:
-        description = "VUnit command line tool version %s" % version()
+        description = f"VUnit command line tool version {version()!s}"
 
     if for_documentation:
         default_output_path = "./vunit_out"
@@ -250,7 +250,7 @@ def positive_int(val):
         assert ival > 0
         return ival
     except (ValueError, AssertionError) as exv:
-        raise argparse.ArgumentTypeError("'%s' is not a valid positive int" % val) from exv
+        raise argparse.ArgumentTypeError(f"'{val!s}' is not a valid positive int") from exv
 
 
 def _parser_for_documentation():


### PR DESCRIPTION
Currently, we are using a deprecated syntax (`"some text %s" % variable`) for formatting strings. CI linting is complaining about it.

There are three alternatives:

- `"some text %s".format(variable)"`
- `f"some text {variable}"`
- `"some text" + str(variable)`

It seems that the official syntax going forward is the second one only (f-strings). I tried using the first one, but linters would still complain. With regard to the last one, that is not desirable I think, however, in some cases I found it necessary because I couldn't make it work using f-strings.

In this PR, most of the sources in the codebase are modified for using f-strings instead of `"some text %s" % variable` or `"some text %s".format(variable)"`. The remaining sources belong to `vunit/sim_if`. I "fixed" those already, but I cannot test all of them. Hence, I decided to include the `ghdl.py` only, and handle those in an upcoming PR.

I followed the following guidelines:

- Replace `%s` with `{VARIABLE!s}`.
- Replace `%r` with `{VARIABLE!r}`.
- Replace `%i` with `{VARIABLE:d}`.
- Replace `%.1f` with `{VARIABLE:.1f}`.
- Replace `"%s\n" % " ".join(cmd)` with `" ".join(cmd) + "\n"`, and `"%s\n" % ("=" * (max(max_len + 25, 0)))` with `("=" * (max(max_len + 25, 0))) + "\n"`.