### PR TITLE
parsing/tokenizer: partial revert of 5141f7c6 (#735)

### DIFF
--- a/vunit/parsing/tokenizer.py
+++ b/vunit/parsing/tokenizer.py
@@ -13,8 +13,11 @@ import re
 from vunit.ostools import read_file, file_exists, simplify_path
 
 
+TokenType = collections.namedtuple("Token", ["kind", "value", "location"])
+
+
 def Token(kind, value="", location=None):  # pylint: disable=invalid-name
-    return collections.namedtuple("Token", ["kind", "value", "location"])(kind, value, location)
+    return TokenType(kind, value, location)
 
 
 class TokenKind:


### PR DESCRIPTION
Close #735.

As discussed in #735, this improves performance significantly.

The previous change was done because of some linter issue. However, this PR seems not to trigger any new warning. Therefore the original issue might have been a temporary rule in the linter.