### PR TITLE
Always use the current environment variables when starting vsim

### DIFF
--- a/vunit/sim_if/vsim_simulator_mixin.py
+++ b/vunit/sim_if/vsim_simulator_mixin.py
@@ -29,7 +29,6 @@ class VsimSimulatorMixin(object):
         self._sim_cfg_file_name = sim_cfg_file_name
 
         prefix = self._prefix  # Avoid circular dependency inhibiting process destruction
-        env = self.get_env()
 
         def create_process(ident):
             return Process(
@@ -42,7 +41,7 @@ class VsimSimulatorMixin(object):
                     str((Path(__file__).parent / "tcl_read_eval_loop.tcl").resolve()),
                 ],
                 cwd=str(Path(sim_cfg_file_name).parent),
-                env=env,
+                env=self.get_env(),
             )
 
         if persistent:


### PR DESCRIPTION
With this change, it is possible to manipulate the environment variables for each testcase via the set_pre_config hook. 

Background:
I have an existing test environment that uses the FLI interface of Questa for co-simulation.
Environment variables are used to pass information about the specific testcase to the FLI C++ code. 
Now I'm trying to use VUnit for automation.
Currently, when using vsim, VUnit samples the environment variables in __init__ of VsimSimulatorMixin. This is executed only once after calling VUnit.main(). The same environment variables are then passed to vsim for each testcase and it's not possible to change them per testcase. 
This change enables me to set environment variables per testcase via the set_pre_config hook. 

