### PR TITLE
add 'compile_builtins' deprecation warning

### DIFF
--- a/docs/data_types/external_api.rst
+++ b/docs/data_types/external_api.rst
@@ -16,11 +16,10 @@ List of types that are currently in the external VHDL API:
 * **string_ptr**, and **byte_vector_ptr** as an alias (:ref:`External string API <ext_string_pkg>`)
 * **integer_vector_ptr** (:ref:`External integer vector API <ext_integer_vector_pkg>`)
 
-.. important:: By default, bodies of the external API functions/procedures include forced failure assertions. Hence, using ``mode/=internal`` without providing a *bridge* to a foreign language will make tests fail. Bridges must be provided through `vu.add_builtins(external=<Options>)`, where `<Options>` defaults to ``{"string": False, "integer_vector": False}``. Each field should contain a list of VHDL files to replace the *dummy* default. See `VUnit/cosim <https://github.com/VUnit/cosim>`_ for reference implementations of bridges and examples.
+.. important:: By default, bodies of the external API functions/procedures include forced failure assertions. Hence, using ``mode/=internal`` without providing a *bridge* to a foreign language will make tests fail. Bridges must be provided through `vu.add_vhdl_builtins(external=<Options>)`, where `<Options>` defaults to ``{"string": False, "integer_vector": False}``. Each field should contain a list of VHDL files to replace the *dummy* default. See `VUnit/cosim <https://github.com/VUnit/cosim>`_ for reference implementations of bridges and examples.
 
 .. toctree::
    :hidden:
 
    ext_string
    ext_integer_vector
-

--- a/docs/py/vunit.rst
+++ b/docs/py/vunit.rst
@@ -2,8 +2,7 @@ vunit.ui
 ========
 
 .. autoclass:: vunit.ui.VUnit()
-   :exclude-members: add_preprocessor,
-      add_builtins
+   :exclude-members: add_preprocessor
 
 Library
 -------

--- a/vunit/builtins.py
+++ b/vunit/builtins.py
@@ -224,10 +224,15 @@ in your VUnit Git repository? You have to do this first if installing using setu
         Add vunit VHDL builtin libraries
 
         :param external: struct to provide bridges for the external VHDL API.
-                         {
-                             'string': ['path/to/custom/file'],
-                             'integer': ['path/to/custom/file']
-                         }.
+
+        :example:
+
+        .. code-block:: python
+
+            Builtins.add_vhdl_builtins(external={
+                'string': ['path/to/custom/file'],
+                'integer': ['path/to/custom/file']
+            })
         """
         self._add_data_types(external=external)
         self._add_files(VHDL_PATH / "*.vhd")

--- a/vunit/ui/__init__.py
+++ b/vunit/ui/__init__.py
@@ -19,7 +19,6 @@ import os
 from typing import Optional, Set, Union
 from pathlib import Path
 from fnmatch import fnmatch
-from warnings import warn
 
 from ..database import PickledDataBase, DataBase
 from .. import ostools
@@ -160,13 +159,22 @@ class VUnit(object):  # pylint: disable=too-many-instance-attributes, too-many-p
         self._builtins = Builtins(self, self._vhdl_standard, simulator_class)
         if compile_builtins:
             self.add_vhdl_builtins()
-            builtins_deprecation_note = (
-                "'compile_builtins' (which defaults to 'True') is deprecated "
-                "and it will be removed in future releases; "
-                "preserve the functionality using "
-                "'compile_builtins=False' and 'VU.add_vhdl_builtins'"
+            hline = "=" * 75
+            print(hline)
+            LOGGER.warning(
+                """Option 'compile_builtins' of methods 'from_args' and 'from_argv' is deprecated.
+In future releases, it will be removed and builtins will need to be added explicitly.
+To prepare for upcoming changes, it is recommended to apply the following modifications in the run script now:
+
+* Use `from_argv(compile_builtins=False)` or `from_args(compile_builtins=False)`.
+* Add an explicit call to 'add_vhdl_builtins'.
+
+Refs:
+  * http://vunit.github.io/py/vunit.html#vunit.ui.VUnit.from_args
+  * http://vunit.github.io/py/vunit.html#vunit.ui.VUnit.from_argv
+"""
             )
-            warn(builtins_deprecation_note, Warning)
+            print(hline)
 
     def _create_database(self):
         """

--- a/vunit/ui/__init__.py
+++ b/vunit/ui/__init__.py
@@ -930,10 +930,15 @@ avoid location preprocessing of other functions sharing name with a VUnit log or
         Add vunit VHDL builtin libraries
 
         :param external: struct to provide bridges for the external VHDL API.
-                         {
-                             'string': ['path/to/custom/file'],
-                             'integer': ['path/to/custom/file']
-                         }.
+
+        :example:
+
+        .. code-block:: python
+
+            VU.add_builtins(external={
+                'string': ['path/to/custom/file'],
+                'integer': ['path/to/custom/file']}
+            )
         """
         self._builtins.add_vhdl_builtins(external=external)
 

--- a/vunit/ui/__init__.py
+++ b/vunit/ui/__init__.py
@@ -19,6 +19,8 @@ import os
 from typing import Optional, Set, Union
 from pathlib import Path
 from fnmatch import fnmatch
+from warnings import warn
+
 from ..database import PickledDataBase, DataBase
 from .. import ostools
 from ..vunit_cli import VUnitCLI
@@ -158,6 +160,13 @@ class VUnit(object):  # pylint: disable=too-many-instance-attributes, too-many-p
         self._builtins = Builtins(self, self._vhdl_standard, simulator_class)
         if compile_builtins:
             self.add_builtins()
+            builtins_deprecation_note = (
+                "'compile_builtins' (which defaults to 'True') is deprecated "
+                "and it will be removed in future releases; "
+                "preserve the functionality using "
+                "'compile_builtins=False' and 'VU.add_builtins'"
+            )
+            warn(builtins_deprecation_note, Warning)
 
     def _create_database(self):
         """

--- a/vunit/ui/__init__.py
+++ b/vunit/ui/__init__.py
@@ -159,12 +159,12 @@ class VUnit(object):  # pylint: disable=too-many-instance-attributes, too-many-p
 
         self._builtins = Builtins(self, self._vhdl_standard, simulator_class)
         if compile_builtins:
-            self.add_builtins()
+            self.add_vhdl_builtins()
             builtins_deprecation_note = (
                 "'compile_builtins' (which defaults to 'True') is deprecated "
                 "and it will be removed in future releases; "
                 "preserve the functionality using "
-                "'compile_builtins=False' and 'VU.add_builtins'"
+                "'compile_builtins=False' and 'VU.add_vhdl_builtins'"
             )
             warn(builtins_deprecation_note, Warning)
 
@@ -934,9 +934,15 @@ avoid location preprocessing of other functions sharing name with a VUnit log or
         )
         runner.run(test_cases)
 
-    def add_builtins(self, external=None):
+    def add_verilog_builtins(self):
         """
-        Add vunit VHDL builtin libraries
+        Add VUnit Verilog builtin libraries
+        """
+        self._builtins.add_verilog_builtins()
+
+    def add_vhdl_builtins(self, external=None):
+        """
+        Add VUnit VHDL builtin libraries
 
         :param external: struct to provide bridges for the external VHDL API.
 
@@ -944,7 +950,7 @@ avoid location preprocessing of other functions sharing name with a VUnit log or
 
         .. code-block:: python
 
-            VU.add_builtins(external={
+            VU.add_vhdl_builtins(external={
                 'string': ['path/to/custom/file'],
                 'integer': ['path/to/custom/file']}
             )

--- a/vunit/verilog.py
+++ b/vunit/verilog.py
@@ -8,6 +8,7 @@
 The main public Python interface of VUnit-Verilog.
 """
 
+from warnings import warn
 from vunit.ui import VUnit as VUnitVHDL
 
 
@@ -16,12 +17,15 @@ class VUnit(VUnitVHDL):
     VUnit Verilog interface
     """
 
-    def add_builtins(self, external=None):  # pylint: disable=arguments-differ
+    # This is a temporary workaround to avoid breaking the scripts of current verilog users
+    def add_vhdl_builtins(self):  # pylint: disable=arguments-differ
         """
         Add vunit Verilog builtin libraries
         """
         self._builtins.add_verilog_builtins()
         builtins_deprecation_note = (
-            "class 'verilog' is deprecated and it will be removed in future releases"
+            "class 'verilog' is deprecated and it will be removed in future releases; "
+            "preserve the functionality using the default vunit class, along with "
+            "'compile_builtins=False' and 'VU.add_verilog_builtins'"
         )
         warn(builtins_deprecation_note, Warning)

--- a/vunit/verilog.py
+++ b/vunit/verilog.py
@@ -21,3 +21,7 @@ class VUnit(VUnitVHDL):
         Add vunit Verilog builtin libraries
         """
         self._builtins.add_verilog_builtins()
+        builtins_deprecation_note = (
+            "class 'verilog' is deprecated and it will be removed in future releases"
+        )
+        warn(builtins_deprecation_note, Warning)

--- a/vunit/verilog/check/run.py
+++ b/vunit/verilog/check/run.py
@@ -5,12 +5,14 @@
 # Copyright (c) 2014-2021, Lars Asplund lars.anders.asplund@gmail.com
 
 from pathlib import Path
-from vunit.verilog import VUnit
+from vunit import VUnit
 
 
 ROOT = Path(__file__).parent
 
 VU = VUnit.from_argv()
+VU.add_verilog_builtins()
+
 VU.add_library("lib").add_source_files(ROOT / "test" / "*.sv")
 VU.set_sim_option("modelsim.vsim_flags.gui", ["-novopt"])
 


### PR DESCRIPTION
This PR lays the ground for deprecating `compile_builtins` and `vunit.verilog` in upcoming releases (not the next one). As discussed in #559, `add_builtins` is to be split into `add_vhdl_builtins` and `add_verilog_builtins`. In the future, users will need to use them explicitly (as it is required for `add_osvvm` or `add_verification_components`).

In this PR, `compile_builtins` is NOT deprecated yet. A warning is added, which will be shown to all the users which are currently using it. Since it is enabled by default, it will be shown for most of the current users of VUnit. The recommendation is that they can use `compile_builtins=False` and `VU.add_vhdl_builtins` now, or wait until the deprecation.

This PR does include a breaking change in the public API, since `add_builtins` is renamed to `add_vhdl_builtins`. That is to avoid the warning recommending the users a function that is to be removed (`add_builtins`). However, since the vast majority of VUnit users should not even be aware that `add_builtins` exists, this change should not be disruptive.

BTW, for some reason `add_builtins` was not shown in the documentation. I don't remember whether it was hidden on purpose (because of being redundant to `compile_builtins`) or because it crashed Sphinx. Anyway, I fixed the docstring and, since it is split, the documentation now includes both `add_verilog_builtins` and `add_vhdl_builtins`.