### PR TITLE
Fix PSL check for valid fifo in data during write, fixes #750

### DIFF
--- a/examples/vhdl/array_axis_vcs/src/fifo.vhd
+++ b/examples/vhdl/array_axis_vcs/src/fifo.vhd
@@ -38,10 +38,8 @@ begin
   -- If your simulator chokes on the following block,
   -- see https://electronics.stackexchange.com/questions/540769/what-kind-of-vhdl-process-is-this/
   PslChecks : block is
-    constant dx : std_logic_vector(d'left downto 0) := (others => 'X');
-    constant du : std_logic_vector(d'left downto 0) := (others => 'U');
   begin
-    assert always (not rst and wr -> not (d ?= dx or d ?= du))@rising_edge(clkw)
+    assert always (not rst and wr -> not is_x(d))@rising_edge(clkw)
       report "wrote X|U to FIFO";
     assert always (not rst and f -> not wr)@rising_edge(clkw)
       report "Wrote to FIFO while full";


### PR DESCRIPTION
As @JimLewis reported in #750 the result of the test if data is unknown during a FIFO write is not what we want in all cases. I fixed that by using the reduction `or` in combination with the `to_x01()` function. That's also better readable code IMHO.