### PR TITLE
Peek functionality

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 .tox
 .vscode
 env/
+.venv/
 venv/
 error.csv
 log.csv

--- a/docs/com/user_guide.rst
+++ b/docs/com/user_guide.rst
@@ -108,7 +108,7 @@ An actor waiting for a message uses the receive procedure
 
 This procedure returns immediately if there are pending message(s) in the receiver's inbox or blocks until the first
 message arrives. The returned message contains the oldest incoming message and its information can be retrieved using
-``pop`` functions. The code below will verify that the message has the expected content using the VUnit
+``pop`` and ``peek`` functions. The code below will verify that the message has the expected content using the VUnit
 :ref:`check_equal <equality_check>` procedure.
 
 .. code-block:: vhdl
@@ -117,7 +117,18 @@ message arrives. The returned message contains the oldest incoming message and i
   my_integer := pop(msg);
   check_equal(my_integer, 17);
 
-Just like ``push`` there are both ``pop`` functions and more verbose aliases on the form ``pop_<type>``.
+Just like ``push`` there are:
+- ``pop`` functions and more verbose aliases on the form ``pop_<type>``,
+- ``peek`` functions and more verbose aliases on the form ``peek_<type>``.
+
+Note that the ``peek`` functions returns the element at the front the message. It does not deletes the element in the message. Therefore, you can peek any number of time, it will return the exact same element.
+
+.. code-block:: vhdl
+
+  push_integer(msg, 17)
+  check_equal(peek_integer(msg), 17);
+  check_equal(peek_integer(msg), 17);
+  check_equal(peek_integer(msg), 17);
 
 Objects are always popped from the message in the same order they were pushed into the message and once all objects
 have been popped the message is empty. If you want to keep a message for later you can make a copy before popping.
@@ -738,7 +749,7 @@ value will be replaced with ``-``.
 Note that ``com`` has limited knowledge of the contents of a message. All data pushed into a message is encoded
 and is basically handled as a sequence of bytes without any overhead for type information. ``com`` doesn't
 know if four bytes represents an integer, four characters or something else. The interpretation of
-these bytes takes place when the user pops data using a type specific pop function. The exception is the message
+these bytes takes place when the user pops/peeks data using a type specific pop/peek function. The exception is the message
 type for which the type overhead is included to provide better debugging. Higher levels of debug information,
 for example that a message represents a read request to a specific address is something that the verification
 component using ``com`` provides.

--- a/vunit/com/codec_datatype_template.py
+++ b/vunit/com/codec_datatype_template.py
@@ -39,12 +39,16 @@ class DatatypeCodecTemplate(object):
     variable result : out $type);
   alias decode_$type is decode[string, positive, $type];
   procedure push(queue : queue_t; value : $type);
+  impure function peek(queue : queue_t) return $type;
   impure function pop(queue : queue_t) return $type;
   alias push_$type is push[queue_t, $type];
+  alias peek_$type is peek[queue_t return $type];
   alias pop_$type is pop[queue_t return $type];
   procedure push(msg : msg_t; value : $type);
+  impure function peek(msg : msg_t) return $type;
   impure function pop(msg : msg_t) return $type;
   alias push_$type is push[msg_t, $type];
+  alias peek_$type is peek[msg_t return $type];
   alias pop_$type is pop[msg_t return $type];
 
 """

--- a/vunit/com/codec_vhdl_array_type.py
+++ b/vunit/com/codec_vhdl_array_type.py
@@ -200,6 +200,11 @@ class ArrayCodecTemplate(DatatypeCodecTemplate):
     push_variable_string(queue, encode(value));
   end;
 
+  impure function peek(queue : queue_t) return $type is
+  begin
+    return decode(peek_variable_string(queue));
+  end;
+
   impure function pop(queue : queue_t) return $type is
   begin
     return decode(pop_variable_string(queue));
@@ -208,6 +213,11 @@ class ArrayCodecTemplate(DatatypeCodecTemplate):
   procedure push(msg : msg_t; value : $type) is
   begin
     push(msg.data, value);
+  end;
+
+  impure function peek(msg : msg_t) return $type is
+  begin
+    return peek(msg.data);
   end;
 
   impure function pop(msg : msg_t) return $type is
@@ -265,6 +275,11 @@ class ArrayCodecTemplate(DatatypeCodecTemplate):
     push_variable_string(queue, encode(value));
   end;
 
+  impure function peek(queue : queue_t) return $type is
+  begin
+    return decode(peek_variable_string(queue));
+  end;
+
   impure function pop(queue : queue_t) return $type is
   begin
     return decode(pop_variable_string(queue));
@@ -273,6 +288,11 @@ class ArrayCodecTemplate(DatatypeCodecTemplate):
   procedure push(msg : msg_t; value : $type) is
   begin
     push(msg.data, value);
+  end;
+
+  impure function peek(msg : msg_t) return $type is
+  begin
+    return peek(msg.data);
   end;
 
   impure function pop(msg : msg_t) return $type is
@@ -361,6 +381,11 @@ class ArrayCodecTemplate(DatatypeCodecTemplate):
     push_variable_string(queue, encode(value));
   end;
 
+  impure function peek(queue : queue_t) return $array_type is
+  begin
+    return decode(peek_variable_string(queue));
+  end;
+
   impure function pop(queue : queue_t) return $array_type is
   begin
     return decode(pop_variable_string(queue));
@@ -369,6 +394,11 @@ class ArrayCodecTemplate(DatatypeCodecTemplate):
   procedure push(msg : msg_t; value : $array_type) is
   begin
     push(msg.data, value);
+  end;
+
+  impure function peek(msg : msg_t) return $array_type is
+  begin
+    return peek(msg.data);
   end;
 
   impure function pop(msg : msg_t) return $array_type is
@@ -490,6 +520,11 @@ class ArrayCodecTemplate(DatatypeCodecTemplate):
     push_variable_string(queue, encode(value));
   end;
 
+  impure function peek(queue : queue_t) return $array_type is
+  begin
+    return decode(peek_variable_string(queue));
+  end;
+
   impure function pop(queue : queue_t) return $array_type is
   begin
     return decode(pop_variable_string(queue));
@@ -498,6 +533,11 @@ class ArrayCodecTemplate(DatatypeCodecTemplate):
   procedure push(msg : msg_t; value : $array_type) is
   begin
     push(msg.data, value);
+  end;
+
+  impure function peek(msg : msg_t) return $array_type is
+  begin
+    return peek(msg.data);
   end;
 
   impure function pop(msg : msg_t) return $array_type is

--- a/vunit/com/codec_vhdl_enumeration_type.py
+++ b/vunit/com/codec_vhdl_enumeration_type.py
@@ -85,6 +85,11 @@ class EnumerationCodecTemplate(DatatypeCodecTemplate):
     push_fix_string(queue, encode(value));
   end;
 
+  impure function peek(queue : queue_t) return $type is
+  begin
+    return decode(peek_fix_string(queue, 1));
+  end;
+
   impure function pop(queue : queue_t) return $type is
   begin
     return decode(pop_fix_string(queue, 1));
@@ -93,6 +98,11 @@ class EnumerationCodecTemplate(DatatypeCodecTemplate):
   procedure push(msg : msg_t; value : $type) is
   begin
     push(msg.data, value);
+  end;
+
+  impure function peek(msg : msg_t) return $type is
+  begin
+    return peek(msg.data);
   end;
 
   impure function pop(msg : msg_t) return $type is

--- a/vunit/com/codec_vhdl_record_type.py
+++ b/vunit/com/codec_vhdl_record_type.py
@@ -99,6 +99,11 @@ class RecordCodecTemplate(DatatypeCodecTemplate):
     push_variable_string(queue, encode(value));
   end;
 
+  impure function peek(queue : queue_t) return $type is
+  begin
+    return decode(peek_variable_string(queue));
+  end;
+
   impure function pop(queue : queue_t) return $type is
   begin
     return decode(pop_variable_string(queue));
@@ -107,6 +112,11 @@ class RecordCodecTemplate(DatatypeCodecTemplate):
   procedure push(msg : msg_t; value : $type) is
   begin
     push(msg.data, value);
+  end;
+
+  impure function peek(msg : msg_t) return $type is
+  begin
+    return peek(msg.data);
   end;
 
   impure function pop(msg : msg_t) return $type is

--- a/vunit/vhdl/com/test/tb_com_codec.vhd
+++ b/vunit/vhdl/com/test/tb_com_codec.vhd
@@ -88,9 +88,10 @@ begin
         check_relation(enum1 = green);
         enum1 := decode(encode(blue));
         check_relation(enum1 = blue);
-      elsif run("Test that custom enumeration type can be pushed and popped") then
+      elsif run("Test that custom enumeration type can be pushed, peeked and popped") then
         msg := new_msg;
         push_enum1_t(msg, red);
+        check_relation(peek_enum1_t(msg) = red, result("for peek_enum1"));
         check_relation(pop_enum1_t(msg) = red, result("for pop_enum1"));
       elsif run("Test that custom record type can be encoded and decoded") then
         rec1 := decode(encode_record1_t((character'pos(lp), -1, -2, -3)));
@@ -107,10 +108,11 @@ begin
         check_relation(rec3 = (char => lp));
         rec3 := decode(encode_record3_t((char => rp)));
         check_relation(rec3 = (char => rp));
-      elsif run("Test that custom record type can be pushed and popped") then
+      elsif run("Test that custom record type can be pushed, peeked and popped") then
         msg := new_msg;
         rec1 := (character'pos(lp), -1, -2, -3);
         push_record1_t(msg, rec1);
+        check_relation(peek_record1_t(msg) = rec1, result("for peek_record1_t"));
         check_relation(pop_record1_t(msg) = rec1, result("for pop_record1_t"));
       elsif run("Test that custom array can be encoded and decoded") then
         a1 := decode(encode_array1_t((0, 1, 2, 3, 4)));
@@ -176,22 +178,26 @@ begin
         check_relation(a10'right(1) = 2);
         check_relation(a10'left(2) = -1);
         check_relation(a10'right(2) = 1);
-      elsif run("Test that custom array can be pushed and popped") then
+      elsif run("Test that custom array can be pushed, peeked and popped") then
         msg := new_msg;
         a1 := (0, 1, 2, 3, 4);
         push_array1_t(msg, a1);
+        check_relation(peek_array1_t(msg) = a1, result("for peek_array1_t"));
         check_relation(pop_array1_t(msg) = a1, result("for pop_array1_t"));
 
         a3 := ((0, 1, 2), (3, 4, 5), (6, 7, 8), (9, 10, 11), (12, 13, 14));
         push_array3_t(msg, a3);
+        check_relation(peek_array3_t(msg) = a3, result("for peek_array3_t"));
         check_relation(pop_array3_t(msg) = a3, result("for pop_array3_t"));
 
         a4 := (0, 1, 2, 3, 4);
         push_array4_t(msg, a4);
+        check_relation(peek_array4_t(msg) = a4, result("for peek_array4_t"));
         check_relation(pop_array4_t(msg) = a4, result("for pop_array4_t"));
 
         a5 := ((0, 1, 2), (3, 4, 5), (6, 7, 8), (9, 10, 11), (12, 13, 14));
         push_array5_t(msg, a5);
+        check_relation(peek_array5_t(msg) = a5, result("for peek_array5_t"));
         check_relation(pop_array5_t(msg) = a5, result("for pop_array5_t"));
 
       elsif run("Test that all provided codecs can be used within a composite") then

--- a/vunit/vhdl/com/test/tb_com_msg_building.vhd
+++ b/vunit/vhdl/com/test/tb_com_msg_building.vhd
@@ -80,200 +80,263 @@ begin
         check(msg.receiver = null_actor);
         check_equal(msg.request_id, no_message_id);
         check(msg.data = null_queue);
-      elsif run("Test push and pop integer") then
+      elsif run("Test push, peek and pop integer") then
         msg := new_msg;
         push_integer(msg, 11);
         push_integer(msg, 22);
+        check_equal(peek_integer(msg), 11, "data");
         check_equal(pop_integer(msg), 11, "data");
+        check_equal(peek_integer(msg), 22, "data");
         check_equal(pop_integer(msg), 22, "data");
-      elsif run("Test push and pop character") then
+      elsif run("Test push, peek and pop character") then
         msg := new_msg;
         push_character(msg, '1');
         push_character(msg, '2');
+        assert peek_character(msg) = '1';
         assert pop_character(msg) = '1';
+        assert peek_character(msg) = '2';
         assert pop_character(msg) = '2';
-      elsif run("Test push and pop queue") then
+      elsif run("Test push, peek and pop queue") then
         msg   := new_msg;
         queue := new_queue;
         push(queue, 22);
         queue_copy := queue;
         push_queue_ref(msg, queue);
         assert queue = null_queue report "Ownership was transfered";
+        assert peek_queue_ref(msg) = queue_copy report "Queue should come back";
         assert pop_queue_ref(msg) = queue_copy report "Queue should come back";
-      elsif run("Test push and pop string") then
+      elsif run("Test push, peek and pop string") then
         msg := new_msg;
         push_string(msg, "hello world");
         push_string(msg, "two");
+        assert peek_string(msg) = "hello world";
         assert pop_string(msg) = "hello world";
+        assert peek_string(msg) = "two";
         assert pop_string(msg) = "two";
-      elsif run("Test push and pop bit") then
+      elsif run("Test push, peek and pop bit") then
         msg := new_msg;
         push_bit(msg, '0');
         push_bit(msg, '1');
+        check(peek_bit(msg) = '0');
         check(pop_bit(msg) = '0');
+        check(peek_bit(msg) = '1');
         check(pop_bit(msg) = '1');
-      elsif run("Test push and pop std_ulogic") then
+      elsif run("Test push, peek and pop std_ulogic") then
         msg := new_msg;
         push_std_ulogic(msg, 'U');
         push_std_ulogic(msg, 'X');
+        assert peek_std_ulogic(msg) = 'U';
         assert pop_std_ulogic(msg) = 'U';
+        assert peek_std_ulogic(msg) = 'X';
         assert pop_std_ulogic(msg) = 'X';
-      elsif run("Test push and pop severity_level") then
+      elsif run("Test push, peek and pop severity_level") then
         msg := new_msg;
         push_severity_level(msg, note);
         push_severity_level(msg, error);
+        check(peek_severity_level(msg) = note);
         check(pop_severity_level(msg) = note);
+        check(peek_severity_level(msg) = error);
         check(pop_severity_level(msg) = error);
-      elsif run("Test push and pop file_open_status") then
+      elsif run("Test push, peek and pop file_open_status") then
         msg := new_msg;
         push_file_open_status(msg, open_ok);
         push_file_open_status(msg, mode_error);
+        check(peek_file_open_status(msg) = open_ok);
         check(pop_file_open_status(msg) = open_ok);
+        check(peek_file_open_status(msg) = mode_error);
         check(pop_file_open_status(msg) = mode_error);
-      elsif run("Test push and pop file_open_kind") then
+      elsif run("Test push, peek and pop file_open_kind") then
         msg := new_msg;
         push_file_open_kind(msg, read_mode);
         push_file_open_kind(msg, append_mode);
+        check(peek_file_open_kind(msg) = read_mode);
         check(pop_file_open_kind(msg) = read_mode);
+        check(peek_file_open_kind(msg) = append_mode);
         check(pop_file_open_kind(msg) = append_mode);
-      elsif run("Test push and pop bit_vector") then
+      elsif run("Test push, peek and pop bit_vector") then
         msg := new_msg;
         push_bit_vector(msg, "1");
         push_bit_vector(msg, "010101");
+        bv(0 to 0) := peek_bit_vector(msg);
+        check(bv(0) = '1');
         bv(0 to 0) := pop_bit_vector(msg);
         check(bv(0) = '1');
+        bv := peek_bit_vector(msg) ;
+        check(bv = "010101");
         bv := pop_bit_vector(msg) ;
         check(bv = "010101");
-      elsif run("Test push and pop std_ulogic_vector") then
+      elsif run("Test push, peek and pop std_ulogic_vector") then
         msg := new_msg;
         push_std_ulogic_vector(msg, "1");
         push_std_ulogic_vector(msg, "010101");
+        sulv(0 to 0) := peek_std_ulogic_vector(msg);
+        check(sulv(0) = '1');
         sulv(0 to 0) := pop_std_ulogic_vector(msg);
         check(sulv(0) = '1');
+        sulv := peek_std_ulogic_vector(msg);
+        check(sulv = "010101");
         sulv := pop_std_ulogic_vector(msg);
         check(sulv = "010101");
-      elsif run("Test push and pop complex") then
+      elsif run("Test push, peek and pop complex") then
         msg := new_msg;
         push_complex(msg, (1.0, 2.2));
         push_complex(msg, (-1.0, -2.2));
+        check(peek_complex(msg) = (1.0, 2.2));
         check(pop_complex(msg) = (1.0, 2.2));
+        check(peek_complex(msg) = (-1.0, -2.2));
         check(pop_complex(msg) = (-1.0, -2.2));
-      elsif run("Test push and pop complex_polar") then
+      elsif run("Test push, peek and pop complex_polar") then
         msg := new_msg;
         push_complex_polar(msg, (1.0, 0.707));
         push_complex_polar(msg, (3.14, -0.707));
+        check(peek_complex_polar(msg) = (1.0, 0.707));
         check(pop_complex_polar(msg) = (1.0, 0.707));
+        check(peek_complex_polar(msg) = (3.14, -0.707));
         check(pop_complex_polar(msg) = (3.14, -0.707));
-      elsif run("Test push and pop ieee.numeric_bit.unsigned") then
+      elsif run("Test push, peek and pop ieee.numeric_bit.unsigned") then
         msg := new_msg;
         push_numeric_bit_unsigned(msg, "1");
         push_numeric_bit_unsigned(msg, "010101");
+        check(peek_numeric_bit_unsigned(msg) = "1");
         check(pop_numeric_bit_unsigned(msg) = "1");
+        check(peek_numeric_bit_unsigned(msg) = "010101");
         check(pop_numeric_bit_unsigned(msg) = "010101");
-      elsif run("Test push and pop ieee.numeric_bit.signed") then
+      elsif run("Test push, peek and pop ieee.numeric_bit.signed") then
         msg := new_msg;
         push_numeric_bit_signed(msg, "1");
         push_numeric_bit_signed(msg, "010101");
+        check(peek_numeric_bit_signed(msg) = "1");
         check(pop_numeric_bit_signed(msg) = "1");
+        check(peek_numeric_bit_signed(msg) = "010101");
         check(pop_numeric_bit_signed(msg) = "010101");
-      elsif run("Test push and pop ieee.numeric_std.unsigned") then
+      elsif run("Test push, peek and pop ieee.numeric_std.unsigned") then
         msg := new_msg;
         push_numeric_std_unsigned(msg, "1");
         push_numeric_std_unsigned(msg, "010101");
+        check(peek_numeric_std_unsigned(msg) = "1");
         check(pop_numeric_std_unsigned(msg) = "1");
+        check(peek_numeric_std_unsigned(msg) = "010101");
         check(pop_numeric_std_unsigned(msg) = "010101");
-      elsif run("Test push and pop ieee.numeric_std.signed") then
+      elsif run("Test push, peek and pop ieee.numeric_std.signed") then
         msg := new_msg;
         push_numeric_std_signed(msg, "1");
         push_numeric_std_signed(msg, "010101");
+        check(peek_numeric_std_signed(msg) = "1");
         check(pop_numeric_std_signed(msg) = "1");
+        check(peek_numeric_std_signed(msg) = "010101");
         check(pop_numeric_std_signed(msg) = "010101");
-      elsif run("Test push and pop signed and unsigned") then
+      elsif run("Test push, peek and pop signed and unsigned") then
         msg := new_msg;
         push_std_ulogic_vector(msg, std_ulogic_vector(ieee.numeric_std.to_unsigned(11, 16)));
         push_std_ulogic_vector(msg, std_ulogic_vector(ieee.numeric_std.to_signed(-1, 8)));
+        assert ieee.numeric_std.unsigned(peek_std_ulogic_vector(msg)) = ieee.numeric_std.to_unsigned(11, 16);
         assert ieee.numeric_std.unsigned(pop_std_ulogic_vector(msg)) = ieee.numeric_std.to_unsigned(11, 16);
+        assert ieee.numeric_std.signed(peek_std_ulogic_vector(msg)) = ieee.numeric_std.to_signed(-1, 8);
         assert ieee.numeric_std.signed(pop_std_ulogic_vector(msg)) = ieee.numeric_std.to_signed(-1, 8);
-      elsif run("Test push and pop real") then
+      elsif run("Test push, peek and pop real") then
         msg := new_msg;
         push_real(msg, 1.0);
         push_real(msg, -1.0);
+        assert peek_real(msg) = 1.0;
         assert pop_real(msg) = 1.0;
+        assert peek_real(msg) = -1.0;
         assert pop_real(msg) = -1.0;
-      elsif run("Test push and pop time") then
+      elsif run("Test push, peek and pop time") then
         msg := new_msg;
         push_time(msg, 1 fs);
         push_time(msg, 1 ps);
+        assert peek_time(msg) = 1 fs;
         assert pop_time(msg) = 1 fs;
+        assert peek_time(msg) = 1 ps;
         assert pop_time(msg) = 1 ps;
-      elsif run("Test push and pop boolean_vector") then
+      elsif run("Test push, peek and pop boolean_vector") then
         msg := new_msg;
         push_boolean_vector(msg, (1 => true));
         push_boolean_vector(msg, (false, true));
+        boolv(0 to 0) := peek_boolean_vector(msg);
+        check(boolv(0) = true);
         boolv(0 to 0) := pop_boolean_vector(msg);
         check(boolv(0) = true);
+        boolv := peek_boolean_vector(msg);
+        check(boolv = (false, true));
         boolv := pop_boolean_vector(msg);
         check(boolv = (false, true));
-      elsif run("Test push and pop integer_vector") then
+      elsif run("Test push, peek and pop integer_vector") then
         msg := new_msg;
         push_integer_vector(msg, (1        => 17));
         push_integer_vector(msg, (-21, 42));
+        check(peek_integer_vector(msg) = (1 => 17));
         check(pop_integer_vector(msg) = (1 => 17));
+        check(peek_integer_vector(msg) = (-21, 42));
         check(pop_integer_vector(msg) = (-21, 42));
-      elsif run("Test push and pop real_vector") then
+      elsif run("Test push, peek and pop real_vector") then
         msg := new_msg;
         push_real_vector(msg, (1        => 17.17));
         push_real_vector(msg, (-21.21, 42.42));
+        check(peek_real_vector(msg) = (1 => 17.17));
         check(pop_real_vector(msg) = (1 => 17.17));
+        check(peek_real_vector(msg) = (-21.21, 42.42));
         check(pop_real_vector(msg) = (-21.21, 42.42));
-      elsif run("Test push and pop time_vector") then
+      elsif run("Test push, peek and pop time_vector") then
         msg := new_msg;
         push_time_vector(msg, (1        => 17.17 ms));
         push_time_vector(msg, (-21.21 min, 42.42 us));
+        check(peek_time_vector(msg) = (1 => 17.17 ms));
         check(pop_time_vector(msg) = (1 => 17.17 ms));
+        check(peek_time_vector(msg) = (-21.21 min, 42.42 us));
         check(pop_time_vector(msg) = (-21.21 min, 42.42 us));
-      elsif run("Test push and pop ufixed") then
+      elsif run("Test push, peek and pop ufixed") then
         msg := new_msg;
         push_ufixed(msg, to_ufixed(17.17, 6, -9));
         push_ufixed(msg, to_ufixed(42.42, 6, -9));
+        check(peek_ufixed(msg) = to_ufixed(17.17, 6, -9));
         check(pop_ufixed(msg) = to_ufixed(17.17, 6, -9));
+        check(peek_ufixed(msg) = to_ufixed(42.42, 6, -9));
         check(pop_ufixed(msg) = to_ufixed(42.42, 6, -9));
-      elsif run("Test push and pop sfixed") then
+      elsif run("Test push, peek and pop sfixed") then
         msg := new_msg;
         push_sfixed(msg, to_sfixed(17.17, 6, -9));
         push_sfixed(msg, to_sfixed(-21.21, 6, -9));
+        check(peek_sfixed(msg) = to_sfixed(17.17, 6, -9));
         check(pop_sfixed(msg) = to_sfixed(17.17, 6, -9));
+        check(peek_sfixed(msg) = to_sfixed(-21.21, 6, -9));
         check(pop_sfixed(msg) = to_sfixed(-21.21, 6, -9));
-      elsif run("Test push and pop float") then
+      elsif run("Test push, peek and pop float") then
         msg := new_msg;
         push_float(msg, to_float(17.17));
         push_float(msg, to_float(-21.21));
+        check(peek_float(msg) = to_float(17.17));
         check(pop_float(msg) = to_float(17.17));
+        check(peek_float(msg) = to_float(-21.21));
         check(pop_float(msg) = to_float(-21.21));
-      elsif run("Test push and pop of msg_type") then
+      elsif run("Test push, peek and pop of msg_type") then
         msg := new_msg;
         push_msg_type(msg, my_msg_type);
+        check(peek_msg_type(msg) = my_msg_type);
         check(pop_msg_type(msg) = my_msg_type);
-      elsif run("Test push and pop of integer_vector_ptr_t") then
+      elsif run("Test push, peek and pop of integer_vector_ptr_t") then
         msg := new_msg;
         integer_vector_ptr := new_integer_vector_ptr;
         integer_vector_ptr_copy := integer_vector_ptr;
         push_integer_vector_ptr_ref(msg, integer_vector_ptr);
         assert integer_vector_ptr = null_ptr report "Ownership was transfered";
+        check(peek_integer_vector_ptr_ref(msg) = integer_vector_ptr_copy);
         check(pop_integer_vector_ptr_ref(msg) = integer_vector_ptr_copy);
-      elsif run("Test push and pop of integer_array_t") then
+      elsif run("Test push, peek and pop of integer_array_t") then
         msg := new_msg;
         integer_array := new_3d(1, 2, 3, 4);
         integer_array_copy := integer_array;
         push_integer_array_t_ref(msg, integer_array);
         check(integer_array = null_integer_array);
+        check(peek_integer_array_t_ref(msg) = integer_array_copy);
         check(pop_integer_array_t_ref(msg) = integer_array_copy);
-      elsif run("Test push and pop of msg_t") then
+      elsif run("Test push, peek and pop of msg_t") then
         msg := new_msg;
         msg2 := new_msg;
         msg2_copy := msg2;
         push(msg, msg2);
         assert msg2 = null_msg report "Ownership was transfered";
+        check(peek(msg) = msg2_copy);
         check(pop(msg) = msg2_copy);
       elsif run("Test setting and getting msg_type") then
         msg := new_msg;
@@ -287,6 +350,7 @@ begin
         check(is_empty(msg));
         push_integer(msg, 11);
         check_false(is_empty(msg));
+        check_equal(peek_integer(msg), 11);
         check_equal(pop_integer(msg), 11);
         check(is_empty(msg));
         push_integer(msg, 11);

--- a/vunit/vhdl/data_types/src/codec_builder.vhd
+++ b/vunit/vhdl/data_types/src/codec_builder.vhd
@@ -25,6 +25,7 @@ package codec_builder_pkg is
     constant byte_array : string)
     return bit_vector;
 
+  constant character_code_length : positive := 1;
   constant integer_code_length : positive := 4;
   constant boolean_code_length : positive := 1;
   constant real_code_length : positive := boolean_code_length + 3 * integer_code_length;
@@ -36,6 +37,8 @@ package codec_builder_pkg is
   constant file_open_kind_code_length : positive := 1;
   constant complex_code_length : positive := 2 * real_code_length;
   constant complex_polar_code_length : positive := 2 * real_code_length;
+  constant range_length : positive := 2 * integer_code_length + boolean_code_length;
+  alias array_header_length is range_length;
 
   procedure decode (
     constant code   :       string;

--- a/vunit/vhdl/data_types/src/queue_pkg-2008p.vhd
+++ b/vunit/vhdl/data_types/src/queue_pkg-2008p.vhd
@@ -10,6 +10,7 @@ use ieee.float_pkg.all;
 
 use work.queue_pkg.all;
 use work.codec_2008p_pkg.all;
+use work.codec_builder_pkg.all;
 use work.codec_builder_2008p_pkg.all;
 
 package queue_2008p_pkg is
@@ -22,8 +23,20 @@ package queue_2008p_pkg is
     queue : queue_t
   ) return boolean_vector;
 
+  procedure peek (
+    queue : queue_t;
+    variable value : out boolean_vector;
+    variable offset : inout natural
+  );
+
+  impure function peek (
+    queue : queue_t
+  ) return boolean_vector;
+
   alias push_boolean_vector is push[queue_t, boolean_vector];
   alias pop_boolean_vector is pop[queue_t return boolean_vector];
+  alias peek_boolean_vector is peek[queue_t, boolean_vector, natural];
+  alias peek_boolean_vector is peek[queue_t return boolean_vector];
 
   procedure push (
     queue : queue_t;
@@ -34,8 +47,20 @@ package queue_2008p_pkg is
     queue : queue_t
   ) return integer_vector;
 
+  procedure peek (
+    queue : queue_t;
+    variable value : out integer_vector;
+    variable offset : inout natural
+  );
+
+  impure function peek (
+    queue : queue_t
+  ) return integer_vector;
+
   alias push_integer_vector is push[queue_t, integer_vector];
   alias pop_integer_vector is pop[queue_t return integer_vector];
+  alias peek_integer_vector is peek[queue_t, integer_vector, natural];
+  alias peek_integer_vector is peek[queue_t return integer_vector];
 
   procedure push (
     queue : queue_t;
@@ -46,8 +71,20 @@ package queue_2008p_pkg is
     queue : queue_t
   ) return real_vector;
 
+  procedure peek (
+    queue : queue_t;
+    variable value : out real_vector;
+    variable offset : inout natural
+  );
+
+  impure function peek (
+    queue : queue_t
+  ) return real_vector;
+
   alias push_real_vector is push[queue_t, real_vector];
   alias pop_real_vector is pop[queue_t return real_vector];
+  alias peek_real_vector is peek[queue_t, real_vector, natural];
+  alias peek_real_vector is peek[queue_t return real_vector];
 
   procedure push (
     queue : queue_t;
@@ -58,8 +95,20 @@ package queue_2008p_pkg is
     queue : queue_t
   ) return time_vector;
 
+  procedure peek (
+    queue : queue_t;
+    variable value : out time_vector;
+    variable offset : inout natural
+  );
+
+  impure function peek (
+    queue : queue_t
+  ) return time_vector;
+
   alias push_time_vector is push[queue_t, time_vector];
   alias pop_time_vector is pop[queue_t return time_vector];
+  alias peek_time_vector is peek[queue_t, time_vector, natural];
+  alias peek_time_vector is peek[queue_t return time_vector];
 
   procedure push (
     queue : queue_t;
@@ -70,8 +119,20 @@ package queue_2008p_pkg is
     queue : queue_t
   ) return ufixed;
 
+  procedure peek (
+    queue : queue_t;
+    variable value : out ufixed;
+    variable offset : inout natural
+  );
+
+  impure function peek (
+    queue : queue_t
+  ) return ufixed;
+
   alias push_ufixed is push[queue_t, ufixed];
   alias pop_ufixed is pop[queue_t return ufixed];
+  alias peek_ufixed is peek[queue_t, ufixed, natural];
+  alias peek_ufixed is peek[queue_t return ufixed];
 
   procedure push (
     queue : queue_t;
@@ -82,8 +143,20 @@ package queue_2008p_pkg is
     queue : queue_t
   ) return sfixed;
 
+  procedure peek (
+    queue : queue_t;
+    variable value : out sfixed;
+    variable offset : inout natural
+  );
+
+  impure function peek (
+    queue : queue_t
+  ) return sfixed;
+
   alias push_sfixed is push[queue_t, sfixed];
   alias pop_sfixed is pop[queue_t return sfixed];
+  alias peek_sfixed is peek[queue_t, sfixed, natural];
+  alias peek_sfixed is peek[queue_t return sfixed];
 
   procedure push (
     queue : queue_t;
@@ -94,8 +167,20 @@ package queue_2008p_pkg is
     queue : queue_t
   ) return float;
 
+  procedure peek (
+    queue : queue_t;
+    variable value : out float;
+    variable offset : inout natural
+  );
+
+  impure function peek (
+    queue : queue_t
+  ) return float;
+
   alias push_float is push[queue_t, float];
   alias pop_float is pop[queue_t return float];
+  alias peek_float is peek[queue_t, float, natural];
+  alias peek_float is peek[queue_t return float];
 end package;
 
 package body queue_2008p_pkg is
@@ -114,6 +199,30 @@ package body queue_2008p_pkg is
     return decode(pop_variable_string(queue));
   end;
 
+  procedure peek (
+    queue : queue_t;
+    variable value : out boolean_vector;
+    variable offset : inout natural
+  ) is
+    constant length : natural := value'length * boolean_code_length;
+    variable result : string(1 to length);
+  begin
+    check_type_peek(queue, vhdl_boolean_vector, offset);
+    peek_variable_string(queue, result, offset);
+    -- offset := offset + value'length;
+    value := decode(result);
+  end;
+
+  impure function peek (
+    queue : queue_t
+  ) return boolean_vector is
+    variable offset : natural := 0;
+  begin
+    -- cannot use the associated procedure because we would need a variable of type array but we cannot constraint it
+    check_type_peek(queue, vhdl_boolean_vector, offset);
+    return decode(peek_variable_string(queue, offset));
+  end;
+
   procedure push (
     queue : queue_t;
     value : integer_vector
@@ -127,6 +236,30 @@ package body queue_2008p_pkg is
   ) return integer_vector is begin
     check_type(queue, vhdl_integer_vector);
     return decode(pop_variable_string(queue));
+  end;
+
+  procedure peek (
+    queue : queue_t;
+    variable value : out integer_vector;
+    variable offset : inout natural
+  ) is
+    constant length : natural := value'length * integer_code_length;
+    variable result : string(1 to length);
+  begin
+    check_type_peek(queue, vhdl_integer_vector, offset);
+    peek_variable_string(queue, result, offset);
+    -- offset := offset + value'length;
+    value := decode(result);
+  end;
+
+  impure function peek (
+    queue : queue_t
+  ) return integer_vector is
+    variable offset : natural := 0;
+  begin
+    -- cannot use the associated procedure because we would need a variable of type array but we cannot constraint it
+    check_type_peek(queue, vhdl_integer_vector, offset);
+    return decode(peek_variable_string(queue, offset));
   end;
 
   procedure push (
@@ -144,6 +277,30 @@ package body queue_2008p_pkg is
     return decode(pop_variable_string(queue));
   end;
 
+  procedure peek (
+    queue : queue_t;
+    variable value : out real_vector;
+    variable offset : inout natural
+  ) is
+    constant length : natural := value'length * real_code_length;
+    variable result : string(1 to length);
+  begin
+    check_type_peek(queue, vhdl_real_vector, offset);
+    peek_variable_string(queue, result, offset);
+    -- offset := offset + value'length;
+    value := decode(result);
+  end;
+
+  impure function peek (
+    queue : queue_t
+  ) return real_vector is
+    variable offset : natural := 0;
+  begin
+    -- cannot use the associated procedure because we would need a variable of type array but we cannot constraint it
+    check_type_peek(queue, vhdl_real_vector, offset);
+    return decode(peek_variable_string(queue, offset));
+  end;
+
   procedure push (
     queue : queue_t;
     value : time_vector
@@ -157,6 +314,30 @@ package body queue_2008p_pkg is
   ) return time_vector is begin
     check_type(queue, vhdl_time_vector);
     return decode(pop_variable_string(queue));
+  end;
+
+  procedure peek (
+    queue : queue_t;
+    variable value : out time_vector;
+    variable offset : inout natural
+  ) is
+    constant length : natural := value'length * time_code_length;
+    variable result : string(1 to length);
+  begin
+    check_type_peek(queue, vhdl_time_vector, offset);
+    peek_variable_string(queue, result, offset);
+    -- offset := offset + value'length;
+    value := decode(result);
+  end;
+
+  impure function peek (
+    queue : queue_t
+  ) return time_vector is
+    variable offset : natural := 0;
+  begin
+    -- cannot use the associated procedure because we would need a variable of type array but we cannot constraint it
+    check_type_peek(queue, vhdl_time_vector, offset);
+    return decode(peek_variable_string(queue, offset));
   end;
 
   procedure push (
@@ -174,6 +355,30 @@ package body queue_2008p_pkg is
     return decode(pop_variable_string(queue));
   end;
 
+  procedure peek (
+    queue : queue_t;
+    variable value : out ufixed;
+    variable offset : inout natural
+  ) is
+    constant length : natural := value'length * std_ulogic_code_length;
+    variable result : string(1 to length);
+  begin
+    check_type_peek(queue, ieee_ufixed, offset);
+    peek_variable_string(queue, result, offset);
+    -- offset := offset + value'length;
+    value := decode(result);
+  end;
+
+  impure function peek (
+    queue : queue_t
+  ) return ufixed is
+    variable offset : natural := 0;
+  begin
+    -- cannot use the associated procedure because we would need a variable of type array but we cannot constraint it
+    check_type_peek(queue, ieee_ufixed, offset);
+    return decode(peek_variable_string(queue, offset));
+  end;
+
   procedure push (
     queue : queue_t;
     value : sfixed
@@ -189,6 +394,30 @@ package body queue_2008p_pkg is
     return decode(pop_variable_string(queue));
   end;
 
+  procedure peek (
+    queue : queue_t;
+    variable value : out sfixed;
+    variable offset : inout natural
+  ) is
+    constant length : natural := value'length * std_ulogic_code_length;
+    variable result : string(1 to length);
+  begin
+    check_type_peek(queue, ieee_sfixed, offset);
+    peek_variable_string(queue, result, offset);
+    -- offset := offset + value'length;
+    value := decode(result);
+  end;
+
+  impure function peek (
+    queue : queue_t
+  ) return sfixed is
+    variable offset : natural := 0;
+  begin
+    -- cannot use the associated procedure because we would need a variable of type array but we cannot constraint it
+    check_type_peek(queue, ieee_sfixed, offset);
+    return decode(peek_variable_string(queue, offset));
+  end;
+
   procedure push (
     queue : queue_t;
     value : float
@@ -202,5 +431,29 @@ package body queue_2008p_pkg is
   ) return float is begin
     check_type(queue, ieee_float);
     return decode(pop_variable_string(queue));
+  end;
+
+  procedure peek (
+    queue : queue_t;
+    variable value : out float;
+    variable offset : inout natural
+  ) is
+    constant length : natural := value'length * std_ulogic_code_length;
+    variable result : string(1 to length);
+  begin
+    check_type_peek(queue, ieee_float, offset);
+    peek_variable_string(queue, result, offset);
+    -- offset := offset + value'length;
+    value := decode(result);
+  end;
+
+  impure function peek (
+    queue : queue_t
+  ) return float is
+    variable offset : natural := 0;
+  begin
+    -- cannot use the associated procedure because we would need a variable of type array but we cannot constraint it
+    check_type_peek(queue, ieee_float, offset);
+    return decode(peek_variable_string(queue, offset));
   end;
 end package body;

--- a/vunit/vhdl/data_types/src/queue_pkg.vhd
+++ b/vunit/vhdl/data_types/src/queue_pkg.vhd
@@ -50,8 +50,20 @@ package queue_pkg is
     queue : queue_t
   ) return integer;
 
+  procedure peek (
+    queue : queue_t;
+    variable value : out integer;
+    variable offset : inout natural
+  );
+
+  impure function peek (
+    queue : queue_t
+  ) return integer;
+
   alias push_integer is push[queue_t, integer];
   alias pop_integer is pop[queue_t return integer];
+  alias peek_integer is peek[queue_t, integer, natural];
+  alias peek_integer is peek[queue_t return integer];
 
   procedure push_byte (
     queue : queue_t;
@@ -59,6 +71,16 @@ package queue_pkg is
   );
 
   impure function pop_byte (
+    queue : queue_t
+  ) return integer;
+
+  procedure peek_byte (
+    queue : queue_t;
+    variable value : out integer;
+    variable offset : inout natural
+  );
+
+  impure function peek_byte (
     queue : queue_t
   ) return integer;
 
@@ -71,8 +93,20 @@ package queue_pkg is
     queue : queue_t
   ) return character;
 
+  procedure peek (
+    queue : queue_t;
+    variable value : out character;
+    variable offset : inout natural
+  );
+
+  impure function peek (
+    queue : queue_t
+  ) return character;
+
   alias push_character is push[queue_t, character];
   alias pop_character is pop[queue_t return character];
+  alias peek_character is peek[queue_t, character, natural];
+  alias peek_character is peek[queue_t return character];
 
   procedure push (
     queue : queue_t;
@@ -83,8 +117,20 @@ package queue_pkg is
     queue : queue_t
   ) return boolean;
 
+  procedure peek (
+    queue : queue_t;
+    variable value : out boolean;
+    variable offset : inout natural
+  );
+
+  impure function peek (
+    queue : queue_t
+  ) return boolean;
+
   alias push_boolean is push[queue_t, boolean];
   alias pop_boolean is pop[queue_t return boolean];
+  alias peek_boolean is peek[queue_t, boolean, natural];
+  alias peek_boolean is peek[queue_t return boolean];
 
   procedure push (
     queue : queue_t;
@@ -95,8 +141,20 @@ package queue_pkg is
     queue : queue_t
   ) return real;
 
+  procedure peek (
+    queue : queue_t;
+    variable value : out real;
+    variable offset : inout natural
+  );
+
+  impure function peek (
+    queue : queue_t
+  ) return real;
+
   alias push_real is push[queue_t, real];
   alias pop_real is pop[queue_t return real];
+  alias peek_real is peek[queue_t, real, natural];
+  alias peek_real is peek[queue_t return real];
 
   procedure push (
     queue : queue_t;
@@ -107,8 +165,20 @@ package queue_pkg is
     queue : queue_t
   ) return bit;
 
+  procedure peek (
+    queue : queue_t;
+    variable value : out bit;
+    variable offset : inout natural
+  );
+
+  impure function peek (
+    queue : queue_t
+  ) return bit;
+
   alias push_bit is push[queue_t, bit];
   alias pop_bit is pop[queue_t return bit];
+  alias peek_bit is peek[queue_t, bit, natural];
+  alias peek_bit is peek[queue_t return bit];
 
   procedure push (
     queue : queue_t;
@@ -119,8 +189,20 @@ package queue_pkg is
     queue : queue_t
   ) return std_ulogic;
 
+  procedure peek (
+    queue : queue_t;
+    variable value : out std_ulogic;
+    variable offset : inout natural
+  );
+
+  impure function peek (
+    queue : queue_t
+  ) return std_ulogic;
+
   alias push_std_ulogic is push[queue_t, std_ulogic];
   alias pop_std_ulogic is pop[queue_t return std_ulogic];
+  alias peek_std_ulogic is peek[queue_t, std_ulogic, natural];
+  alias peek_std_ulogic is peek[queue_t return std_ulogic];
 
   procedure push (
     queue : queue_t;
@@ -131,8 +213,20 @@ package queue_pkg is
     queue : queue_t
   ) return severity_level;
 
+  procedure peek (
+    queue : queue_t;
+    variable value : out severity_level;
+    variable offset : inout natural
+  );
+
+  impure function peek (
+    queue : queue_t
+  ) return severity_level;
+
   alias push_severity_level is push[queue_t, severity_level];
   alias pop_severity_level is pop[queue_t return severity_level];
+  alias peek_severity_level is peek[queue_t, severity_level, natural];
+  alias peek_severity_level is peek[queue_t return severity_level];
 
   procedure push (
     queue : queue_t;
@@ -143,8 +237,20 @@ package queue_pkg is
     queue : queue_t
   ) return file_open_status;
 
+  procedure peek (
+    queue : queue_t;
+    variable value : out file_open_status;
+    variable offset : inout natural
+  );
+
+  impure function peek (
+    queue : queue_t
+  ) return file_open_status;
+
   alias push_file_open_status is push[queue_t, file_open_status];
   alias pop_file_open_status is pop[queue_t return file_open_status];
+  alias peek_file_open_status is peek[queue_t, file_open_status, natural];
+  alias peek_file_open_status is peek[queue_t return file_open_status];
 
   procedure push (
     queue : queue_t;
@@ -155,8 +261,20 @@ package queue_pkg is
     queue : queue_t
   ) return file_open_kind;
 
+  procedure peek (
+    queue : queue_t;
+    variable value : out file_open_kind;
+    variable offset : inout natural
+  );
+
+  impure function peek (
+    queue : queue_t
+  ) return file_open_kind;
+
   alias push_file_open_kind is push[queue_t, file_open_kind];
   alias pop_file_open_kind is pop[queue_t return file_open_kind];
+  alias peek_file_open_kind is peek[queue_t, file_open_kind, natural];
+  alias peek_file_open_kind is peek[queue_t return file_open_kind];
 
   procedure push (
     queue : queue_t;
@@ -167,8 +285,20 @@ package queue_pkg is
     queue : queue_t
   ) return bit_vector;
 
+  procedure peek (
+    queue : queue_t;
+    variable value : out bit_vector;
+    variable offset : inout natural
+  );
+
+  impure function peek (
+    queue : queue_t
+  ) return bit_vector;
+
   alias push_bit_vector is push[queue_t, bit_vector];
   alias pop_bit_vector is pop[queue_t return bit_vector];
+  alias peek_bit_vector is peek[queue_t, bit_vector, natural];
+  alias peek_bit_vector is peek[queue_t return bit_vector];
 
   procedure push (
     queue : queue_t;
@@ -179,8 +309,20 @@ package queue_pkg is
     queue : queue_t
   ) return std_ulogic_vector;
 
+  procedure peek (
+    queue : queue_t;
+    variable value : out std_ulogic_vector;
+    variable offset : inout natural
+  );
+
+  impure function peek (
+    queue : queue_t
+  ) return std_ulogic_vector;
+
   alias push_std_ulogic_vector is push[queue_t, std_ulogic_vector];
   alias pop_std_ulogic_vector is pop[queue_t return std_ulogic_vector];
+  alias peek_std_ulogic_vector is peek[queue_t, std_ulogic_vector, natural];
+  alias peek_std_ulogic_vector is peek[queue_t return std_ulogic_vector];
 
   procedure push (
     queue : queue_t;
@@ -191,8 +333,20 @@ package queue_pkg is
     queue : queue_t
   ) return complex;
 
+  procedure peek (
+    queue : queue_t;
+    variable value : out complex;
+    variable offset : inout natural
+  );
+
+  impure function peek (
+    queue : queue_t
+  ) return complex;
+
   alias push_complex is push[queue_t, complex];
   alias pop_complex is pop[queue_t return complex];
+  alias peek_complex is peek[queue_t, complex, natural];
+  alias peek_complex is peek[queue_t return complex];
 
   procedure push (
     queue : queue_t;
@@ -203,8 +357,20 @@ package queue_pkg is
     queue : queue_t
   ) return complex_polar;
 
+  procedure peek (
+    queue : queue_t;
+    variable value : out complex_polar;
+    variable offset : inout natural
+  );
+
+  impure function peek (
+    queue : queue_t
+  ) return complex_polar;
+
   alias push_complex_polar is push[queue_t, complex_polar];
   alias pop_complex_polar is pop[queue_t return complex_polar];
+  alias peek_complex_polar is peek[queue_t, complex_polar, natural];
+  alias peek_complex_polar is peek[queue_t return complex_polar];
 
   procedure push (
     queue : queue_t;
@@ -215,8 +381,20 @@ package queue_pkg is
     queue : queue_t
   ) return ieee.numeric_bit.unsigned;
 
+  procedure peek (
+    queue : queue_t;
+    variable value : out ieee.numeric_bit.unsigned;
+    variable offset : inout natural
+  );
+
+  impure function peek (
+    queue : queue_t
+  ) return ieee.numeric_bit.unsigned;
+
   alias push_numeric_bit_unsigned is push[queue_t, ieee.numeric_bit.unsigned];
   alias pop_numeric_bit_unsigned is pop[queue_t return ieee.numeric_bit.unsigned];
+  alias peek_numeric_bit_unsigned is peek[queue_t, ieee.numeric_bit.unsigned, natural];
+  alias peek_numeric_bit_unsigned is peek[queue_t return ieee.numeric_bit.unsigned];
 
   procedure push (
     queue : queue_t;
@@ -227,8 +405,20 @@ package queue_pkg is
     queue : queue_t
   ) return ieee.numeric_bit.signed;
 
+  procedure peek (
+    queue : queue_t;
+    variable value : out ieee.numeric_bit.signed;
+    variable offset : inout natural
+  );
+
+  impure function peek (
+    queue : queue_t
+  ) return ieee.numeric_bit.signed;
+
   alias push_numeric_bit_signed is push[queue_t, ieee.numeric_bit.signed];
   alias pop_numeric_bit_signed is pop[queue_t return ieee.numeric_bit.signed];
+  alias peek_numeric_bit_signed is peek[queue_t, ieee.numeric_bit.signed, natural];
+  alias peek_numeric_bit_signed is peek[queue_t return ieee.numeric_bit.signed];
 
   procedure push (
     queue : queue_t;
@@ -239,8 +429,20 @@ package queue_pkg is
     queue : queue_t
   ) return ieee.numeric_std.unsigned;
 
+  procedure peek (
+    queue : queue_t;
+    variable value : out ieee.numeric_std.unsigned;
+    variable offset : inout natural
+  );
+
+  impure function peek (
+    queue : queue_t
+  ) return ieee.numeric_std.unsigned;
+
   alias push_numeric_std_unsigned is push[queue_t, ieee.numeric_std.unsigned];
   alias pop_numeric_std_unsigned is pop[queue_t return ieee.numeric_std.unsigned];
+  alias peek_numeric_std_unsigned is peek[queue_t, ieee.numeric_std.unsigned, natural];
+  alias peek_numeric_std_unsigned is peek[queue_t return ieee.numeric_std.unsigned];
 
   procedure push (
     queue : queue_t;
@@ -251,8 +453,20 @@ package queue_pkg is
     queue : queue_t
   ) return ieee.numeric_std.signed;
 
+  procedure peek (
+    queue : queue_t;
+    variable value : out ieee.numeric_std.signed;
+    variable offset : inout natural
+  );
+
+  impure function peek (
+    queue : queue_t
+  ) return ieee.numeric_std.signed;
+
   alias push_numeric_std_signed is push[queue_t, ieee.numeric_std.signed];
   alias pop_numeric_std_signed is pop[queue_t return ieee.numeric_std.signed];
+  alias peek_numeric_std_signed is peek[queue_t, ieee.numeric_std.signed, natural];
+  alias peek_numeric_std_signed is peek[queue_t return ieee.numeric_std.signed];
 
   procedure push (
     queue : queue_t;
@@ -263,8 +477,20 @@ package queue_pkg is
     queue : queue_t
   ) return string;
 
+  procedure peek (
+    queue : queue_t;
+    variable value : out string;
+    variable offset : inout natural
+  );
+
+  impure function peek (
+    queue : queue_t
+  ) return string;
+
   alias push_string is push[queue_t, string];
   alias pop_string is pop[queue_t return string];
+  alias peek_string is peek[queue_t, string, natural];
+  alias peek_string is peek[queue_t return string];
 
   procedure push (
     queue : queue_t;
@@ -275,8 +501,20 @@ package queue_pkg is
     queue : queue_t
   ) return time;
 
+  procedure peek (
+    queue : queue_t;
+    variable value : out time;
+    variable offset : inout natural
+  );
+
+  impure function peek (
+    queue : queue_t
+  ) return time;
+
   alias push_time is push[queue_t, time];
   alias pop_time is pop[queue_t return time];
+  alias peek_time is peek[queue_t, time, natural];
+  alias peek_time is peek[queue_t return time];
 
   procedure push (
     queue : queue_t;
@@ -287,8 +525,20 @@ package queue_pkg is
     queue : queue_t
   ) return integer_vector_ptr_t;
 
+  procedure peek (
+    queue : queue_t;
+    variable value : out integer_vector_ptr_t;
+    variable offset : inout natural
+  );
+
+  impure function peek (
+    queue : queue_t
+  ) return integer_vector_ptr_t;
+
   alias push_integer_vector_ptr_ref is push[queue_t, integer_vector_ptr_t];
   alias pop_integer_vector_ptr_ref is pop[queue_t return integer_vector_ptr_t];
+  alias peek_integer_vector_ptr_ref is peek[queue_t, integer_vector_ptr_t, natural];
+  alias peek_integer_vector_ptr_ref is peek[queue_t return integer_vector_ptr_t];
 
   procedure push (
     queue : queue_t;
@@ -299,8 +549,20 @@ package queue_pkg is
     queue : queue_t
   ) return string_ptr_t;
 
+  procedure peek (
+    queue : queue_t;
+    variable value : out string_ptr_t;
+    variable offset : inout natural
+  );
+
+  impure function peek (
+    queue : queue_t
+  ) return string_ptr_t;
+
   alias push_string_ptr_ref is push[queue_t, string_ptr_t];
   alias pop_string_ptr_ref is pop[queue_t return string_ptr_t];
+  alias peek_string_ptr_ref is peek[queue_t, string_ptr_t, natural];
+  alias peek_string_ptr_ref is peek[queue_t return string_ptr_t];
 
   procedure push (
     queue : queue_t;
@@ -311,8 +573,20 @@ package queue_pkg is
     queue : queue_t
   ) return queue_t;
 
+  procedure peek (
+    queue : queue_t;
+    variable value : out queue_t;
+    variable offset : inout natural
+  );
+
+  impure function peek (
+    queue : queue_t
+  ) return queue_t;
+
   alias push_queue_ref is push[queue_t, queue_t];
   alias pop_queue_ref is pop[queue_t return queue_t];
+  alias peek_queue_ref is peek[queue_t, queue_t, natural];
+  alias peek_queue_ref is peek[queue_t return queue_t];
 
   procedure push_ref (
     constant queue : queue_t;
@@ -323,8 +597,20 @@ package queue_pkg is
     queue : queue_t
   ) return integer_array_t;
 
+  procedure peek_ref (
+    queue : queue_t;
+    variable value : out integer_array_t;
+    variable offset : inout natural
+  );
+
+  impure function peek_ref (
+    queue : queue_t
+  ) return integer_array_t;
+
   alias push_integer_array_t_ref is push_ref[queue_t, integer_array_t];
   alias pop_integer_array_t_ref is pop_ref[queue_t return integer_array_t];
+  alias peek_integer_array_t_ref is peek_ref[queue_t, integer_array_t, natural];
+  alias peek_integer_array_t_ref is peek_ref[queue_t return integer_array_t];
 
   -- Private
   type queue_element_type_t is (
@@ -335,6 +621,7 @@ package queue_pkg is
     vunit_string_ptr_t, vunit_queue_t, vunit_integer_array_t, vhdl_boolean_vector, vhdl_integer_vector,
     vhdl_real_vector, vhdl_time_vector, ieee_ufixed, ieee_sfixed, ieee_float
   );
+  constant queue_element_type_t_code_length : positive := 1;
 
   function encode (
     data : queue_t
@@ -358,9 +645,16 @@ package queue_pkg is
     element_type : queue_element_type_t
   );
 
-  procedure check_type (
+  procedure check_type_pop (
     queue        : queue_t;
     element_type : queue_element_type_t
+  );
+  alias check_type is check_type_pop[queue_t, queue_element_type_t];
+
+  procedure check_type_peek (
+    queue        : queue_t;
+    element_type : queue_element_type_t;
+    variable offset : inout natural
   );
 
   procedure unsafe_push (
@@ -369,6 +663,16 @@ package queue_pkg is
   );
 
   impure function unsafe_pop (
+    queue : queue_t
+  ) return character;
+
+  procedure unsafe_peek (
+    queue : queue_t;
+    variable value : out character;
+    variable offset : inout natural
+  );
+
+  impure function unsafe_peek (
     queue : queue_t
   ) return character;
 
@@ -381,6 +685,17 @@ package queue_pkg is
     queue : queue_t
   ) return string;
 
+  procedure peek_variable_string (
+    queue : queue_t;
+    variable value : out string;
+    variable offset : inout natural
+  );
+
+  impure function peek_variable_string (
+    queue : queue_t;
+    offset : natural := 0
+  ) return string;
+
   procedure push_fix_string (
     queue : queue_t;
     value : string
@@ -389,5 +704,17 @@ package queue_pkg is
   impure function pop_fix_string (
     queue  : queue_t;
     length : natural
+  ) return string;
+
+  procedure peek_fix_string (
+    queue  : queue_t;
+    variable result : out string;
+    variable offset : inout natural
+  );
+
+  impure function peek_fix_string (
+    queue  : queue_t;
+    length : natural;
+    offset : natural := 0
   ) return string;
 end package;

--- a/vunit/vhdl/data_types/test/tb_queue-2008p.vhd
+++ b/vunit/vhdl/data_types/test/tb_queue-2008p.vhd
@@ -26,55 +26,71 @@ begin
   begin
     test_runner_setup(runner, runner_cfg);
 
-    if run("Test push and pop boolean_vector") then
+    if run("Test push, peek and pop boolean_vector") then
       queue := new_queue;
       push_boolean_vector(queue, (1 => true));
       push_boolean_vector(queue, (false, true));
+      boolv(0 to 0) := peek_boolean_vector(queue);
+      check(boolv(0) = true);
       boolv(0 to 0) := pop_boolean_vector(queue);
       check(boolv(0) = true);
+      boolv := peek_boolean_vector(queue);
+      check(boolv = (false, true));
       boolv := pop_boolean_vector(queue);
       check(boolv = (false, true));
 
-    elsif run("Test push and pop integer_vector") then
+    elsif run("Test push, peek and pop integer_vector") then
       queue := new_queue;
       push_integer_vector(queue, (1 => 17));
       push_integer_vector(queue, (-21, 42));
+      check(peek_integer_vector(queue) = (1 => 17));
       check(pop_integer_vector(queue) = (1 => 17));
+      check(peek_integer_vector(queue) = (-21, 42));
       check(pop_integer_vector(queue) = (-21, 42));
 
-    elsif run("Test push and pop real_vector") then
+    elsif run("Test push, peek and pop real_vector") then
       queue := new_queue;
       push_real_vector(queue, (1 => 17.17));
       push_real_vector(queue, (-21.21, 42.42));
+      check(peek_real_vector(queue) = (1 => 17.17));
       check(pop_real_vector(queue) = (1 => 17.17));
+      check(peek_real_vector(queue) = (-21.21, 42.42));
       check(pop_real_vector(queue) = (-21.21, 42.42));
 
-    elsif run("Test push and pop time_vector") then
+    elsif run("Test push, peek and pop time_vector") then
       queue := new_queue;
       push_time_vector(queue, (1 => 17.17 ms));
       push_time_vector(queue, (-21.21 min, 42.42 us));
+      check(peek_time_vector(queue) = (1 => 17.17 ms));
       check(pop_time_vector(queue) = (1 => 17.17 ms));
+      check(peek_time_vector(queue) = (-21.21 min, 42.42 us));
       check(pop_time_vector(queue) = (-21.21 min, 42.42 us));
 
-    elsif run("Test push and pop ufixed") then
+    elsif run("Test push, peek and pop ufixed") then
       queue := new_queue;
       push_ufixed(queue, to_ufixed(17.17, 6, -9));
       push_ufixed(queue, to_ufixed(42.42, 6, -9));
+      check(peek_ufixed(queue) = to_ufixed(17.17, 6, -9));
       check(pop_ufixed(queue) = to_ufixed(17.17, 6, -9));
+      check(peek_ufixed(queue) = to_ufixed(42.42, 6, -9));
       check(pop_ufixed(queue) = to_ufixed(42.42, 6, -9));
 
-    elsif run("Test push and pop sfixed") then
+    elsif run("Test push, peek and pop sfixed") then
       queue := new_queue;
       push_sfixed(queue, to_sfixed(17.17, 6, -9));
       push_sfixed(queue, to_sfixed(-21.21, 6, -9));
+      check(peek_sfixed(queue) = to_sfixed(17.17, 6, -9));
       check(pop_sfixed(queue) = to_sfixed(17.17, 6, -9));
+      check(peek_sfixed(queue) = to_sfixed(-21.21, 6, -9));
       check(pop_sfixed(queue) = to_sfixed(-21.21, 6, -9));
 
-    elsif run("Test push and pop float") then
+    elsif run("Test push, peek and pop float") then
       queue := new_queue;
       push_float(queue, to_float(17.17));
       push_float(queue, to_float(-21.21));
+      check(peek_float(queue) = to_float(17.17));
       check(pop_float(queue) = to_float(17.17));
+      check(peek_float(queue) = to_float(-21.21));
       check(pop_float(queue) = to_float(-21.21));
 
     end if;

--- a/vunit/vhdl/data_types/test/tb_queue.vhd
+++ b/vunit/vhdl/data_types/test/tb_queue.vhd
@@ -36,6 +36,8 @@ begin
     variable integer_vector_ptr, integer_vector_ptr_copy : integer_vector_ptr_t;
     variable string_ptr, string_ptr_copy : string_ptr_t;
     variable integer_array, integer_array_copy: integer_array_t;
+    variable offset : natural;
+    -- variable var1, var2 : std_ulogic_vector;
   begin
     test_runner_setup(runner, runner_cfg);
     if run("Test default queue is null") then
@@ -48,10 +50,13 @@ begin
       push_integer(queue, 11);
       check_false(is_empty(queue), "Empty queue");
 
+      check_equal(peek_integer(queue), 11, "data");
+      check_false(is_empty(queue), "Empty queue");
+
       check_equal(pop_integer(queue), 11, "data");
       check(is_empty(queue), "Empty queue");
 
-    elsif run("Test push and pop integer") then
+    elsif run("Test push, peek and pop integer") then
       queue := new_queue;
       assert queue /= null_queue report "Expected non null queue";
       check_equal(length(queue), 0, "Empty queue length");
@@ -61,31 +66,41 @@ begin
       push_integer(queue, 22);
       check_equal(length(queue), 10, "Length");
 
+      check_equal(peek_integer(queue), 11, "data");
+      check_equal(length(queue), 10, "Length");
       check_equal(pop_integer(queue), 11, "data");
+      check_equal(length(queue), 5, "Length");
+      check_equal(peek_integer(queue), 22, "data");
       check_equal(length(queue), 5, "Length");
       check_equal(pop_integer(queue), 22, "data");
       check_equal(length(queue), 0, "Length");
 
       push_integer(queue, integer'low);
+      check_equal(peek_integer(queue), integer'low, "data");
       check_equal(pop_integer(queue), integer'low, "data");
       push_integer(queue, integer'high);
+      check_equal(peek_integer(queue), integer'high, "data");
       check_equal(pop_integer(queue), integer'high, "data");
 
-    elsif run("Test push and pop byte") then
+    elsif run("Test push, peek and pop byte") then
       queue := new_queue;
       push_byte(queue, 11);
       push_byte(queue, 22);
+      check_equal(peek_byte(queue), 11, "data");
       check_equal(pop_byte(queue), 11, "data");
+      check_equal(peek_byte(queue), 22, "data");
       check_equal(pop_byte(queue), 22, "data");
 
-    elsif run("Test push and pop boolean") then
+    elsif run("Test push, peek and pop boolean") then
       queue := new_queue;
       push_boolean(queue, false);
       push_boolean(queue, true);
+      check_false(peek_boolean(queue), "data");
       check_false(pop_boolean(queue), "data");
+      check_true(peek_boolean(queue), "data");
       check_true(pop_boolean(queue), "data");
 
-    elsif run("Test push and pop character") then
+    elsif run("Test push, peek and pop character") then
       queue := new_queue;
       assert queue /= null_queue report "Expected non null queue";
       check_equal(length(queue), 0, "Empty queue length");
@@ -95,8 +110,10 @@ begin
       push_character(queue, '2');
       check_equal(length(queue), 4, "Length");
 
+      assert peek_character(queue) = '1';
       assert pop_character(queue) = '1';
       check_equal(length(queue), 2, "Length");
+      assert peek_character(queue) = '2';
       assert pop_character(queue) = '2';
       check_equal(length(queue), 0, "Length");
 
@@ -109,34 +126,41 @@ begin
       flush(queue);
       check_equal(length(queue), 0, "Length");
 
-    elsif run("Test push and pop queue_t") then
+    elsif run("Test push, peek and pop queue_t") then
       queue := new_queue;
       another_queue := new_queue;
       push(another_queue, 22);
       queue_copy := another_queue;
       push_queue_ref(queue, another_queue);
       assert another_queue = null_queue report "Ownership was transfered";
+      assert peek_queue_ref(queue) = queue_copy report "Queue should come back";
       assert pop_queue_ref(queue) = queue_copy report "Queue should come back";
 
-    elsif run("Test push and pop string") then
+    elsif run("Test push, peek and pop string") then
       queue := new_queue;
       push_string(queue, "hello world");
       push_string(queue, "two");
       push_string(queue, test_string1);
       push_string(queue, test_string2);
+      assert peek_string(queue) = "hello world";
       assert pop_string(queue) = "hello world";
+      assert peek_string(queue) = "two";
       assert pop_string(queue) = "two";
+      assert peek_string(queue) = test_string1;
       assert pop_string(queue) = test_string1;
+      assert peek_string(queue) = test_string2;
       assert pop_string(queue) = test_string2;
 
-    elsif run("Test push and pop bit") then
+    elsif run("Test push, peek and pop bit") then
       queue := new_queue;
       push_bit(queue, '0');
       push_bit(queue, '1');
+      check(peek_bit(queue) = '0');
       check(pop_bit(queue) = '0');
+      check(peek_bit(queue) = '1');
       check(pop_bit(queue) = '1');
 
-    elsif run("Test push and pop std_ulogic") then
+    elsif run("Test push, peek and pop std_ulogic") then
       queue := new_queue;
       push_std_ulogic(queue, 'U');
       push_std_ulogic(queue, 'X');
@@ -147,132 +171,186 @@ begin
       push_std_ulogic(queue, 'L');
       push_std_ulogic(queue, 'H');
       push_std_ulogic(queue, '-');
+      assert peek_std_ulogic(queue) = 'U';
       assert pop_std_ulogic(queue) = 'U';
+      assert peek_std_ulogic(queue) = 'X';
       assert pop_std_ulogic(queue) = 'X';
+      assert peek_std_ulogic(queue) = '0';
       assert pop_std_ulogic(queue) = '0';
+      assert peek_std_ulogic(queue) = '1';
       assert pop_std_ulogic(queue) = '1';
+      assert peek_std_ulogic(queue) = 'Z';
       assert pop_std_ulogic(queue) = 'Z';
+      assert peek_std_ulogic(queue) = 'W';
       assert pop_std_ulogic(queue) = 'W';
+      assert peek_std_ulogic(queue) = 'L';
       assert pop_std_ulogic(queue) = 'L';
+      assert peek_std_ulogic(queue) = 'H';
       assert pop_std_ulogic(queue) = 'H';
+      assert peek_std_ulogic(queue) = '-';
       assert pop_std_ulogic(queue) = '-';
 
-    elsif run("Test push and pop severity_level") then
+    elsif run("Test push, peek and pop severity_level") then
       queue := new_queue;
       push_severity_level(queue, note);
       push_severity_level(queue, error);
+      check(peek_severity_level(queue) = note);
       check(pop_severity_level(queue) = note);
+      check(peek_severity_level(queue) = error);
       check(pop_severity_level(queue) = error);
 
-    elsif run("Test push and pop file_open_status") then
+    elsif run("Test push, peek and pop file_open_status") then
       queue := new_queue;
       push_file_open_status(queue, open_ok);
       push_file_open_status(queue, mode_error);
+      check(peek_file_open_status(queue) = open_ok);
       check(pop_file_open_status(queue) = open_ok);
+      check(peek_file_open_status(queue) = mode_error);
       check(pop_file_open_status(queue) = mode_error);
 
-    elsif run("Test push and pop file_open_kind") then
+    elsif run("Test push, peek and pop file_open_kind") then
       queue := new_queue;
       push_file_open_kind(queue, read_mode);
       push_file_open_kind(queue, append_mode);
+      check(peek_file_open_kind(queue) = read_mode);
       check(pop_file_open_kind(queue) = read_mode);
+      check(peek_file_open_kind(queue) = append_mode);
       check(pop_file_open_kind(queue) = append_mode);
 
-    elsif run("Test push and pop bit_vector") then
+    elsif run("Test push, peek and pop bit_vector") then
       queue := new_queue;
       push_bit_vector(queue, "1");
       push_bit_vector(queue, "010101");
+      offset := 0;
+      peek_bit_vector(queue, bv(0 to 0), offset);
+      check(bv(0) = '1');
+      peek_bit_vector(queue, bv, offset);
+      check(bv = "010101");
+      bv(0 to 0) := peek_bit_vector(queue);
+      check(bv(0) = '1');
       bv(0 to 0) := pop_bit_vector(queue);
       check(bv(0) = '1');
+      offset := 0;
+      peek_bit_vector(queue, bv, offset);
+      check(bv = "010101");
+      bv := peek_bit_vector(queue);
+      check(bv = "010101");
       bv := pop_bit_vector(queue);
       check(bv = "010101");
 
-    elsif run("Test push and pop std_ulogic_vector") then
+    elsif run("Test push, peek and pop std_ulogic_vector") then
       queue := new_queue;
       push_std_ulogic_vector(queue, descending_sulv);
       push_std_ulogic_vector(queue, ascending_sulv);
+      assert peek_std_ulogic_vector(queue) = descending_sulv;
       assert pop_std_ulogic_vector(queue) = descending_sulv;
+      assert peek_std_ulogic_vector(queue) = ascending_sulv;
       assert pop_std_ulogic_vector(queue) = ascending_sulv;
 
-    elsif run("Test push and pop complex") then
+    elsif run("Test push, peek and pop complex") then
       queue := new_queue;
       push_complex(queue, (1.0, 2.2));
       push_complex(queue, (-1.0, -2.2));
+      check(peek_complex(queue) = (1.0, 2.2));
       check(pop_complex(queue) = (1.0, 2.2));
+      check(peek_complex(queue) = (-1.0, -2.2));
       check(pop_complex(queue) = (-1.0, -2.2));
 
-    elsif run("Test push and pop complex_polar") then
+    elsif run("Test push, peek and pop complex_polar") then
       queue := new_queue;
       push_complex_polar(queue, (1.0, 0.707));
       push_complex_polar(queue, (3.14, -0.707));
+      check(peek_complex_polar(queue) = (1.0, 0.707));
       check(pop_complex_polar(queue) = (1.0, 0.707));
+      check(peek_complex_polar(queue) = (3.14, -0.707));
       check(pop_complex_polar(queue) = (3.14, -0.707));
 
-    elsif run("Test push and pop ieee.numeric_bit.unsigned") then
+    elsif run("Test push, peek and pop ieee.numeric_bit.unsigned") then
       queue := new_queue;
       push_numeric_bit_unsigned(queue, "1");
       push_numeric_bit_unsigned(queue, "010101");
+      check(peek_numeric_bit_unsigned(queue) = "1");
       check(pop_numeric_bit_unsigned(queue) = "1");
+      check(peek_numeric_bit_unsigned(queue) = "010101");
       check(pop_numeric_bit_unsigned(queue) = "010101");
 
-    elsif run("Test push and pop ieee.numeric_bit.signed") then
+    elsif run("Test push, peek and pop ieee.numeric_bit.signed") then
       queue := new_queue;
       push_numeric_bit_signed(queue, "1");
       push_numeric_bit_signed(queue, "010101");
+      check(peek_numeric_bit_signed(queue) = "1");
       check(pop_numeric_bit_signed(queue) = "1");
+      check(peek_numeric_bit_signed(queue) = "010101");
       check(pop_numeric_bit_signed(queue) = "010101");
 
-    elsif run("Test push and pop ieee.numeric_std.unsigned") then
+    elsif run("Test push, peek and pop ieee.numeric_std.unsigned") then
       queue := new_queue;
       push_numeric_std_unsigned(queue, "1");
       push_numeric_std_unsigned(queue, "010101");
+      check(peek_numeric_std_unsigned(queue) = "1");
       check(pop_numeric_std_unsigned(queue) = "1");
+      check(peek_numeric_std_unsigned(queue) = "010101");
       check(pop_numeric_std_unsigned(queue) = "010101");
 
-    elsif run("Test push and pop ieee.numeric_std.signed") then
+    elsif run("Test push, peek and pop ieee.numeric_std.signed") then
       queue := new_queue;
       push_numeric_std_signed(queue, "1");
       push_numeric_std_signed(queue, "010101");
+      check(peek_numeric_std_signed(queue) = "1");
       check(pop_numeric_std_signed(queue) = "1");
+      check(peek_numeric_std_signed(queue) = "010101");
       check(pop_numeric_std_signed(queue) = "010101");
 
-    elsif run("Test push and pop std_logic_vector") then
+    elsif run("Test push, peek and pop std_logic_vector") then
       queue := new_queue;
       push_std_ulogic_vector(queue, std_ulogic_vector(descending_slv));
       push_std_ulogic_vector(queue, std_ulogic_vector(ascending_slv));
+      assert std_logic_vector(peek_std_ulogic_vector(queue)) = descending_slv;
       assert std_logic_vector(pop_std_ulogic_vector(queue)) = descending_slv;
+      assert std_logic_vector(peek_std_ulogic_vector(queue)) = ascending_slv;
       assert std_logic_vector(pop_std_ulogic_vector(queue)) = ascending_slv;
 
-    elsif run("Test push and pop signed and unsigned") then
+    elsif run("Test push, peek and pop signed and unsigned") then
       queue := new_queue;
       push_std_ulogic_vector(queue, std_ulogic_vector(ieee.numeric_std.to_unsigned(11, 16)));
       push_std_ulogic_vector(queue, std_ulogic_vector(ieee.numeric_std.to_signed(-1, 8)));
+      assert ieee.numeric_std.unsigned(peek_std_ulogic_vector(queue)) = ieee.numeric_std.to_unsigned(11, 16);
       assert ieee.numeric_std.unsigned(pop_std_ulogic_vector(queue)) = ieee.numeric_std.to_unsigned(11, 16);
+      assert ieee.numeric_std.signed(peek_std_ulogic_vector(queue)) = ieee.numeric_std.to_signed(-1, 8);
       assert ieee.numeric_std.signed(pop_std_ulogic_vector(queue)) = ieee.numeric_std.to_signed(-1, 8);
 
-    elsif run("Test push and pop real") then
+    elsif run("Test push, peek and pop real") then
       queue := new_queue;
       push_real(queue, 1.0);
       push_real(queue, -1.0);
       push_real(queue, 2.0);
       push_real(queue, 0.5);
       push_real(queue, -0.5);
+      assert peek_real(queue) = 1.0;
       assert pop_real(queue) = 1.0;
+      assert peek_real(queue) = -1.0;
       assert pop_real(queue) = -1.0;
+      assert peek_real(queue) = 2.0;
       assert pop_real(queue) = 2.0;
+      assert peek_real(queue) = 0.5;
       assert pop_real(queue) = 0.5;
+      assert peek_real(queue) = -0.5;
       assert pop_real(queue) = -0.5;
 
       push_real(queue, 1.0 + 0.5**23); -- Single
       push_real(queue, -(1.0 + 0.5**23)); -- Single
       push_real(queue, 1.0 + 0.5**53); -- Double
       push_real(queue, -(1.0 + 0.5**53)); -- Double
+      assert peek_real(queue) = 1.0 + 0.5**23;
       assert pop_real(queue) = 1.0 + 0.5**23;
+      assert peek_real(queue) = -(1.0 + 0.5**23);
       assert pop_real(queue) = -(1.0 + 0.5**23);
+      assert peek_real(queue) = 1.0 + 0.5**53;
       assert pop_real(queue) = 1.0 + 0.5**53;
+      assert peek_real(queue) = -(1.0 + 0.5**53);
       assert pop_real(queue) = -(1.0 + 0.5**53);
 
-    elsif run("Test push and pop time") then
+    elsif run("Test push, peek and pop time") then
       queue := new_queue;
       push_time(queue, 1 fs);
       push_time(queue, 1 ps);
@@ -281,46 +359,60 @@ begin
       push_time(queue, 1 sec);
       push_time(queue, 1 min);
       push_time(queue, 1 hr);
+      assert peek_time(queue) = 1 fs;
       assert pop_time(queue) = 1 fs;
+      assert peek_time(queue) = 1 ps;
       assert pop_time(queue) = 1 ps;
+      assert peek_time(queue) = 1 ns;
       assert pop_time(queue) = 1 ns;
+      assert peek_time(queue) = 1 ms;
       assert pop_time(queue) = 1 ms;
+      assert peek_time(queue) = 1 sec;
       assert pop_time(queue) = 1 sec;
+      assert peek_time(queue) = 1 min;
       assert pop_time(queue) = 1 min;
+      assert peek_time(queue) = 1 hr;
       assert pop_time(queue) = 1 hr;
 
       push_time(queue, 1 hr + 1 fs);
+      assert peek_time(queue) = 1 hr + 1 fs;
       assert pop_time(queue) = 1 hr + 1 fs;
 
       push_time(queue, -1 fs);
       push_time(queue, -1 hr);
       push_time(queue, -1 hr - 1 fs);
+      assert peek_time(queue) = -1 fs;
       assert pop_time(queue) = -1 fs;
+      assert peek_time(queue) = -1 hr;
       assert pop_time(queue) = -1 hr;
+      assert peek_time(queue) = -1 hr - 1 fs;
       assert pop_time(queue) = -1 hr - 1 fs;
 
-    elsif run("Test push and pop integer_vector_ptr_t") then
+    elsif run("Test push, peek and pop integer_vector_ptr_t") then
       queue := new_queue;
       integer_vector_ptr := new_integer_vector_ptr;
       integer_vector_ptr_copy := integer_vector_ptr;
       push_integer_vector_ptr_ref(queue, integer_vector_ptr);
       assert integer_vector_ptr = null_ptr report "Ownership was transfered";
+      assert peek_integer_vector_ptr_ref(queue) = integer_vector_ptr_copy;
       assert pop_integer_vector_ptr_ref(queue) = integer_vector_ptr_copy;
 
-    elsif run("Test push and pop string_ptr_t") then
+    elsif run("Test push, peek and pop string_ptr_t") then
       queue := new_queue;
       string_ptr := new_string_ptr;
       string_ptr_copy := string_ptr;
       push_string_ptr_ref(queue, string_ptr);
       assert string_ptr = null_string_ptr report "Ownership was transfered";
+      assert peek_string_ptr_ref(queue) = string_ptr_copy;
       assert pop_string_ptr_ref(queue) = string_ptr_copy;
 
-    elsif run("Test push and pop integer_array_t") then
+    elsif run("Test push, peek and pop integer_array_t") then
       queue := new_queue;
       integer_array := new_3d(1, 2, 3, 4);
       integer_array_copy := integer_array;
       push_integer_array_t_ref(queue, integer_array);
       assert integer_array = null_integer_array;
+      assert peek_integer_array_t_ref(queue) = integer_array_copy;
       assert pop_integer_array_t_ref(queue) = integer_array_copy;
 
     elsif run("Test codecs") then

--- a/vunit/vhdl/verification_components/test/tb_avalon_master.vhd
+++ b/vunit/vhdl/verification_components/test/tb_avalon_master.vhd
@@ -182,6 +182,8 @@ begin
 
       info(tb_logger, "Compare...");
       for i in 0 to tb_cfg.transfers-1 loop
+        tmp := peek(data_queue);
+        check_equal(tmp, std_logic_vector(to_unsigned(i, readdata'length)), "read data");
         tmp := pop(data_queue);
         check_equal(tmp, std_logic_vector(to_unsigned(i, readdata'length)), "read data");
       end loop;
@@ -201,6 +203,8 @@ begin
 
       info(tb_logger, "Compare...");
       for i in 0 to tb_cfg.transfers-1 loop
+        tmp := peek(data_queue);
+        check_equal(tmp, std_logic_vector(to_unsigned(i, readdata'length)), "read data");
         tmp := pop(data_queue);
         check_equal(tmp, std_logic_vector(to_unsigned(i, readdata'length)), "read data");
       end loop;
@@ -237,6 +241,8 @@ begin
         burst_rd_ref := pop(rd_ref_queue);
         await_burst_read_bus_reply(net, bus_handle, data_queue, burst_rd_ref);
         while not is_empty(data_queue) loop
+          tmp := peek(data_queue);
+          check_equal(tmp, std_logic_vector(to_unsigned(i, readdata'length)), "read data");
           tmp := pop(data_queue);
           check_equal(tmp, std_logic_vector(to_unsigned(i, readdata'length)), "read data");
           i := i + 1;

--- a/vunit/vhdl/verification_components/test/tb_avalon_stream.vhd
+++ b/vunit/vhdl/verification_components/test/tb_avalon_stream.vhd
@@ -63,7 +63,7 @@ begin
       pop_stream(net, slave_stream, tmp);
       check_equal(tmp, std_logic_vector'(x"55"), "pop stream second data");
 
-    elsif run("push delay pop") then
+    elsif run("test push and pop with delay") then
       push_stream(net, master_stream, x"de");
       wait until rising_edge(clk);
       wait until rising_edge(clk);

--- a/vunit/vhdl/verification_components/test/tb_avalon_stream_pkg.vhd
+++ b/vunit/vhdl/verification_components/test/tb_avalon_stream_pkg.vhd
@@ -34,33 +34,41 @@ begin
     set_format(display_handler, verbose, true);
 
     wait until rising_edge(clk);
-    if run("test single transaction push and pop") then
+    if run("test single transaction push, peek and pop") then
       avalon_stream_transaction.data := x"ab";
       msg := new_avalon_stream_transaction_msg(avalon_stream_transaction);
       msg_type := message_type(msg);
+      peek_avalon_stream_transaction(msg, avalon_stream_transaction_tmp);
+      check_equal(avalon_stream_transaction_tmp.data, avalon_stream_transaction.data, "peek stream transaction data");
       handle_avalon_stream_transaction(msg_type, msg, avalon_stream_transaction_tmp);
       check_equal(avalon_stream_transaction_tmp.data, avalon_stream_transaction.data, "pop stream transaction data");
 
-    elsif run("test double transaction push and pop") then
+    elsif run("test double transaction push, peek and pop") then
       avalon_stream_transaction.data := x"a5";
       msg := new_avalon_stream_transaction_msg(avalon_stream_transaction);
       msg_type := message_type(msg);
+      peek_avalon_stream_transaction(msg, avalon_stream_transaction_tmp);
+      check_equal(avalon_stream_transaction_tmp.data, avalon_stream_transaction.data, "peek stream transaction data");
       handle_avalon_stream_transaction(msg_type, msg, avalon_stream_transaction_tmp);
       check_equal(avalon_stream_transaction_tmp.data, avalon_stream_transaction.data, "pop stream transaction data");
 
       avalon_stream_transaction.data := x"9e";
       msg := new_avalon_stream_transaction_msg(avalon_stream_transaction);
       msg_type := message_type(msg);
+      peek_avalon_stream_transaction(msg, avalon_stream_transaction_tmp);
+      check_equal(avalon_stream_transaction_tmp.data, avalon_stream_transaction.data, "peek stream transaction data");
       handle_avalon_stream_transaction(msg_type, msg, avalon_stream_transaction_tmp);
       check_equal(avalon_stream_transaction_tmp.data, avalon_stream_transaction.data, "pop stream transaction data");
 
-    elsif run("test transaction push delay pop") then
+    elsif run("test transaction push delay peek and pop") then
       avalon_stream_transaction.data := x"f1";
       msg := new_avalon_stream_transaction_msg(avalon_stream_transaction);
       msg_type := message_type(msg);
       wait until rising_edge(clk);
       wait until rising_edge(clk);
       wait until rising_edge(clk);
+      peek_avalon_stream_transaction(msg, avalon_stream_transaction_tmp);
+      check_equal(avalon_stream_transaction_tmp.data, avalon_stream_transaction.data, "peek stream transaction data");
       handle_avalon_stream_transaction(msg_type, msg, avalon_stream_transaction_tmp);
       check_equal(avalon_stream_transaction_tmp.data, avalon_stream_transaction.data, "pop stream transaction data");
 
@@ -71,6 +79,10 @@ begin
         avalon_stream_transaction.eop  := (i = 7);
         msg := new_avalon_stream_transaction_msg(avalon_stream_transaction);
         msg_type := message_type(msg);
+        peek_avalon_stream_transaction(msg, avalon_stream_transaction_tmp);
+        check_equal(avalon_stream_transaction_tmp.data, std_logic_vector(to_unsigned(i, 8)), "peek stream data"&natural'image(i));
+        check_equal(avalon_stream_transaction_tmp.sop, i = 0, "peek stream sop");
+        check_equal(avalon_stream_transaction_tmp.eop, i = 7, "peek stream eop");
         handle_avalon_stream_transaction(msg_type, msg, avalon_stream_transaction_tmp);
         check_equal(avalon_stream_transaction_tmp.data, std_logic_vector(to_unsigned(i, 8)), "pop stream data"&natural'image(i));
         check_equal(avalon_stream_transaction_tmp.sop, i = 0, "pop stream sop");


### PR DESCRIPTION
Add a peek functionality to the queue_pkg: returns the element at the front the queue. It does not delete the element in the queue (contrary to the already existing pop command).
The peek functionality has alos been added to the com package and some of the verification components.

Added a small description of the peek functionality in the documentation of the com library when using messages.

My first Pull Request (ever), don't hesitate to give feedback.