### PR TITLE
Drive invalid in AXI VCs

### DIFF
--- a/vunit/vhdl/verification_components/src/axi_lite_master.vhd
+++ b/vunit/vhdl/verification_components/src/axi_lite_master.vhd
@@ -19,10 +19,12 @@ context work.com_context;
 context work.vunit_context;
 
 entity axi_lite_master is
-  generic(
-    bus_handle : bus_master_t
+  generic (
+    bus_handle : bus_master_t;
+    drive_invalid : boolean := true;
+    drive_invalid_val : std_logic := 'X'
   );
-  port(
+  port (
     aclk : in std_logic;
 
     arready : in std_logic;
@@ -45,13 +47,15 @@ entity axi_lite_master is
 
     bvalid : in std_logic;
     bready : out std_logic := '0';
-    bresp : in axi_resp_t := axi_resp_okay);
+    bresp : in axi_resp_t := axi_resp_okay
+  );
 end entity;
 
 architecture a of axi_lite_master is
   constant reply_queue, message_queue : queue_t := new_queue;
   signal idle : boolean := true;
 begin
+
   main : process
     variable request_msg : msg_t;
     variable msg_type : msg_type_t;
@@ -73,77 +77,120 @@ begin
 
   -- Use separate process to always align to rising edge of clock
   bus_process : process
+    procedure drive_ar_invalid is
+    begin
+      if drive_invalid then
+        araddr <= (araddr'range => drive_invalid_val);
+      end if;
+    end procedure;
+
+    procedure drive_aw_invalid is
+    begin
+      if drive_invalid then
+        awaddr <= (awaddr'range => drive_invalid_val);
+      end if;
+    end procedure;
+
+    procedure drive_w_invalid is
+    begin
+      if drive_invalid then
+        wdata <= (wdata'range => drive_invalid_val);
+        wstrb <= (wstrb'range => drive_invalid_val);
+      end if;
+    end procedure;
+
     variable request_msg : msg_t;
     variable msg_type : msg_type_t;
-    variable w_done, aw_done : boolean;
     variable expected_resp : axi_resp_t;
+    variable w_done, aw_done : boolean;
+
+    -- These variables are needed to keep the values for logging when transaction is fully done
+    variable addr_this_transaction : std_logic_vector(awaddr'range) := (others => '0');
+    variable wdata_this_transaction : std_logic_vector(wdata'range) := (others => '0');
   begin
-    wait until rising_edge(aclk) and not is_empty(message_queue);
-    idle <= false;
-    wait for 0 ps;
+    -- Initialization
+    drive_ar_invalid;
+    drive_aw_invalid;
+    drive_w_invalid;
 
-    request_msg := pop(message_queue);
-    msg_type := message_type(request_msg);
+    loop
+      wait until rising_edge(aclk) and not is_empty(message_queue);
+      idle <= false;
+      wait for 0 ps;
 
-    if is_read(msg_type) then
-      araddr <= pop_std_ulogic_vector(request_msg);
-      expected_resp := pop_std_ulogic_vector(request_msg) when is_axi_lite_msg(msg_type) else axi_resp_okay;
-      push(reply_queue, request_msg);
+      request_msg := pop(message_queue);
+      msg_type := message_type(request_msg);
 
-      arvalid <= '1';
-      wait until (arvalid and arready) = '1' and rising_edge(aclk);
-      arvalid <= '0';
+      if is_read(msg_type) then
+        addr_this_transaction := pop_std_ulogic_vector(request_msg);
+        expected_resp := pop_std_ulogic_vector(request_msg) when is_axi_lite_msg(msg_type) else axi_resp_okay;
+        push(reply_queue, request_msg);
 
-      rready <= '1';
-      wait until (rvalid and rready) = '1' and rising_edge(aclk);
-      rready <= '0';
-      check_axi_resp(bus_handle, rresp, expected_resp, "rresp");
+        araddr <= addr_this_transaction;
 
-      if is_visible(bus_handle.p_logger, debug) then
-        debug(bus_handle.p_logger,
-              "Read 0x" & to_hstring(rdata) &
-                " from address 0x" & to_hstring(araddr));
-      end if;
+        arvalid <= '1';
+        wait until (arvalid and arready) = '1' and rising_edge(aclk);
+        arvalid <= '0';
+        drive_ar_invalid;
 
-    elsif is_write(msg_type) then
-      awaddr <= pop_std_ulogic_vector(request_msg);
-      wdata <= pop_std_ulogic_vector(request_msg);
-      wstrb <= pop_std_ulogic_vector(request_msg);
-      expected_resp := pop_std_ulogic_vector(request_msg) when is_axi_lite_msg(msg_type) else axi_resp_okay;
-      delete(request_msg);
+        rready <= '1';
+        wait until (rvalid and rready) = '1' and rising_edge(aclk);
+        rready <= '0';
+        check_axi_resp(bus_handle, rresp, expected_resp, "rresp");
 
-      wvalid <= '1';
-      awvalid <= '1';
-
-      w_done := false;
-      aw_done := false;
-      while not (w_done and aw_done) loop
-        wait until ((awvalid and awready) = '1' or (wvalid and wready) = '1') and rising_edge(aclk);
-
-        if (awvalid and awready) = '1' then
-          awvalid <= '0';
-          aw_done := true;
+        if is_visible(bus_handle.p_logger, debug) then
+          debug(bus_handle.p_logger,
+                "Read 0x" & to_hstring(rdata) &
+                  " from address 0x" & to_hstring(addr_this_transaction));
         end if;
 
-        if (wvalid and wready) = '1' then
-          wvalid <= '0';
-          w_done := true;
+      elsif is_write(msg_type) then
+        addr_this_transaction := pop_std_ulogic_vector(request_msg);
+        wdata_this_transaction := pop_std_ulogic_vector(request_msg);
+        wstrb <= pop_std_ulogic_vector(request_msg);
+        expected_resp := pop_std_ulogic_vector(request_msg) when is_axi_lite_msg(msg_type) else axi_resp_okay;
+        delete(request_msg);
+
+        awaddr <= addr_this_transaction;
+        wdata <= wdata_this_transaction;
+
+        wvalid <= '1';
+        awvalid <= '1';
+
+        w_done := false;
+        aw_done := false;
+        while not (w_done and aw_done) loop
+          wait until ((awvalid and awready) = '1' or (wvalid and wready) = '1') and rising_edge(aclk);
+
+          if (awvalid and awready) = '1' then
+            awvalid <= '0';
+            drive_aw_invalid;
+
+            aw_done := true;
+          end if;
+
+          if (wvalid and wready) = '1' then
+            wvalid <= '0';
+            drive_w_invalid;
+
+            w_done := true;
+          end if;
+        end loop;
+
+        bready <= '1';
+        wait until (bvalid and bready) = '1' and rising_edge(aclk);
+        bready <= '0';
+        check_axi_resp(bus_handle, bresp, expected_resp, "bresp");
+
+        if is_visible(bus_handle.p_logger, debug) then
+          debug(bus_handle.p_logger,
+                "Wrote 0x" & to_hstring(wdata_this_transaction) &
+                  " to address 0x" & to_hstring(addr_this_transaction));
         end if;
-      end loop;
-
-      bready <= '1';
-      wait until (bvalid and bready) = '1' and rising_edge(aclk);
-      bready <= '0';
-      check_axi_resp(bus_handle, bresp, expected_resp, "bresp");
-
-      if is_visible(bus_handle.p_logger, debug) then
-        debug(bus_handle.p_logger,
-              "Wrote 0x" & to_hstring(wdata) &
-                " to address 0x" & to_hstring(awaddr));
       end if;
-    end if;
 
-    idle <= true;
+      idle <= true;
+    end loop;
   end process;
 
   -- Reply in separate process do not destroy alignment with the clock

--- a/vunit/vhdl/verification_components/src/axi_read_slave.vhd
+++ b/vunit/vhdl/verification_components/src/axi_read_slave.vhd
@@ -16,7 +16,10 @@ context work.vc_context;
 
 entity axi_read_slave is
   generic (
-    axi_slave : axi_slave_t);
+    axi_slave : axi_slave_t;
+    drive_invalid : boolean := true;
+    drive_invalid_val : std_logic := 'X'
+  );
   port (
     aclk : in std_logic;
 
@@ -34,7 +37,7 @@ entity axi_read_slave is
     rdata : out std_logic_vector;
     rresp : out axi_resp_t;
     rlast : out std_logic
-    );
+  );
 end entity;
 
 architecture a of axi_read_slave is
@@ -51,6 +54,17 @@ begin
   end process;
 
   axi_process : process
+
+    procedure drive_r_invalid is
+    begin
+      if drive_invalid then
+        rid <= (rid'range => drive_invalid_val);
+        rdata <= (rdata'range => drive_invalid_val);
+        rresp <= (rresp'range => drive_invalid_val);
+        rlast <= drive_invalid_val;
+      end if;
+    end procedure;
+
     variable input_burst, burst : axi_burst_t;
     variable address : integer;
     variable idx : integer;
@@ -60,17 +74,17 @@ begin
     variable has_response_time : boolean := false;
   begin
     assert arid'length = rid'length report "arid vs rid data width mismatch";
+
     -- Initialization
-    rid <= (rid'range => '0');
-    rdata <= (rdata'range => '0');
-    rresp <= (rresp'range => '0');
-    rlast <= '0';
+    drive_r_invalid;
 
     wait on initialized until initialized;
 
     loop
       if (rready and rvalid) = '1' then
         rvalid <= '0';
+        drive_r_invalid;
+
         beats := beats - 1;
       end if;
 
@@ -90,18 +104,21 @@ begin
           has_response_time := false;
           burst := self.pop_burst;
           beats := burst.length;
-          rid <= std_logic_vector(to_unsigned(burst.id, rid'length));
-          rresp <= axi_resp_okay;
           address := burst.address;
         end if;
       end if;
 
       if beats > 0 and (rvalid = '0' or rready = '1') and not self.should_stall_data then
         rvalid <= '1';
+
+        rid <= std_logic_vector(to_unsigned(burst.id, rid'length));
+
         for j in 0 to burst.size-1 loop
           idx := (address + j) mod self.data_size;
           rdata(8*idx+7 downto 8*idx) <= std_logic_vector(to_unsigned(read_byte(axi_slave.p_memory, address+j), 8));
         end loop;
+
+        rresp <= axi_resp_okay;
 
         if burst.burst_type = axi_burst_type_incr then
           address := address + burst.size;

--- a/vunit/vhdl/verification_components/test/tb_axi_lite_master.vhd
+++ b/vunit/vhdl/verification_components/test/tb_axi_lite_master.vhd
@@ -425,6 +425,30 @@ begin
     end if;
   end process;
 
+  check_not_valid : process
+    constant a_addr_invalid_value : std_logic_vector(araddr'range) := (others => 'X');
+    constant wdata_invalid_value : std_logic_vector(wdata'range) := (others => 'X');
+    constant wstrb_invalid_value : std_logic_vector(wstrb'range) := (others => 'X');
+  begin
+    wait until rising_edge(clk);
+
+    -- All signals should be driven with 'X' when the channel is not valid
+    -- (R and B channels have no outputs from the VC, except for handshake).
+
+    if not arvalid then
+      check_equal(araddr, a_addr_invalid_value, "ARADDR not X when ARVALID low");
+    end if;
+
+    if not awvalid then
+      check_equal(awaddr, a_addr_invalid_value, "AWADDR not X when AWVALID low");
+    end if;
+
+    if not wvalid then
+      check_equal(wdata, wdata_invalid_value, "WDATA not X when WVALID low");
+      check_equal(wstrb, wstrb_invalid_value, "WSTRB not X when WVALID low");
+    end if;
+  end process;
+
   dut : entity work.axi_lite_master
     generic map (
       bus_handle => bus_handle)

--- a/vunit/vhdl/verification_components/test/tb_axi_read_slave.vhd
+++ b/vunit/vhdl/verification_components/test/tb_axi_read_slave.vhd
@@ -393,6 +393,23 @@ begin
   end process;
   test_runner_watchdog(runner, 1 ms);
 
+  check_not_valid : process
+    constant rid_invalid_value : std_logic_vector(rid'range) := (others => 'X');
+    constant rdata_invalid_value : std_logic_vector(rdata'range) := (others => 'X');
+    constant rresp_invalid_value : std_logic_vector(rresp'range) := (others => 'X');
+  begin
+    wait until rising_edge(clk);
+
+    -- All signals should be driven with 'X' when the channel is not valid
+    -- (AR has no outputs from the VC, except for handshake, so check is only for R).
+    if not rvalid then
+      check_equal(rid, rid_invalid_value, "RID not X when RVALID low");
+      check_equal(rdata, rdata_invalid_value, "RDATA not X when RVALID low");
+      check_equal(rresp, rresp_invalid_value, "RRESP not X when RVALID low");
+      check_equal(rlast, 'X', "RLAST not X when RVALID low");
+    end if;
+  end process;
+
   dut : entity work.axi_read_slave
     generic map (
       axi_slave => axi_slave)

--- a/vunit/vhdl/verification_components/test/tb_axi_write_slave.vhd
+++ b/vunit/vhdl/verification_components/test/tb_axi_write_slave.vhd
@@ -613,6 +613,20 @@ begin
   end process;
   test_runner_watchdog(runner, 1 ms);
 
+  check_not_valid : process
+    constant bid_invalid_value : std_logic_vector(bid'range) := (others => 'X');
+    constant bresp_invalid_value : std_logic_vector(bresp'range) := (others => 'X');
+  begin
+    wait until rising_edge(clk);
+
+    -- All signals should be driven with 'X' when the channel is not valid
+    -- (AW and W have no outputs from the VC, except for handshake, so check is only for B).
+    if not bvalid then
+      check_equal(bid, bid_invalid_value, "BID not X when BVALID low");
+      check_equal(bresp, bresp_invalid_value, "BRESP not X when BVALID low");
+    end if;
+  end process;
+
   dut : entity work.axi_write_slave
     generic map (
       axi_slave => axi_slave)


### PR DESCRIPTION
When the 'valid' signal is low for an AXI (-Lite) channel, the signals of the channel should be driven with 'X'.
They should not keep their value from the last time the channel was valid.
This can hide errors in the DUT if the DUT samples values in the wrong clock cycle.

This change is largely inspired by the AXI-Stream VCs.