### PR TITLE
builtins: skip addition of builtins if the library is added previously

### DIFF
--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -212,3 +212,13 @@ named ``vX.Y.Z`` is found in Git. A new release will not be made if:
 
 - The ``X.Y.Z`` release is already on PyPI.
 - The repo tag does not exist.
+
+Submodule related
+-----------------
+
+As of VUnit v4.7.0, the version of the submodules is printed in the corresponding ``add_*`` methods of
+:vunit_file:`builtins.py <vunit/builtins.py>`.
+Therefore, when bumping the submodules, maintainers/contributors need to remember modifying the string to match the new
+version.
+
+Furthermore, since OSVVM is tagged periodically, bumping from tag to tag is strongly suggested.


### PR DESCRIPTION
As discussed in #767, this PR modifies the functions for adding the built OSVVM and JSON-for-VHDL.  Currently, a try...except block is used:

https://github.com/VUnit/vunit/blob/7879504ba6a97be82137199e8819f770e4017681/vunit/builtins.py#L139-L142

That approach has two main caveats. On the one hand, the `try` statement is not case sensitive. Hence, if a library named `OSVVM` exists, it does not get it when asking for `osvvm`. That falls back to the exception, which crashes because adding a library is case insensitive. If no crash is produced, additional sources are added to the existing library.

In this PR, `_add_library_if_not_exist` is added, which lowercases library names to check if it exists. Furthermore, if the library exists already, adding builtins is skipped, instead of mixing the content.

I didn't find any function in the API for retrieving the names of the libraries declared already. Hence, I used `[library.lower() for library in self._vunit_obj._project._libraries]`. However, we might want to add it in the project class.