### PR TITLE
Rework codec

### DIFF
--- a/docs/data_types/codec.rst
+++ b/docs/data_types/codec.rst
@@ -1,0 +1,12 @@
+.. _codec_pkg:
+
+*codec* package
+---------------
+
+.. literalinclude:: ../../vunit/vhdl/data_types/src/codec.vhd
+   :language: vhdl
+   :lines: 22-229
+
+.. literalinclude:: ../../vunit/vhdl/data_types/src/codec-2008p.vhd
+   :language: vhdl
+   :lines: 24-71

--- a/docs/data_types/user_guide.rst
+++ b/docs/data_types/user_guide.rst
@@ -16,6 +16,11 @@ VUnit comes with a number of convenient data types included:
     append and reshape operations, and reading/writing data to/from
     *.csv* or *.raw* byte files.
 
+VUnit **queue_t** (:ref:`Queue API <queue_pkg>`) functionality is built
+on top of the **codec** (:ref:`Codec API <codec_pkg>`) package. The
+codec (:ref:`Codec API <codec_pkg>`) package enable to encode any
+predefined type into a unique type (each type is encoded into a string).
+
 .. toctree::
    :hidden:
 

--- a/vunit/com/codec_datatype_template.py
+++ b/vunit/com/codec_datatype_template.py
@@ -16,28 +16,40 @@ class DatatypeCodecTemplate(object):
 
     to_string_declarations = Template(
         """\
-  function to_string (
-    constant data : $type)
-    return string;
+  -- Printing function for the type $type
+  function to_string(data : $type) return string;
 
 """
     )
 
     codec_declarations = Template(
         """\
-  function encode (
-    constant data : $type)
-    return string;
-  alias encode_$type is encode[$type return string];
-  function decode (
-    constant code : string)
-    return $type;
-  alias decode_$type is decode[string return $type];
-  procedure decode (
-    constant code   : string;
-    variable index : inout positive;
-    variable result : out $type);
-  alias decode_$type is decode[string, positive, $type];
+  -----------------------------------------------------------------------------
+  -- Codec package extension for the type $type
+  -----------------------------------------------------------------------------
+
+  function encode_$type(data : $type) return code_t;
+  function decode_$type(code : code_t) return $type;
+  alias encode is encode_$type[$type return code_t];
+  alias decode is decode_$type[code_t return $type];
+  procedure encode_$type(
+    constant data  : in    $type;
+    variable index : inout code_index_t;
+    variable code  : inout code_t
+  );
+  procedure decode_$type(
+    constant code   : in    code_t;
+    variable index  : inout code_index_t;
+    variable result : out   $type
+  );
+  alias encode is encode_$type[$type, code_index_t, code_t];
+  alias decode is decode_$type[code_t, code_index_t, $type];
+
+
+  -----------------------------------------------------------------------------
+  -- Queue package extension for the type $type
+  -----------------------------------------------------------------------------
+
   procedure push(queue : queue_t; value : $type);
   impure function pop(queue : queue_t) return $type;
   alias push_$type is push[queue_t, $type];

--- a/vunit/com/codec_generator.py
+++ b/vunit/com/codec_generator.py
@@ -54,6 +54,7 @@ def generate_codecs(
 library vunit_lib;
 use vunit_lib.string_ops.all;
 context vunit_lib.com_context;
+use vunit_lib.common_pkg.all;
 use vunit_lib.queue_pkg.all;
 use vunit_lib.queue_2008p_pkg.all;
 

--- a/vunit/com/codec_vhdl_package.py
+++ b/vunit/com/codec_vhdl_package.py
@@ -109,7 +109,14 @@ class CodecVHDLPackage(VHDLPackage):
         """Generate codecs and to_string functions for all record data types."""
 
         declarations = ""
-        definitions = ""
+        definitions = """
+  -- Helper function to make tests pass GHDL v0.37
+  function get_encoded_length(vec: string) return integer is
+  begin
+    return vec'length;
+  end function;
+
+"""
         for record in self.record_types:
             (
                 new_declarations,
@@ -123,12 +130,8 @@ class CodecVHDLPackage(VHDLPackage):
         """Generate codecs and to_string functions for all array data types."""
 
         declarations = ""
-        definitions = """
-  -- Helper function to make tests pass GHDL v0.37
-  function get_encoded_length ( constant vec: string ) return integer is
-  begin return vec'length; end;
+        definitions = ""
 
-"""
         for array in self.array_types:
             (
                 new_declarations,
@@ -333,7 +336,7 @@ class PackageCodecTemplate(object):
     constant code : string)
     return $type is
   begin
-    return decode(code);
+    return decode_$type(code);
   end;
 
 """
@@ -345,7 +348,7 @@ class PackageCodecTemplate(object):
     constant code : string)
     return $type is
   begin
-    return decode(code);
+    return decode_$type(code);
   end;
 
 """

--- a/vunit/com/codec_vhdl_record_type.py
+++ b/vunit/com/codec_vhdl_record_type.py
@@ -23,29 +23,32 @@ class CodecVHDLRecordType(VHDLRecordType):
         declarations = ""
         definitions = ""
 
+        declarations += template.codec_length_declarations.substitute(type=self.identifier)
         declarations += template.codec_declarations.substitute(type=self.identifier)
         declarations += template.to_string_declarations.substitute(type=self.identifier)
-        element_encoding_list = []
+        element_encoding_list_procedure = []
+        element_encoding_list_function = []
         element_decoding_list = []
         num_of_elements = 0
         for element in self.elements:
             for i in element.identifier_list:
-                element_encoding_list.append(f"encode(data.{i!s})")
+                element_encoding_list_procedure.append(f"encode(data.{i!s}, index, code);")
+                element_encoding_list_function.append(f"encode(data.{i!s})")
                 element_decoding_list.append(f"decode(code, index, result.{i!s});")
-
                 num_of_elements += 1
-        element_encodings = " & ".join(element_encoding_list)
 
+        element_encodings_procedure = "\n    ".join(element_encoding_list_procedure)
+        element_encodings_function = " & ".join(element_encoding_list_function)
         element_decodings = "\n    ".join(element_decoding_list)
         definitions += template.record_codec_definition.substitute(
             type=self.identifier,
-            element_encodings=element_encodings,
-            num_of_elements=str(num_of_elements),
+            element_encodings_procedure=element_encodings_procedure,
+            element_encodings_function=element_encodings_function,
             element_decodings=element_decodings,
         )
         definitions += template.record_to_string_definition.substitute(
             type=self.identifier,
-            element_encoding_list=", ".join(element_encoding_list),
+            element_encoding_list=", ".join(element_encoding_list_function),
             num_of_elements=str(num_of_elements),
         )
 
@@ -55,44 +58,74 @@ class CodecVHDLRecordType(VHDLRecordType):
 class RecordCodecTemplate(DatatypeCodecTemplate):
     """This class contains record templates."""
 
+    codec_length_declarations = Template(
+        """\
+  -- Codec package extension for the type $type
+
+  function code_length_$type(data : $type) return natural;
+  alias code_length is code_length_$type[$type return natural];
+"""
+    )
+
     record_to_string_definition = Template(
         """\
-  function to_string (
-    constant data : $type)
-    return string is
+  -- Printing function for the type $type
+  function to_string(data : $type) return string is
   begin
     return create_group($num_of_elements, $element_encoding_list);
-  end function to_string;
+  end function;
 """
     )
 
     record_codec_definition = Template(
         """\
-  function encode (
-    constant data : $type)
-    return string is
-  begin
-    return $element_encodings;
-  end function encode;
+  -----------------------------------------------------------------------------
+  -- Codec package extension for the type $type
+  -----------------------------------------------------------------------------
 
-  procedure decode (
-    constant code   : string;
-    variable index : inout   positive;
-    variable result : out $type) is
+  procedure encode_$type(
+    constant data  : in    $type;
+    variable index : inout code_index_t;
+    variable code  : inout code_t
+  ) is
+  begin
+    $element_encodings_procedure
+  end procedure;
+
+  procedure decode_$type(
+    constant code   : in    code_t;
+    variable index  : inout code_index_t;
+    variable result : out   $type
+  ) is
   begin
     $element_decodings
-  end procedure decode;
+  end procedure;
 
-  function decode (
-    constant code : string)
-    return $type is
-    variable ret_val : $type;
-    variable index : positive := code'left;
+  function encode_$type(data : $type) return code_t is
   begin
-    decode(code, index, ret_val);
+    return $element_encodings_function;
+  end function;
 
+  function decode_$type(code : code_t) return $type is
+    variable ret_val : $type;
+    variable index   : code_index_t := code'left;
+  begin
+    decode_$type(code, index, ret_val);
     return ret_val;
-  end function decode;
+  end function;
+
+  -- With the current version of the vhdl_parser, it is not possible
+  -- to construct the function using the code_length function of the
+  -- record constituent
+  function code_length_$type(data : $type) return natural is
+  begin
+    return get_encoded_length(encode_$type(data));
+  end function;
+
+
+  -----------------------------------------------------------------------------
+  -- Queue package extension for the type $type
+  -----------------------------------------------------------------------------
 
   procedure push(queue : queue_t; value : $type) is
   begin

--- a/vunit/vhdl/data_types/src/codec-2008p.vhd
+++ b/vunit/vhdl/data_types/src/codec-2008p.vhd
@@ -26,7 +26,7 @@ package codec_2008p_pkg is
   -- This package extends the codec_pkg to support the types
   -- introduced by the VHDL-2008 revision.
   -- The main documentation of the coded functionnality are located
-  -- on the codec_pkg.vhd file.
+  -- in the codec_pkg.vhd file.
 
 
   --===========================================================================
@@ -75,173 +75,133 @@ use work.codec_pkg.all;
 use work.codec_builder_2008p_pkg.all;
 
 package body codec_2008p_pkg is
-  -----------------------------------------------------------------------------
-  -- Predefined composite types
-  -----------------------------------------------------------------------------
-  function encode (
-    constant data : boolean_vector)
-    return string is
-    variable data_bv : bit_vector(data'range);
+
+  --===========================================================================
+  -- Encode functions of new predefined types from VHDL 2008
+  --===========================================================================
+
+  function encode_boolean_vector(data : boolean_vector) return code_t is
+    variable ret_val : code_t(1 to code_length_boolean_vector(data'length));
+    variable index : code_index_t := ret_val'left;
   begin
-    for i in data'range loop
-      if data(i) then
-        data_bv(i) := '1';
-      else
-        data_bv(i) := '0';
-      end if;
-    end loop;
-
-    return encode(data_bv);
-  end;
-
-  function decode (
-    constant code : string)
-    return boolean_vector is
-    constant ret_range : range_t := get_range(code);
-    variable ret_val : boolean_vector(ret_range'range) := (others => false);
-    variable index   : positive := code'left;
-  begin
-    decode(code, index, ret_val);
-
+    encode_boolean_vector(data, index, ret_val);
     return ret_val;
-  end;
+  end function;
 
-  function encode (
-    constant data : integer_vector)
-    return string is
-    variable ret_val : string(1 to 9 + data'length*4);
-    variable index   : positive := 10;
+  function encode_integer_vector(data : integer_vector) return code_t is
+    variable ret_val : code_t(1 to code_length_integer_vector(data'length));
+    variable index : code_index_t := ret_val'left;
   begin
-    ret_val(1 to 9) := encode_array_header(encode(data'left), encode(data'right), encode(data'ascending));
-    for i in data'range loop
-      ret_val(index to index + 3) := encode(data(i));
-      index                       := index + 4;
-    end loop;
-
+    encode_integer_vector(data, index, ret_val);
     return ret_val;
-  end;
+  end function;
 
-  function decode (
-    constant code : string)
-    return integer_vector is
-    constant ret_range : range_t := get_range(code);
-    variable ret_val : integer_vector(ret_range'range) := (others => integer'left);
-    variable index   : positive := code'left;
+  function encode_real_vector(data : real_vector) return code_t is
+    variable ret_val : code_t(1 to code_length_real_vector(data'length));
+    variable index : code_index_t := ret_val'left;
   begin
-    decode(code, index, ret_val);
-
+    encode_real_vector(data, index, ret_val);
     return ret_val;
-  end;
+  end function;
 
-  function encode (
-    constant data : real_vector)
-    return string is
-    variable ret_val : string(1 to 9 + 13*data'length);
-    variable index   : positive := 10;
+  function encode_time_vector(data : time_vector) return code_t is
+    variable ret_val : code_t(1 to code_length_time_vector(data'length));
+    variable index : code_index_t := ret_val'left;
   begin
-    ret_val(1 to 9) := encode_array_header(encode(data'left), encode(data'right), encode(data'ascending));
-    for i in data'range loop
-      ret_val(index to index + 12) := encode(data(i));
-      index                       := index + 13;
-    end loop;
-
+    encode_time_vector(data, index, ret_val);
     return ret_val;
-  end;
+  end function;
 
-  function decode (
-    constant code : string)
-    return real_vector is
-    constant ret_range : range_t := get_range(code);
-    variable ret_val : real_vector(ret_range'range) := (others => real'left);
-    variable index   : positive := code'left;
+  function encode_ufixed(data : unresolved_ufixed) return code_t is
+    variable ret_val : code_t(1 to code_length_ufixed(data'length));
+    variable index : code_index_t := ret_val'left;
   begin
-    decode(code, index, ret_val);
-
+    encode_ufixed(data, index, ret_val);
     return ret_val;
-  end;
+  end function;
 
-  function encode (
-    constant data : time_vector)
-    return string is
-    variable ret_val : string(1 to 9 + 8*data'length);
-    variable index   : positive := 10;
+  function encode_sfixed(data : unresolved_sfixed) return code_t is
+    variable ret_val : code_t(1 to code_length_sfixed(data'length));
+    variable index : code_index_t := ret_val'left;
   begin
-    ret_val(1 to 9) := encode_array_header(encode(data'left), encode(data'right), encode(data'ascending));
-    for i in data'range loop
-      ret_val(index to index + 7) := encode(data(i));
-      index                       := index + 8;
-    end loop;
-
+    encode_sfixed(data, index, ret_val);
     return ret_val;
-  end;
+  end function;
 
-  function decode (
-    constant code : string)
-    return time_vector is
-    constant ret_range : range_t := get_range(code);
-    variable ret_val : time_vector(ret_range'range) := (others => time'left);
-    variable index   : positive := code'left;
+  function encode_float(data : unresolved_float) return code_t is
+    variable ret_val : code_t(1 to code_length_float(data'length));
+    variable index : code_index_t := ret_val'left;
   begin
-    decode(code, index, ret_val);
-
+    encode_float(data, index, ret_val);
     return ret_val;
-  end;
+  end function;
 
-  function encode (
-    constant data : ufixed)
-    return string is
+
+  --===========================================================================
+  -- Decode functions of new predefined types from VHDL 2008
+  --===========================================================================
+
+  function decode_boolean_vector(code : code_t) return boolean_vector is
+    constant ret_range : range_t := decode_range(code);
+    variable ret_val : boolean_vector(ret_range'range);
+    variable index : code_index_t := code'left;
   begin
-    return encode(std_ulogic_array(data));
-  end;
-
-  function decode (
-    constant code : string)
-    return ufixed is
-    constant ret_range : range_t := get_range(code);
-    variable ret_val : ufixed(ret_range'range);
-    variable index   : positive := code'left;
-  begin
-    decode(code, index, ret_val);
-
+    decode_boolean_vector(code, index, ret_val);
     return ret_val;
-  end;
+  end function;
 
-  function encode (
-    constant data : sfixed)
-    return string is
+  function decode_integer_vector(code : code_t) return integer_vector is
+    constant ret_range : range_t := decode_range(code);
+    variable ret_val : integer_vector(ret_range'range);
+    variable index : code_index_t := code'left;
   begin
-    return encode(std_ulogic_array(data));
-  end;
-
-  function decode (
-    constant code : string)
-    return sfixed is
-    constant ret_range : range_t := get_range(code);
-    variable ret_val : sfixed(ret_range'range);
-    variable index   : positive := code'left;
-  begin
-    decode(code, index, ret_val);
-
+    decode_integer_vector(code, index, ret_val);
     return ret_val;
-  end;
+  end function;
 
-  function encode (
-    constant data : float)
-    return string is
+  function decode_real_vector(code : code_t) return real_vector is
+    constant ret_range : range_t := decode_range(code);
+    variable ret_val : real_vector(ret_range'range);
+    variable index : code_index_t := code'left;
   begin
-    return encode(std_ulogic_array(data));
-  end;
-
-  function decode (
-    constant code : string)
-    return float is
-    constant ret_range : range_t := get_range(code);
-    variable ret_val : float(ret_range'range);
-    variable index   : positive := code'left;
-  begin
-    decode(code, index, ret_val);
-
+    decode_real_vector(code, index, ret_val);
     return ret_val;
-  end;
+  end function;
 
-end package body codec_2008p_pkg;
+  function decode_time_vector(code : code_t) return time_vector is
+    constant ret_range : range_t := decode_range(code);
+    variable ret_val : time_vector(ret_range'range);
+    variable index : code_index_t := code'left;
+  begin
+    decode_time_vector(code, index, ret_val);
+    return ret_val;
+  end function;
+
+  function decode_ufixed(code : code_t) return unresolved_ufixed is
+    constant ret_range : range_t := decode_range(code);
+    variable ret_val : unresolved_ufixed(ret_range'range);
+    variable index : code_index_t := code'left;
+  begin
+    decode_ufixed(code, index, ret_val);
+    return ret_val;
+  end function;
+
+  function decode_sfixed(code : code_t) return unresolved_sfixed is
+    constant ret_range : range_t := decode_range(code);
+    variable ret_val : unresolved_sfixed(ret_range'range);
+    variable index : code_index_t := code'left;
+  begin
+    decode_sfixed(code, index, ret_val);
+    return ret_val;
+  end function;
+
+  function decode_float(code : code_t) return unresolved_float is
+    constant ret_range : range_t := decode_range(code);
+    variable ret_val : unresolved_float(ret_range'range);
+    variable index : code_index_t := code'left;
+  begin
+    decode_float(code, index, ret_val);
+    return ret_val;
+  end function;
+
+end package body;

--- a/vunit/vhdl/data_types/src/codec-2008p.vhd
+++ b/vunit/vhdl/data_types/src/codec-2008p.vhd
@@ -6,85 +6,72 @@
 --
 -- Copyright (c) 2014-2022, Lars Asplund lars.anders.asplund@gmail.com
 
+library std;
+use std.textio.all;
+
 library ieee;
 use ieee.std_logic_1164.all;
-use ieee.math_complex.all;
 use ieee.numeric_bit.all;
 use ieee.numeric_std.all;
+use ieee.math_complex.all;
 use ieee.fixed_pkg.all;
 use ieee.float_pkg.all;
 
-use std.textio.all;
+library work;
+use work.codec_builder_pkg.all;
+
 
 package codec_2008p_pkg is
-  -----------------------------------------------------------------------------
-  -- Predefined composite types
-  -----------------------------------------------------------------------------
-  function encode (
-    constant data : boolean_vector)
-    return string;
-  function decode (
-    constant code : string)
-    return boolean_vector;
-  function encode (
-    constant data : integer_vector)
-    return string;
-  function decode (
-    constant code : string)
-    return integer_vector;
-  function encode (
-    constant data : real_vector)
-    return string;
-  function decode (
-    constant code : string)
-    return real_vector;
-  function encode (
-    constant data : time_vector)
-    return string;
-  function decode (
-    constant code : string)
-    return time_vector;
-  function encode (
-    constant data : ufixed)
-    return string;
-  function decode (
-    constant code : string)
-    return ufixed;
-  function encode (
-    constant data : sfixed)
-    return string;
-  function decode (
-    constant code : string)
-    return sfixed;
-  function encode (
-    constant data : float)
-    return string;
-  function decode (
-    constant code : string)
-    return float;
 
-  -----------------------------------------------------------------------------
-  -- Aliases
-  -----------------------------------------------------------------------------
-  alias encode_boolean_vector is encode[boolean_vector return string];
-  alias decode_boolean_vector is decode[string return boolean_vector];
-  alias encode_integer_vector is encode[integer_vector return string];
-  alias decode_integer_vector is decode[string return integer_vector];
-  alias encode_real_vector is encode[real_vector return string];
-  alias decode_real_vector is decode[string return real_vector];
-  alias encode_time_vector is encode[time_vector return string];
-  alias decode_time_vector is decode[string return time_vector];
-  alias encode_ufixed is encode[ufixed return string];
-  alias decode_ufixed is decode[string return ufixed];
-  alias encode_sfixed is encode[sfixed return string];
-  alias decode_sfixed is decode[string return sfixed];
-  alias encode_float is encode[float return string];
-  alias decode_float is decode[string return float];
+  -- This package extends the codec_pkg to support the types
+  -- introduced by the VHDL-2008 revision.
+  -- The main documentation of the coded functionnality are located
+  -- on the codec_pkg.vhd file.
+
+
+  --===========================================================================
+  -- API for the CASUAL USERS
+  --===========================================================================
+
+  function encode_boolean_vector(data : boolean_vector) return code_t;
+  function decode_boolean_vector(code : string) return boolean_vector;
+  alias encode is encode_boolean_vector[boolean_vector return code_t];
+  alias decode is decode_boolean_vector[string return boolean_vector];
+
+  function encode_integer_vector(data : integer_vector) return code_t;
+  function decode_integer_vector(code : string) return integer_vector;
+  alias encode is encode_integer_vector[integer_vector return code_t];
+  alias decode is decode_integer_vector[string return integer_vector];
+
+  function encode_real_vector(data : real_vector) return code_t;
+  function decode_real_vector(code : string) return real_vector;
+  alias encode is encode_real_vector[real_vector return code_t];
+  alias decode is decode_real_vector[string return real_vector];
+
+  function encode_time_vector(data : time_vector) return code_t;
+  function decode_time_vector(code : string) return time_vector;
+  alias encode is encode_time_vector[time_vector return code_t];
+  alias decode is decode_time_vector[string return time_vector];
+
+  function encode_ufixed(data : unresolved_ufixed) return code_t;
+  function decode_ufixed(code : string) return unresolved_ufixed;
+  alias encode is encode_ufixed[unresolved_ufixed return code_t];
+  alias decode is decode_ufixed[string return unresolved_ufixed];
+
+  function encode_sfixed(data : unresolved_sfixed) return code_t;
+  function decode_sfixed(code : string) return unresolved_sfixed;
+  alias encode is encode_sfixed[unresolved_sfixed return code_t];
+  alias decode is decode_sfixed[string return unresolved_sfixed];
+
+  function encode_float(data : unresolved_float) return code_t;
+  function decode_float(code : string) return unresolved_float;
+  alias encode is encode_float[unresolved_float return code_t];
+  alias decode is decode_float[string return unresolved_float];
 
 end package;
 
+
 use work.codec_pkg.all;
-use work.codec_builder_pkg.all;
 use work.codec_builder_2008p_pkg.all;
 
 package body codec_2008p_pkg is

--- a/vunit/vhdl/data_types/src/codec.vhd
+++ b/vunit/vhdl/data_types/src/codec.vhd
@@ -776,4 +776,23 @@ package body codec_pkg is
     return decode_raw_std_ulogic_array(code, code'length * basic_code_length);
   end function;
 
+
+  --===========================================================================
+  -- Deprecated functions - Maintained for backward compatibility.
+  --===========================================================================
+
+  -- Deprecated. Maintained for backward compatibility.
+  function get_range(code : code_t) return range_t is
+    constant range_left   : integer := decode_integer(code(code'left                       to code'left+code_length_integer-1));
+    constant range_right  : integer := decode_integer(code(code'left+code_length_integer   to code'left+code_length_integer*2-1));
+    constant is_ascending : boolean := decode_boolean(code(code'left+code_length_integer*2 to code'left+code_length_integer*2+code_length_boolean-1));
+    constant ret_val_ascending  : range_t(range_left to range_right) := (others => '0');
+    constant ret_val_descending : range_t(range_left downto range_right) := (others => '0');
+  begin
+    assert False report
+      "This function ('get_range') is deprecated. Please use 'decode_range' from codec_pkg.vhd"
+    severity warning;
+    return decode_range(code);
+  end function;
+
 end package body;

--- a/vunit/vhdl/data_types/src/codec.vhd
+++ b/vunit/vhdl/data_types/src/codec.vhd
@@ -6,196 +6,230 @@
 --
 -- Copyright (c) 2014-2022, Lars Asplund lars.anders.asplund@gmail.com
 
-library ieee;
-use ieee.std_logic_1164.all;
-use ieee.math_complex.all;
-use ieee.numeric_bit.all;
-use ieee.numeric_std.all;
-use ieee.math_real.all;
-
+library std;
 use std.textio.all;
 
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.numeric_bit.all;
+use ieee.numeric_std.all;
+use ieee.math_complex.all;
+
+library work;
 use work.codec_builder_pkg.all;
 
+
+
 package codec_pkg is
-  -----------------------------------------------------------------------------
-  -- Predefined scalar types
-  -----------------------------------------------------------------------------
-  function encode (
-    constant data : integer)
-    return string;
-  function decode (
-    constant code : string)
-    return integer;
-  function encode (
-    constant data : real)
-    return string;
-  function decode (
-    constant code : string)
-    return real;
-  function encode (
-    constant data : time)
-    return string;
-  function decode (
-    constant code : string)
-    return time;
-  function encode (
-    constant data : boolean)
-    return string;
-  function decode (
-    constant code : string)
-    return boolean;
-  function encode (
-    constant data : bit)
-    return string;
-  function decode (
-    constant code : string)
-    return bit;
-  function encode (
-    constant data : std_ulogic)
-    return string;
-  function decode (
-    constant code : string)
-    return std_ulogic;
-  function encode (
-    constant data : severity_level)
-    return string;
-  function decode (
-    constant code : string)
-    return severity_level;
-  function encode (
-    constant data : file_open_status)
-    return string;
-  function decode (
-    constant code : string)
-    return file_open_status;
-  function encode (
-    constant data : file_open_kind)
-    return string;
-  function decode (
-    constant code : string)
-    return file_open_kind;
-  function encode (
-    constant data : character)
-    return string;
-  function decode (
-    constant code : string)
-    return character;
+
+  -- This packages enables the user to encode any predefined type into a unique type.
+  -- This unique type is a 'string' (array of 'character').
+  -- The functionality can be used to build a queue capable of storing different
+  -- types in it (see the VUnit 'queue' package)
+
+  -- Remark: this package encodes any predefined type into a string, however, this
+  -- package is not meant for serialization and deserialization of data accross
+  -- versions of VUnit.
+
+
+  --===========================================================================
+  -- API for the CASUAL USERS
+  --===========================================================================
+  -- All data going through the encoding process becomes a string: it
+  -- basically becomes a sequence of bytes without any overhead for type
+  -- information. The 'codec' package doesn’t know if four bytes represents an
+  -- integer, four characters or something else. The interpretation of these
+  -- bytes takes place when the user decodes the data using a type specific
+  -- 'decode' function.
 
   -----------------------------------------------------------------------------
-  -- Predefined composite types
+  -- Encode and decode functions of predefined enumerated types
   -----------------------------------------------------------------------------
-  function encode (
-    constant data : string)
-    return string;
-  function decode (
-    constant code : string)
-    return string;
-  function encode (
-    constant data : bit_vector)
-    return string;
-  function decode (
-    constant code : string)
-    return bit_vector;
-  function encode (
-    constant data : std_ulogic_vector)
-    return string;
-  function decode (
-    constant code : string)
-    return std_ulogic_vector;
-  function encode (
-    constant data : complex)
-    return string;
-  function decode (
-    constant code : string)
-    return complex;
-  function encode (
-    constant data : complex_polar)
-    return string;
-  function decode (
-    constant code : string)
-    return complex_polar;
-  function encode (
-    constant data : ieee.numeric_bit.unsigned)
-    return string;
-  function decode (
-    constant code : string)
-    return ieee.numeric_bit.unsigned;
-  function encode (
-    constant data : ieee.numeric_bit.signed)
-    return string;
-  function decode (
-    constant code : string)
-    return ieee.numeric_bit.signed;
-  function encode (
-    constant data : ieee.numeric_std.unsigned)
-    return string;
-  function decode (
-    constant code : string)
-    return ieee.numeric_std.unsigned;
-  function encode (
-    constant data : ieee.numeric_std.signed)
-    return string;
-  function decode (
-    constant code : string)
-    return ieee.numeric_std.signed;
+
+  function encode_boolean(data : boolean) return code_t;
+  function decode_boolean(code : code_t) return boolean;
+  alias encode is encode_boolean[boolean return code_t];
+  alias decode is decode_boolean[code_t return boolean];
+
+  function encode_character(data : character) return code_t;
+  function decode_character(code : code_t) return character;
+  alias encode is encode_character[character return code_t];
+  alias decode is decode_character[code_t return character];
+
+  function encode_bit(data : bit) return code_t;
+  function decode_bit(code : code_t) return bit;
+  alias encode is encode_bit[bit return code_t];
+  alias decode is decode_bit[code_t return bit];
+
+  function encode_std_ulogic(data : std_ulogic) return code_t;
+  function decode_std_ulogic(code : code_t) return std_ulogic;
+  alias encode is encode_std_ulogic[std_ulogic return code_t];
+  alias decode is decode_std_ulogic[code_t return std_ulogic];
+
+  function encode_severity_level(data : severity_level) return code_t;
+  function decode_severity_level(code : code_t) return severity_level;
+  alias encode is encode_severity_level[severity_level return code_t];
+  alias decode is decode_severity_level[code_t return severity_level];
+
+  function encode_file_open_kind(data : file_open_kind) return code_t;
+  function decode_file_open_kind(code : code_t) return file_open_kind;
+  alias encode is encode_file_open_kind[file_open_kind return code_t];
+  alias decode is decode_file_open_kind[code_t return file_open_kind];
+
+  function encode_file_open_status(data : file_open_status) return code_t;
+  function decode_file_open_status(code : code_t) return file_open_status;
+  alias encode is encode_file_open_status[file_open_status return code_t];
+  alias decode is decode_file_open_status[code_t return file_open_status];
+
 
   -----------------------------------------------------------------------------
-  -- Aliases
+  -- Encode and decode functions of predefined scalar types
   -----------------------------------------------------------------------------
-  alias encode_integer is encode[integer return string];
-  alias decode_integer is decode[string return integer];
-  alias encode_real is encode[real return string];
-  alias decode_real is decode[string return real];
-  alias encode_time is encode[time return string];
-  alias decode_time is decode[string return time];
-  alias encode_boolean is encode[boolean return string];
-  alias decode_boolean is decode[string return boolean];
-  alias encode_bit is encode[bit return string];
-  alias decode_bit is decode[string return bit];
-  alias encode_std_ulogic is encode[std_ulogic return string];
-  alias decode_std_ulogic is decode[string return std_ulogic];
-  alias encode_severity_level is encode[severity_level return string];
-  alias decode_severity_level is decode[string return severity_level];
-  alias encode_file_open_status is encode[file_open_status return string];
-  alias decode_file_open_status is decode[string return file_open_status];
-  alias encode_file_open_kind is encode[file_open_kind return string];
-  alias decode_file_open_kind is decode[string return file_open_kind];
-  alias encode_character is encode[character return string];
-  alias decode_character is decode[string return character];
 
-  alias encode_string is encode[string return string];
-  alias decode_string is decode[string return string];
-  alias encode_bit_vector is encode[bit_vector return string];
-  alias decode_bit_vector is decode[string return bit_vector];
-  alias encode_std_ulogic_vector is encode[std_ulogic_vector return string];
-  alias decode_std_ulogic_vector is decode[string return std_ulogic_vector];
-  alias encode_complex is encode[complex return string];
-  alias decode_complex is decode[string return complex];
-  alias encode_complex_polar is encode[complex_polar return string];
-  alias decode_complex_polar is decode[string return complex_polar];
-  alias encode_numeric_bit_unsigned is encode[ieee.numeric_bit.unsigned return string];
-  alias decode_numeric_bit_unsigned is decode[string return ieee.numeric_bit.unsigned];
-  alias encode_numeric_bit_signed is encode[ieee.numeric_bit.signed return string];
-  alias decode_numeric_bit_signed is decode[string return ieee.numeric_bit.signed];
-  alias encode_numeric_std_unsigned is encode[ieee.numeric_std.unsigned return string];
-  alias decode_numeric_std_unsigned is decode[string return ieee.numeric_std.unsigned];
-  alias encode_numeric_std_signed is encode[ieee.numeric_std.signed return string];
-  alias decode_numeric_std_signed is decode[string return ieee.numeric_std.signed];
+  function encode_integer(data : integer) return code_t;
+  function decode_integer(code : code_t) return integer;
+  alias encode is encode_integer[integer return code_t];
+  alias decode is decode_integer[code_t return integer];
+
+  function encode_real(data : real) return code_t;
+  function decode_real(code : code_t) return real;
+  alias encode is encode_real[real return code_t];
+  alias decode is decode_real[code_t return real];
+
+  function encode_time(data : time) return code_t;
+  function decode_time(code : code_t) return time;
+  alias encode is encode_time[time return code_t];
+  alias decode is decode_time[code_t return time];
+
 
   -----------------------------------------------------------------------------
-  -- Support
+  -- Encode and decode functions of predefined composite types (records)
   -----------------------------------------------------------------------------
-  type range_t is array (integer range <>) of bit;
 
-  function get_range (
-    constant code : string)
-    return range_t;
-  function encode (
-    constant data : std_ulogic_array)
-    return string;
+  function encode_complex(data : complex) return code_t;
+  function decode_complex(code : code_t) return complex;
+  alias encode is encode_complex[complex return code_t];
+  alias decode is decode_complex[code_t return complex];
+
+  function encode_complex_polar(data : complex_polar) return code_t;
+  function decode_complex_polar(code : code_t) return complex_polar;
+  alias encode is encode_complex_polar[complex_polar return code_t];
+  alias decode is decode_complex_polar[code_t return complex_polar];
+
+
+  -----------------------------------------------------------------------------
+  -- Encode and decode functions and procedures for range
+  -----------------------------------------------------------------------------
+
+  function encode_range(range_left : integer; range_right : integer; is_ascending : boolean) return code_t;
+  function decode_range(code : code_t) return range_t;
+  function decode_range(code : code_t; index : code_index_t) return range_t;
+  alias encode is encode_range[integer, integer, boolean return code_t];
+  alias decode is decode_range[code_t return range_t];
+  alias decode is decode_range[code_t, code_index_t return range_t];
+
+
+  -----------------------------------------------------------------------------
+  -- Encode and decode functions of predefined composite types (arrays)
+  -----------------------------------------------------------------------------
+
+  function encode_string(data : string) return code_t;
+  function decode_string(code : code_t) return string;
+  alias encode is encode_string[string return code_t];
+  alias decode is decode_string[code_t return string];
+
+  -- The ieee.std_ulogic_vector is defined with a natural range.
+  -- If you need to encode an array of ieee.std_ulogic (or an array of any subtype
+  -- of ieee.std_ulogic) with an integer range, you can use the type 'std_ulogic_array'
+  -- type bit_array is array(integer range <>) of bit;
+  function encode_bit_array(data : bit_array) return code_t;
+  function decode_bit_array(code : code_t) return bit_array;
+  alias encode is encode_bit_array[bit_array return code_t];
+  alias decode is decode_bit_array[code_t return bit_array];
+
+  function encode_bit_vector(data : bit_vector) return code_t;
+  function decode_bit_vector(code : code_t) return bit_vector;
+  alias encode is encode_bit_vector[bit_vector return code_t];
+  alias decode is decode_bit_vector[code_t return bit_vector];
+
+  function encode_numeric_bit_unsigned(data : ieee.numeric_bit.unsigned) return code_t;
+  function decode_numeric_bit_unsigned(code : code_t) return ieee.numeric_bit.unsigned;
+  alias encode is encode_numeric_bit_unsigned[ieee.numeric_bit.unsigned return code_t];
+  alias decode is decode_numeric_bit_unsigned[code_t return ieee.numeric_bit.unsigned];
+
+  function encode_numeric_bit_signed(data : ieee.numeric_bit.signed) return code_t;
+  function decode_numeric_bit_signed(code : code_t) return ieee.numeric_bit.signed;
+  alias encode is encode_numeric_bit_signed[ieee.numeric_bit.signed return code_t];
+  alias decode is decode_numeric_bit_signed[code_t return ieee.numeric_bit.signed];
+
+  -- The std.bit_vector is defined with a natural range.
+  -- If you need to encode an array of std.bit (or an array of any subtype
+  -- of std.bit) with an integer range, you can use the type 'bit_array'
+  -- type std_ulogic_array is array(integer range <>) of std_ulogic;
+  function encode_std_ulogic_array(data : std_ulogic_array) return code_t;
+  function decode_std_ulogic_array(code : code_t) return std_ulogic_array;
+  alias encode is encode_std_ulogic_array[std_ulogic_array return code_t];
+  alias decode is decode_std_ulogic_array[code_t return std_ulogic_array];
+
+  function encode_std_ulogic_vector(data : std_ulogic_vector) return code_t;
+  function decode_std_ulogic_vector(code : code_t) return std_ulogic_vector;
+  alias encode is encode_std_ulogic_vector[std_ulogic_vector return code_t];
+  alias decode is decode_std_ulogic_vector[code_t return std_ulogic_vector];
+
+  function encode_numeric_std_unsigned(data : ieee.numeric_std.unresolved_unsigned) return code_t;
+  function decode_numeric_std_unsigned(code : code_t) return ieee.numeric_std.unresolved_unsigned;
+  alias encode is encode_numeric_std_unsigned[ieee.numeric_std.unresolved_unsigned return code_t];
+  alias decode is decode_numeric_std_unsigned[code_t return ieee.numeric_std.unresolved_unsigned];
+
+  function encode_numeric_std_signed(data : ieee.numeric_std.unresolved_signed) return code_t;
+  function decode_numeric_std_signed(code : code_t) return ieee.numeric_std.unresolved_signed;
+  alias encode is encode_numeric_std_signed[ieee.numeric_std.unresolved_signed return code_t];
+  alias decode is decode_numeric_std_signed[code_t return ieee.numeric_std.unresolved_signed];
+
+
+  --===========================================================================
+  -- API for the ADVANCED USERS
+  --===========================================================================
+
+  -----------------------------------------------------------------------------
+  -- Encoding of 'raw' string, 'raw' bit_array and 'raw' std_ulogic_array
+  -----------------------------------------------------------------------------
+  -- We define functions which encode a 'string', 'bit_array' or a 'std_ulogic_array' without its range.
+  -- It can be useful when you encode a value which has always same width. For example,
+  -- integers are encoded using 'encode_raw_bit_array' because thay are always
+  -- 32 bits (or 64 bits in VHDL-2019).
+
+  -- Note that the 'encode' functions do not have aliases functions 'encode' as they
+  -- are homograph with the 'encode_string', 'encode_bit_array' or
+  -- 'encode_std_ulogic_array'. Same thing for decode functions.
+
+  -- To encode/decode string with its range, use encode_string and decode_string.
+  function encode_raw_string(data : string) return code_t;
+  function decode_raw_string(code : code_t) return string;
+  function decode_raw_string(code : code_t; length : positive) return string;
+
+  -- To encode/decode bit_array with its range, use encode_bit_array and decode_bit_array.
+  function encode_raw_bit_array(data : bit_array) return code_t;
+  function decode_raw_bit_array(code : code_t) return bit_array;
+  function decode_raw_bit_array(code : code_t; length : positive) return bit_array;
+
+  -- To encode/decode std_ulogic_array with its range, use encode_std_ulogic_array and decode_std_ulogic_array.
+  function encode_raw_std_ulogic_array(data : std_ulogic_array) return code_t;
+  function decode_raw_std_ulogic_array(code : code_t) return std_ulogic_array;
+  function decode_raw_std_ulogic_array(code : code_t; length : positive) return std_ulogic_array;
+
+
+  --===========================================================================
+  -- Deprecated functions. Maintained for backward compatibility
+  --===========================================================================
+
+  -- This function is deprecated.
+  -- Use the 'decode_range' function instead.
+  function get_range(code : code_t) return range_t;
 
 end package;
+
+
 
 package body codec_pkg is
   -----------------------------------------------------------------------------

--- a/vunit/vhdl/data_types/src/codec.vhd
+++ b/vunit/vhdl/data_types/src/codec.vhd
@@ -19,7 +19,6 @@ library work;
 use work.codec_builder_pkg.all;
 
 
-
 package codec_pkg is
 
   -- This packages enables the user to encode any predefined type into a unique type.

--- a/vunit/vhdl/data_types/src/codec.vhd
+++ b/vunit/vhdl/data_types/src/codec.vhd
@@ -475,4 +475,305 @@ package body codec_pkg is
     return ret_val;
   end function;
 
+
+  --===========================================================================
+  -- Encode and decode functions and procedures for range
+  --===========================================================================
+
+  function encode_range(range_left : integer; range_right : integer; is_ascending : boolean) return code_t is
+    variable ret_val : code_t(1 to code_length_integer_range);
+    variable index   : code_index_t := ret_val'left;
+  begin
+    encode_range(range_left, range_right, is_ascending, index, ret_val);
+    return ret_val;
+  end function;
+
+  function decode_range(code : code_t; index : code_index_t) return range_t is
+    variable code_alias : code_t(1 to code'length-index+1) := code(index to code'length);
+    constant range_left : integer := decode_integer(
+      code_alias(1 to code_length_integer)
+    );
+    constant range_right : integer := decode_integer(
+      code_alias(1 + code_length_integer to code_length_integer*2)
+    );
+    constant is_ascending : boolean := decode_boolean(
+      code_alias(1 + code_length_integer*2 to code_length_integer*2 + code_length_boolean)
+    );
+    constant ret_val_ascending  : range_t(range_left to range_right) := (others => '0');
+    constant ret_val_descending : range_t(range_left downto range_right) := (others => '0');
+  begin
+    if is_ascending then
+      return ret_val_ascending;
+    else
+      return ret_val_descending;
+    end if;
+  end function;
+
+  function decode_range(code : code_t) return range_t is
+  begin
+    return decode_range(code, code'left);
+  end function;
+
+
+  --===========================================================================
+  -- Encode and decode procedures of predefined composite types (arrays)
+  --===========================================================================
+
+  -----------------------------------------------------------------------------
+  -- string
+  -----------------------------------------------------------------------------
+  function encode_string(data : string) return code_t is
+    variable ret_val : code_t(1 to code_length_string(data'length));
+    variable index   : code_index_t := ret_val'left;
+  begin
+    encode_string(data, index, ret_val);
+    return ret_val;
+  end function;
+
+  function decode_string(code : code_t) return string is
+    constant ret_range : range_t := decode_range(code);
+    variable ret_val : string(ret_range'range) := (others => NUL);
+    variable index   : code_index_t := code'left;
+  begin
+    decode_string(code, index, ret_val);
+    return ret_val;
+  end function;
+
+  -----------------------------------------------------------------------------
+  -- bit_array
+  -----------------------------------------------------------------------------
+  function encode_bit_array(data : bit_array) return code_t is
+    variable ret_val : code_t(1 to code_length_bit_array(data'length));
+    variable index   : code_index_t := ret_val'left;
+  begin
+    encode_bit_array(data, index, ret_val);
+    return ret_val;
+  end function;
+
+  function decode_bit_array(code : code_t) return bit_array is
+    constant ret_range : range_t := decode_range(code);
+    variable ret_val : bit_array(ret_range'range);
+    variable index   : code_index_t := code'left;
+  begin
+    decode_bit_array(code, index, ret_val);
+    return ret_val;
+  end function;
+
+  -----------------------------------------------------------------------------
+  -- bit_vector
+  -----------------------------------------------------------------------------
+  function encode_bit_vector(data : bit_vector) return code_t is
+    variable ret_val : code_t(1 to code_length_bit_vector(data'length));
+    variable index   : code_index_t := ret_val'left;
+  begin
+    encode_bit_vector(data, index, ret_val);
+    return ret_val;
+  end function;
+
+  function decode_bit_vector(code : code_t) return bit_vector is
+    constant ret_range : range_t := decode_range(code);
+    variable ret_val : bit_vector(ret_range'range);
+    variable index   : code_index_t := code'left;
+  begin
+    decode_bit_vector(code, index, ret_val);
+    return ret_val;
+  end function;
+
+  -----------------------------------------------------------------------------
+  -- ieee.numeric_bit.unsigned
+  -----------------------------------------------------------------------------
+  function encode_numeric_bit_unsigned(data : ieee.numeric_bit.unsigned) return code_t is
+    variable ret_val : code_t(1 to code_length_numeric_bit_unsigned(data'length));
+    variable index   : code_index_t := ret_val'left;
+  begin
+    encode_numeric_bit_unsigned(data, index, ret_val);
+    return ret_val;
+  end function;
+
+  function decode_numeric_bit_unsigned(code : code_t) return ieee.numeric_bit.unsigned is
+    constant ret_range : range_t := decode_range(code);
+    variable ret_val : ieee.numeric_bit.unsigned(ret_range'range);
+    variable index   : code_index_t := code'left;
+  begin
+    decode_numeric_bit_unsigned(code, index, ret_val);
+    return ret_val;
+  end function;
+
+  -----------------------------------------------------------------------------
+  -- ieee.numeric_bit.signed
+  -----------------------------------------------------------------------------
+  function encode_numeric_bit_signed(data : ieee.numeric_bit.signed) return code_t is
+    variable ret_val : code_t(1 to code_length_numeric_bit_signed(data'length));
+    variable index   : code_index_t := ret_val'left;
+  begin
+    encode_numeric_bit_signed(data, index, ret_val);
+    return ret_val;
+  end function;
+
+  function decode_numeric_bit_signed(code : code_t) return ieee.numeric_bit.signed is
+    constant ret_range : range_t := decode_range(code);
+    variable ret_val : ieee.numeric_bit.signed(ret_range'range);
+    variable index   : code_index_t := code'left;
+  begin
+    decode_numeric_bit_signed(code, index, ret_val);
+    return ret_val;
+  end function;
+
+  -----------------------------------------------------------------------------
+  -- std_ulogic_array
+  -----------------------------------------------------------------------------
+  function encode_std_ulogic_array(data : std_ulogic_array) return code_t is
+    variable ret_val : code_t(1 to code_length_std_ulogic_array(data'length));
+    variable index   : code_index_t := ret_val'left;
+  begin
+    encode_std_ulogic_array(data, index, ret_val);
+    return ret_val;
+  end function;
+
+  function decode_std_ulogic_array(code : code_t) return std_ulogic_array is
+    constant ret_range : range_t := decode_range(code);
+    variable ret_val : std_ulogic_array(ret_range'range);
+    variable index   : code_index_t := code'left;
+  begin
+    decode_std_ulogic_array(code, index, ret_val);
+    return ret_val;
+  end function;
+
+  -----------------------------------------------------------------------------
+  -- std_ulogic_vector
+  -----------------------------------------------------------------------------
+  function encode_std_ulogic_vector(data : std_ulogic_vector) return code_t is
+    variable ret_val : code_t(1 to code_length_std_ulogic_vector(data'length));
+    variable index   : code_index_t := ret_val'left;
+  begin
+    encode_std_ulogic_vector(data, index, ret_val);
+    return ret_val;
+  end function;
+
+  function decode_std_ulogic_vector(code : code_t) return std_ulogic_vector is
+    constant ret_range : range_t := decode_range(code);
+    variable ret_val : std_ulogic_vector(ret_range'range);
+    variable index   : code_index_t := code'left;
+  begin
+    decode_std_ulogic_vector(code, index, ret_val);
+    return ret_val;
+  end function;
+
+  -----------------------------------------------------------------------------
+  -- ieee.numeric_std.unresolved_unsigned
+  -----------------------------------------------------------------------------
+  function encode_numeric_std_unsigned(data : ieee.numeric_std.unresolved_unsigned) return code_t is
+    variable ret_val : code_t(1 to code_length_numeric_std_unsigned(data'length));
+    variable index   : code_index_t := ret_val'left;
+  begin
+    encode_numeric_std_unsigned(data, index, ret_val);
+    return ret_val;
+  end function;
+
+  function decode_numeric_std_unsigned(code : code_t) return ieee.numeric_std.unresolved_unsigned is
+    constant ret_range : range_t := decode_range(code);
+    variable ret_val : ieee.numeric_std.unresolved_unsigned(ret_range'range);
+    variable index   : code_index_t := code'left;
+  begin
+    decode_numeric_std_unsigned(code, index, ret_val);
+    return ret_val;
+  end function;
+
+  -----------------------------------------------------------------------------
+  -- ieee.numeric_std.unresolved_signed
+  -----------------------------------------------------------------------------
+  function encode_numeric_std_signed(data : ieee.numeric_std.unresolved_signed) return code_t is
+    variable ret_val : code_t(1 to code_length_numeric_std_signed(data'length));
+    variable index   : code_index_t := ret_val'left;
+  begin
+    encode_numeric_std_signed(data, index, ret_val);
+    return ret_val;
+  end function;
+
+  function decode_numeric_std_signed(code : code_t) return ieee.numeric_std.unresolved_signed is
+    constant ret_range : range_t := decode_range(code);
+    variable ret_val : ieee.numeric_std.unresolved_signed(ret_range'range);
+    variable index   : code_index_t := code'left;
+  begin
+    decode_numeric_std_signed(code, index, ret_val);
+    return ret_val;
+  end function;
+
+
+  --===========================================================================
+  -- Encode and Decode functions of for a 'raw' string, 'raw' bit_array and 'raw' std_ulogic_array
+  --===========================================================================
+
+  -----------------------------------------------------------------------------
+  -- raw_string
+  -----------------------------------------------------------------------------
+  function encode_raw_string(data : string) return code_t is
+    variable ret_val : code_t(1 to code_length_raw_string(data'length));
+    variable index : code_index_t := ret_val'left;
+  begin
+    encode_raw_string(data, index, ret_val);
+    return ret_val;
+  end function;
+
+  function decode_raw_string(code : code_t; length : positive) return string is
+    variable ret_val : string(length-1 downto 0);
+    variable index : code_index_t := code'left;
+  begin
+    decode_raw_string(code, index, ret_val);
+    return ret_val;
+  end function;
+
+  function decode_raw_string(code : code_t) return string is
+  begin
+    return decode_raw_string(code, code'length * basic_code_length);
+  end function;
+
+  -----------------------------------------------------------------------------
+  -- raw_bit_array
+  -----------------------------------------------------------------------------
+  function encode_raw_bit_array(data : bit_array) return code_t is
+    variable ret_val : code_t(1 to code_length_raw_bit_array(data'length));
+    variable index : code_index_t := ret_val'left;
+  begin
+    encode_raw_bit_array(data, index, ret_val);
+    return ret_val;
+  end function;
+
+  function decode_raw_bit_array(code : code_t; length : positive) return bit_array is
+    variable ret_val : bit_array(length-1 downto 0);
+    variable index : code_index_t := code'left;
+  begin
+    decode_raw_bit_array(code, index, ret_val);
+    return ret_val;
+  end function;
+
+  function decode_raw_bit_array(code : code_t) return bit_array is
+  begin
+    return decode_raw_bit_array(code, code'length * basic_code_length);
+  end function;
+
+  -----------------------------------------------------------------------------
+  -- raw_std_ulogic_array
+  -----------------------------------------------------------------------------
+  function encode_raw_std_ulogic_array(data : std_ulogic_array) return code_t is
+    variable ret_val : code_t(1 to code_length_raw_std_ulogic_array(data'length));
+    variable index : code_index_t := ret_val'left;
+  begin
+    encode_raw_std_ulogic_array(data, index, ret_val);
+    return ret_val;
+  end function;
+
+  function decode_raw_std_ulogic_array(code : code_t; length : positive) return std_ulogic_array is
+    variable ret_val : std_ulogic_array(length-1 downto 0);
+    variable index : code_index_t := code'left;
+  begin
+    decode_raw_std_ulogic_array(code, index, ret_val);
+    return ret_val;
+  end function;
+
+  function decode_raw_std_ulogic_array(code : code_t) return std_ulogic_array is
+  begin
+    return decode_raw_std_ulogic_array(code, code'length * basic_code_length);
+  end function;
+
 end package body;

--- a/vunit/vhdl/data_types/src/codec_builder-2008p.vhd
+++ b/vunit/vhdl/data_types/src/codec_builder-2008p.vhd
@@ -1,4 +1,4 @@
--- This package contains support functions for standard codec building
+-- This file provides functionality to encode/decode standard types to/from string.
 --
 -- This Source Code Form is subject to the terms of the Mozilla Public
 -- License, v. 2.0. If a copy of the MPL was not distributed with this file,
@@ -6,48 +6,93 @@
 --
 -- Copyright (c) 2014-2022, Lars Asplund lars.anders.asplund@gmail.com
 
+library std;
+use std.textio.all;
+
 library ieee;
 use ieee.std_logic_1164.all;
-use ieee.math_complex.all;
 use ieee.numeric_bit.all;
 use ieee.numeric_std.all;
+use ieee.math_complex.all;
 use ieee.fixed_pkg.all;
 use ieee.float_pkg.all;
 
-use std.textio.all;
-
+library work;
 use work.codec_builder_pkg.all;
 
+
 package codec_builder_2008p_pkg is
-  procedure decode (
-    constant code   :       string;
-    variable index  : inout positive;
-    variable result : out   boolean_vector);
-  procedure decode (
-    constant code   :       string;
-    variable index  : inout positive;
-    variable result : out   integer_vector);
-  procedure decode (
-    constant code   :       string;
-    variable index  : inout positive;
-    variable result : out   real_vector);
-  procedure decode (
-    constant code   :       string;
-    variable index  : inout positive;
-    variable result : out   time_vector);
-  procedure decode (
-    constant code   :       string;
-    variable index  : inout positive;
-    variable result : out   ufixed);
-  procedure decode (
-    constant code   :       string;
-    variable index  : inout positive;
-    variable result : out   sfixed);
-  procedure decode (
-    constant code   :       string;
-    variable index  : inout positive;
-    variable result : out   float);
-end package codec_builder_2008p_pkg;
+
+  --===========================================================================
+  -- API for the ADVANCED USERS
+  --===========================================================================
+
+  -----------------------------------------------------------------------------
+  -- Encoding length for each types
+  -----------------------------------------------------------------------------
+  -- If you need to retrieve the length of the encoded data without
+  -- encoding it, you can use these functions:
+
+  -- These functions give you the length of the encoded array depending on the
+  -- length of the array to encode
+  function code_length_boolean_vector(length : natural) return natural;
+  function code_length_integer_vector(length : natural) return natural;
+  function code_length_real_vector(length : natural) return natural;
+  function code_length_time_vector(length : natural) return natural;
+  function code_length_ufixed(length : natural) return natural;
+  function code_length_sfixed(length : natural) return natural;
+  function code_length_float(length : natural) return natural;
+
+  function code_length_boolean_vector(data : boolean_vector) return natural;
+  function code_length_integer_vector(data : integer_vector) return natural;
+  function code_length_real_vector(data : real_vector) return natural;
+  function code_length_time_vector(data : time_vector) return natural;
+  function code_length_ufixed(data : ufixed) return natural;
+  function code_length_sfixed(data : sfixed) return natural;
+  function code_length_float(data : float) return natural;
+
+
+
+  --===========================================================================
+  -- API for the VUnit DEVELOPERS
+  --===========================================================================
+
+  procedure encode_boolean_vector(constant data : in boolean_vector; variable index : inout code_index_t; variable code : out code_t);
+  procedure decode_boolean_vector(constant code : in code_t; variable index : inout code_index_t; variable result : out boolean_vector);
+  alias encode is encode_boolean_vector[boolean_vector, code_index_t, code_t];
+  alias decode is decode_boolean_vector[code_t, code_index_t, boolean_vector];
+
+  procedure encode_integer_vector(constant data : in integer_vector; variable index : inout code_index_t; variable code : out code_t);
+  procedure decode_integer_vector(constant code : in code_t; variable index : inout code_index_t; variable result : out integer_vector);
+  alias encode is encode_integer_vector[integer_vector, code_index_t, code_t];
+  alias decode is decode_integer_vector[code_t, code_index_t, integer_vector];
+
+  procedure encode_real_vector(constant data : in real_vector; variable index : inout code_index_t; variable code : out code_t);
+  procedure decode_real_vector(constant code : in code_t; variable index : inout code_index_t; variable result : out real_vector);
+  alias encode is encode_real_vector[real_vector, code_index_t, code_t];
+  alias decode is decode_real_vector[code_t, code_index_t, real_vector];
+
+  procedure encode_time_vector(constant data : in time_vector; variable index : inout code_index_t; variable code : out code_t);
+  procedure decode_time_vector(constant code : in code_t; variable index : inout code_index_t; variable result : out time_vector);
+  alias encode is encode_time_vector[time_vector, code_index_t, code_t];
+  alias decode is decode_time_vector[code_t, code_index_t, time_vector];
+
+  procedure encode_ufixed(constant data : in unresolved_ufixed; variable index : inout code_index_t; variable code : out code_t);
+  procedure decode_ufixed(constant code : in code_t; variable index : inout code_index_t; variable result : out unresolved_ufixed);
+  alias encode is encode_ufixed[unresolved_ufixed, code_index_t, code_t];
+  alias decode is decode_ufixed[code_t, code_index_t, unresolved_ufixed];
+
+  procedure encode_sfixed(constant data : in unresolved_sfixed; variable index : inout code_index_t; variable code : out code_t);
+  procedure decode_sfixed(constant code : in code_t; variable index : inout code_index_t; variable result : out unresolved_sfixed);
+  alias encode is encode_sfixed[unresolved_sfixed, code_index_t, code_t];
+  alias decode is decode_sfixed[code_t, code_index_t, unresolved_sfixed];
+
+  procedure encode_float(constant data : in unresolved_float; variable index : inout code_index_t; variable code : out code_t);
+  procedure decode_float(constant code : in code_t; variable index : inout code_index_t; variable result : out unresolved_float);
+  alias encode is encode_float[unresolved_float, code_index_t, code_t];
+  alias decode is decode_float[code_t, code_index_t, unresolved_float];
+
+end package;
 
 package body codec_builder_2008p_pkg is
   procedure decode (

--- a/vunit/vhdl/data_types/src/codec_builder-2008p.vhd
+++ b/vunit/vhdl/data_types/src/codec_builder-2008p.vhd
@@ -94,80 +94,235 @@ package codec_builder_2008p_pkg is
 
 end package;
 
+
+
 package body codec_builder_2008p_pkg is
-  procedure decode (
-    constant code   :       string;
-    variable index  : inout positive;
-    variable result : out   boolean_vector) is
-    variable result_bv : bit_vector(result'range);
+
+  --===========================================================================
+  -- Encode and Decode procedures of new predefined types from VHDL 2008
+  --===========================================================================
+
+  -----------------------------------------------------------------------------
+  -- boolean_vector
+  -----------------------------------------------------------------------------
+  procedure encode_boolean_vector(constant data : in boolean_vector; variable index : inout code_index_t; variable code : out code_t) is
+    variable ret_val : bit_array(data'range);
   begin
-    decode(code, index, result_bv);
-    for i in result'range loop
-      result(i) := result_bv(i) = '1';
+    for i in data'range loop
+      if data(i) then
+        ret_val(i) := '1';
+      else
+        ret_val(i) := '0';
+      end if;
     end loop;
-  end;
+    encode_bit_array(ret_val, index, code);
+  end procedure;
 
-  procedure decode (
-    constant code   :       string;
-    variable index  : inout positive;
-    variable result : out   integer_vector) is
+  procedure decode_boolean_vector(constant code : in code_t; variable index : inout code_index_t; variable result : out boolean_vector) is
+    variable ret_val : bit_array(result'range);
   begin
-    index := index + 9;
-    for i in result'range loop
-      decode(code, index, result(i));
+    decode_bit_array(code, index, ret_val);
+    for i in ret_val'range loop
+      result(i) := ret_val(i) = '1';
     end loop;
-  end;
+  end procedure;
 
-  procedure decode (
-    constant code   :       string;
-    variable index  : inout positive;
-    variable result : out   real_vector) is
+  -----------------------------------------------------------------------------
+  -- integer_vector
+  -----------------------------------------------------------------------------
+  procedure encode_integer_vector(constant data : in integer_vector; variable index : inout code_index_t; variable code : out code_t) is
   begin
-    index := index + 9;
-    for i in result'range loop
-      decode(code, index, result(i));
+    encode_range(data'left, data'right, data'ascending, index, code);
+    for i in data'range loop
+      encode_integer(data(i), index, code);
     end loop;
-  end;
+  end procedure;
 
-  procedure decode (
-    constant code   :       string;
-    variable index  : inout positive;
-    variable result : out   time_vector) is
+  procedure decode_integer_vector(constant code : in code_t; variable index : inout code_index_t; variable result : out integer_vector) is
   begin
-    index := index + 9;
+    index := index + code_length_integer_range;
     for i in result'range loop
-      decode(code, index, result(i));
+      decode_integer(code, index, result(i));
     end loop;
-  end;
+  end procedure;
 
-  procedure decode (
-    constant code   :       string;
-    variable index  : inout positive;
-    variable result : out   ufixed) is
-    variable result_sula : std_ulogic_array(result'range);
+  -----------------------------------------------------------------------------
+  -- real_vector
+  -----------------------------------------------------------------------------
+  procedure encode_real_vector(constant data : in real_vector; variable index : inout code_index_t; variable code : out code_t) is
   begin
-    decode(code, index, result_sula);
-    result := ufixed(result_sula);
-  end;
+    encode_range(data'left, data'right, data'ascending, index, code);
+    for i in data'range loop
+      encode_real(data(i), index, code);
+    end loop;
+  end procedure;
 
-  procedure decode (
-    constant code   :       string;
-    variable index  : inout positive;
-    variable result : out   sfixed) is
-    variable result_sula : std_ulogic_array(result'range);
+  procedure decode_real_vector(constant code : in code_t; variable index : inout code_index_t; variable result : out real_vector) is
   begin
-    decode(code, index, result_sula);
-    result := sfixed(result_sula);
-  end;
+    index := index + code_length_integer_range;
+    for i in result'range loop
+      decode_real(code, index, result(i));
+    end loop;
+  end procedure;
 
-  procedure decode (
-    constant code   :       string;
-    variable index  : inout positive;
-    variable result : out   float) is
-    variable result_sula : std_ulogic_array(result'range);
+  -----------------------------------------------------------------------------
+  -- time_vector
+  -----------------------------------------------------------------------------
+  procedure encode_time_vector(constant data : in time_vector; variable index : inout code_index_t; variable code : out code_t) is
   begin
-    decode(code, index, result_sula);
-    result := float(result_sula);
-  end;
+    encode_range(data'left, data'right, data'ascending, index, code);
+    for i in data'range loop
+      encode_time(data(i), index, code);
+    end loop;
+  end procedure;
 
-end package body codec_builder_2008p_pkg;
+  procedure decode_time_vector(constant code : in code_t; variable index : inout code_index_t; variable result : out time_vector) is
+  begin
+    index := index + code_length_integer_range;
+    for i in result'range loop
+      decode_time(code, index, result(i));
+    end loop;
+  end procedure;
+
+  -----------------------------------------------------------------------------
+  -- unresolved_ufixed
+  -----------------------------------------------------------------------------
+  procedure encode_ufixed(constant data : in unresolved_ufixed; variable index : inout code_index_t; variable code : out code_t) is
+  begin
+    encode_std_ulogic_array(std_ulogic_array(data), index, code);
+  end procedure;
+
+  procedure decode_ufixed(constant code : in code_t; variable index : inout code_index_t; variable result : out unresolved_ufixed) is
+    variable ret_val : std_ulogic_array(result'range);
+  begin
+    decode_std_ulogic_array(code, index, ret_val);
+    result := unresolved_ufixed(ret_val);
+  end procedure;
+
+  -----------------------------------------------------------------------------
+  -- unresolved_sfixed
+  -----------------------------------------------------------------------------
+  procedure encode_sfixed(constant data : in unresolved_sfixed; variable index : inout code_index_t; variable code : out code_t) is
+  begin
+    encode_std_ulogic_array(std_ulogic_array(data), index, code);
+  end procedure;
+
+  procedure decode_sfixed(constant code : in code_t; variable index : inout code_index_t; variable result : out unresolved_sfixed) is
+    variable ret_val : std_ulogic_array(result'range);
+  begin
+    decode_std_ulogic_array(code, index, ret_val);
+    result := unresolved_sfixed(ret_val);
+  end procedure;
+
+  -----------------------------------------------------------------------------
+  -- unresolved_float
+  -----------------------------------------------------------------------------
+  procedure encode_float(constant data : in unresolved_float; variable index : inout code_index_t; variable code : out code_t) is
+  begin
+    encode_std_ulogic_array(std_ulogic_array(data), index, code);
+  end procedure;
+
+  procedure decode_float(constant code : in code_t; variable index : inout code_index_t; variable result : out unresolved_float) is
+    variable ret_val : std_ulogic_array(result'range);
+  begin
+    decode_std_ulogic_array(code, index, ret_val);
+    result := unresolved_float(ret_val);
+  end procedure;
+
+
+  --===========================================================================
+  -- Functions which gives the number of code_t element to be used to encode the type
+  --===========================================================================
+
+  -----------------------------------------------------------------------------
+  -- boolean_vector
+  -----------------------------------------------------------------------------
+  function code_length_boolean_vector(length : natural) return natural is
+  begin
+    return code_length_bit_array(length);
+  end function;
+
+  function code_length_boolean_vector(data : boolean_vector) return natural is
+  begin
+    return code_length_boolean_vector(data'length);
+  end function;
+
+  -----------------------------------------------------------------------------
+  -- integer_vector
+  -----------------------------------------------------------------------------
+  function code_length_integer_vector(length : natural) return natural is
+  begin
+    return code_length_integer_range + code_length_integer * length;
+  end function;
+
+  function code_length_integer_vector(data : integer_vector) return natural is
+  begin
+    return code_length_integer_vector(data'length);
+  end function;
+
+  -----------------------------------------------------------------------------
+  -- real_vector
+  -----------------------------------------------------------------------------
+  function code_length_real_vector(length : natural) return natural is
+  begin
+    return code_length_integer_range + code_length_real * length;
+  end function;
+
+  function code_length_real_vector(data : real_vector) return natural is
+  begin
+    return code_length_real_vector(data'length);
+  end function;
+
+  -----------------------------------------------------------------------------
+  -- time_vector
+  -----------------------------------------------------------------------------
+  function code_length_time_vector(length : natural) return natural is
+  begin
+    return code_length_integer_range + code_length_time * length;
+  end function;
+
+  function code_length_time_vector(data : time_vector) return natural is
+  begin
+    return code_length_time_vector(data'length);
+  end function;
+
+  -----------------------------------------------------------------------------
+  -- unresolved_ufixed
+  -----------------------------------------------------------------------------
+  function code_length_ufixed(length : natural) return natural is
+  begin
+    return code_length_std_ulogic_array(length);
+  end function;
+
+  function code_length_ufixed(data : ufixed) return natural is
+  begin
+    return code_length_ufixed(data'length);
+  end function;
+
+  -----------------------------------------------------------------------------
+  -- unresolved_sfixed
+  -----------------------------------------------------------------------------
+  function code_length_sfixed(length : natural) return natural is
+  begin
+    return code_length_std_ulogic_array(length);
+  end function;
+
+  function code_length_sfixed(data : sfixed) return natural is
+  begin
+    return code_length_sfixed(data'length);
+  end function;
+
+  -----------------------------------------------------------------------------
+  -- unresolved_float
+  -----------------------------------------------------------------------------
+  function code_length_float(length : natural) return natural is
+  begin
+    return code_length_std_ulogic_array(length);
+  end function;
+
+  function code_length_float(data : float) return natural is
+  begin
+    return code_length_float(data'length);
+  end function;
+
+end package body;

--- a/vunit/vhdl/data_types/src/codec_builder.vhd
+++ b/vunit/vhdl/data_types/src/codec_builder.vhd
@@ -1,4 +1,4 @@
--- This package contains support functions for standard codec building
+-- This file provides functionality to encode/decode standard types to/from string.
 --
 -- This Source Code Form is subject to the terms of the Mozilla Public
 -- License, v. 2.0. If a copy of the MPL was not distributed with this file,

--- a/vunit/vhdl/data_types/src/codec_builder.vhd
+++ b/vunit/vhdl/data_types/src/codec_builder.vhd
@@ -781,9 +781,6 @@ package body codec_builder_pkg is
   begin
     code(index) := data;
     index       := index + code_length_character;
-    assert code_length_character = 1 report
-      "Character wronglength"
-    severity failure;
   end procedure;
 
   procedure decode_character(constant code : in code_t; variable index : inout code_index_t; variable result : out character) is

--- a/vunit/vhdl/data_types/src/codec_builder.vhd
+++ b/vunit/vhdl/data_types/src/codec_builder.vhd
@@ -6,126 +6,385 @@
 --
 -- Copyright (c) 2014-2022, Lars Asplund lars.anders.asplund@gmail.com
 
-library ieee;
-use ieee.std_logic_1164.all;
-use ieee.math_complex.all;
-use ieee.numeric_bit.all;
-use ieee.numeric_std.all;
-
+library std;
 use std.textio.all;
 
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.numeric_bit.all;
+use ieee.numeric_std.all;
+use ieee.math_real.all;
+use ieee.math_complex.all;
+
+library work;
+use work.common_pkg.all;
+
+
 package codec_builder_pkg is
-  type std_ulogic_array is array (integer range <>) of std_ulogic;
 
-  function get_simulator_resolution return time;
-  function to_byte_array (
-    constant value : bit_vector)
-    return string;
-  function from_byte_array (
-    constant byte_array : string)
-    return bit_vector;
+  -- This packages enables the user to encode any predefined type into a unique type.
+  -- This unique type is a 'string' (array of 'character').
+  -- The functionality can be used to build a queue capable of storing different
+  -- types in it (see the VUnit 'queue' package)
+  alias code_t is string;
 
-  constant integer_code_length : positive := 4;
-  constant boolean_code_length : positive := 1;
-  constant real_code_length : positive := boolean_code_length + 3 * integer_code_length;
-  constant std_ulogic_code_length : positive := 1;
-  constant bit_code_length : positive := 1;
-  constant time_code_length : positive := 8;
-  constant severity_level_code_length : positive := 1;
-  constant file_open_status_code_length : positive := 1;
-  constant file_open_kind_code_length : positive := 1;
-  constant complex_code_length : positive := 2 * real_code_length;
-  constant complex_polar_code_length : positive := 2 * real_code_length;
+  -- Remark: this package encodes any predefined type into a string, however, this
+  -- package is not meant for serialization and deserialization of data accross
+  -- versions of VUnit.
 
-  procedure decode (
-    constant code   :       string;
-    variable index  : inout positive;
-    variable result : out   integer);
-  procedure decode (
-    constant code   :       string;
-    variable index  : inout positive;
-    variable result : out   real);
-  procedure decode (
-    constant code   :       string;
-    variable index  : inout positive;
-    variable result : out   time);
-  procedure decode (
-    constant code   :       string;
-    variable index  : inout positive;
-    variable result : out   boolean);
-  procedure decode (
-    constant code   :       string;
-    variable index  : inout positive;
-    variable result : out   bit);
-  procedure decode (
-    constant code   :       string;
-    variable index  : inout positive;
-    variable result : out   std_ulogic);
-  procedure decode (
-    constant code   :       string;
-    variable index  : inout positive;
-    variable result : out   severity_level);
-  procedure decode (
-    constant code   :       string;
-    variable index  : inout positive;
-    variable result : out   file_open_status);
-  procedure decode (
-    constant code   :       string;
-    variable index  : inout positive;
-    variable result : out   file_open_kind);
-  procedure decode (
-    constant code   :       string;
-    variable index  : inout positive;
-    variable result : out   character);
-  procedure decode (
-    constant code   :       string;
-    variable index  : inout positive;
-    variable result : out   std_ulogic_array);
-  procedure decode (
-    constant code   :       string;
-    variable index  : inout positive;
-    variable result : out   string);
-  procedure decode (
-    constant code   :       string;
-    variable index  : inout positive;
-    variable result : out   bit_vector);
-  procedure decode (
-    constant code   :       string;
-    variable index  : inout positive;
-    variable result : out   std_ulogic_vector);
-  procedure decode (
-    constant code   :       string;
-    variable index  : inout positive;
-    variable result : out   complex);
-  procedure decode (
-    constant code   :       string;
-    variable index  : inout positive;
-    variable result : out   complex_polar);
-  procedure decode (
-    constant code   :       string;
-    variable index  : inout positive;
-    variable result : out   ieee.numeric_bit.unsigned);
-  procedure decode (
-    constant code   :       string;
-    variable index  : inout positive;
-    variable result : out   ieee.numeric_bit.signed);
-  procedure decode (
-    constant code   :       string;
-    variable index  : inout positive;
-    variable result : out   ieee.numeric_std.unsigned);
-  procedure decode (
-    constant code   :       string;
-    variable index  : inout positive;
-    variable result : out   ieee.numeric_std.signed);
-  function encode_array_header (
-    constant range_left1   : string;
-    constant range_right1  : string;
-    constant is_ascending1 : string;
-    constant range_left2   : string := "";
-    constant range_right2  : string := "";
-    constant is_ascending2 : string := "T")
-    return string;
-end package codec_builder_pkg;
+
+  --===========================================================================
+  -- API for the ADVANCED USERS
+  --===========================================================================
+
+  -----------------------------------------------------------------------------
+  -- Base types and constants describing how the encoding is performed
+  -----------------------------------------------------------------------------
+
+  -- A character (string of length 1) is 8 bits long
+  constant basic_code_length : positive := 8;
+  -- A character (string of length 1) can store up to 2**8 = 256 values
+  constant basic_code_nb_values : positive := 2**basic_code_length;
+
+
+  -----------------------------------------------------------------------------
+  -- VUnit defined types
+  -----------------------------------------------------------------------------
+
+  -- The std.bit_vector is defined with a natural range.
+  -- If you need to encode an array of std.bit (or an array of any subtype
+  -- of std.bit) with an integer range, you can use the type 'bit_array'
+  type bit_array is array(integer range <>) of bit;
+
+  -- The ieee.std_ulogic_vector is defined with a natural range.
+  -- If you need to encode an array of ieee.std_ulogic (or an array of any subtype
+  -- of ieee.std_ulogic) with an integer range, you can use the type 'std_ulogic_array'
+  type std_ulogic_array is array(integer range <>) of std_ulogic;
+
+
+  -----------------------------------------------------------------------------
+  -- Encoding length for each type
+  -----------------------------------------------------------------------------
+  -- If you need to retrieve the length of the encoded data without
+  -- encoding it, you can use these functions:
+  -- There are useful to automatically get the encoding length of a subtype
+  -- using the 'generic' function: "code_length(data)"
+
+  -- Note: some of these functions have a default value for the parameter 'data'. This is useful
+  -- for automatically generating encode and decode procedure/functions of more complex types
+  -- has all the functions have the same parameter 'data'.
+
+  -- The details of how each type is encoded is described in the package body
+
+  -- Predefined enumerated types
+  function code_length_boolean(data : boolean := boolean'left) return natural;
+  function code_length_character(data : character := character'left) return natural;
+  function code_length_bit(data : bit := bit'left) return natural;
+  function code_length_std_ulogic(data : std_ulogic := std_ulogic'left) return natural;
+  function code_length_severity_level(data : severity_level := severity_level'left) return natural;
+  function code_length_file_open_kind(data : file_open_kind := file_open_kind'left) return natural;
+  function code_length_file_open_status(data : file_open_status := file_open_status'left) return natural;
+
+  alias code_length is code_length_boolean[boolean return natural];
+  alias code_length is code_length_character[character return natural];
+  alias code_length is code_length_bit[bit return natural];
+  alias code_length is code_length_std_ulogic[std_ulogic return natural];
+  alias code_length is code_length_severity_level[severity_level return natural];
+  alias code_length is code_length_file_open_kind[file_open_kind return natural];
+  alias code_length is code_length_file_open_status[file_open_status return natural];
+
+  -- Predefined scalar types
+  function code_length_integer(data : integer := integer'left) return natural;
+  function code_length_real(data : real := real'left) return natural;
+  function code_length_time(data : time := time'left) return natural;
+
+  alias code_length is code_length_integer[integer return natural];
+  alias code_length is code_length_real[real return natural];
+  alias code_length is code_length_time[time return natural];
+
+  -- Predefined composite types (records)
+  function code_length_complex(data : complex := MATH_CZERO) return natural;
+  function code_length_complex_polar(data : complex_polar := (MAG => 0.0, ARG => 0.0)) return natural;
+
+  alias code_length is code_length_complex[complex return natural];
+  alias code_length is code_length_complex_polar[complex_polar return natural];
+
+  -- Predefined composite types (arrays)
+  -- Note: We can use an alternate function for array types which takes the
+  -- length of the array to encode instead of the array itself.
+  function code_length_string(length : natural) return natural;
+  function code_length_bit_vector(length : natural) return natural;
+  function code_length_numeric_bit_unsigned(length : natural) return natural;
+  function code_length_numeric_bit_signed(length : natural) return natural;
+  function code_length_std_ulogic_vector(length : natural) return natural;
+  function code_length_numeric_std_unsigned(length : natural) return natural;
+  function code_length_numeric_std_signed(length : natural) return natural;
+  function code_length_bit_array(length : natural) return natural;
+  function code_length_std_ulogic_array(length : natural) return natural;
+
+  function code_length_string(data : string) return natural;
+  function code_length_bit_vector(data : bit_vector) return natural;
+  function code_length_numeric_bit_unsigned(data : ieee.numeric_bit.unsigned) return natural;
+  function code_length_numeric_bit_signed(data : ieee.numeric_bit.signed) return natural;
+  function code_length_std_ulogic_vector(data : std_ulogic_vector) return natural;
+  function code_length_numeric_std_unsigned(data : ieee.numeric_std.unresolved_unsigned) return natural;
+  function code_length_numeric_std_signed(data : ieee.numeric_std.unresolved_signed) return natural;
+  function code_length_bit_array(data : bit_array) return natural;
+  function code_length_std_ulogic_array(data : std_ulogic_array) return natural;
+
+  alias code_length is code_length_string[string return natural];
+  alias code_length is code_length_bit_vector[bit_vector return natural];
+  alias code_length is code_length_numeric_bit_unsigned[ieee.numeric_bit.unsigned return natural];
+  alias code_length is code_length_numeric_bit_signed[ieee.numeric_bit.signed return natural];
+  alias code_length is code_length_std_ulogic_vector[std_ulogic_vector return natural];
+  alias code_length is code_length_numeric_std_unsigned[ieee.numeric_std.unresolved_unsigned return natural];
+  alias code_length is code_length_numeric_std_signed[ieee.numeric_std.unresolved_signed return natural];
+  alias code_length is code_length_bit_array[bit_array return natural];
+  alias code_length is code_length_std_ulogic_array[std_ulogic_array return natural];
+
+
+
+  --===========================================================================
+  -- API for the VUnit DEVELOPERS
+  --===========================================================================
+  -- This section present low level procedures to encode and decode. They are not
+  -- intented to be used by the casual user.
+  -- These are intended for VUnit developers (and advanced users) to build encode
+  -- and decode procedures and functions of more complex types.
+
+  -- Index to track the position of an encoded element inside an instance of code_t
+  alias code_index_t is positive;
+
+  -----------------------------------------------------------------------------
+  -- Alternate encode and decode procedures
+  -----------------------------------------------------------------------------
+  -- In most of the procedures, there are:
+  --  * the 'code' parameter which is the encoded data.
+  --  * the 'index' parameter which indicates from where inside the 'code' parameter
+  --    we must start to encode the data or decode the data.
+  -- The 'index' is updated by the procedures in order for the next encode/decode
+  -- procedure to be able to keep encoding or decoding the data without having to deal
+  -- with the length of the internal representation.
+  -- The implementations on the 'encode_complex' and 'decode_complex' is an example
+  -- of that feature. We first encode/decode the real part, then the imaginary part.
+
+  -- Predefined enumerated types
+  procedure encode_boolean(constant data : in boolean; variable index : inout code_index_t; variable code : inout code_t);
+  procedure decode_boolean(constant code : in code_t; variable index : inout code_index_t; variable result : out boolean);
+  alias encode is encode_boolean[boolean, code_index_t, code_t];
+  alias decode is decode_boolean[code_t, code_index_t, boolean];
+
+  procedure encode_character(constant data : in character; variable index : inout code_index_t; variable code : inout code_t);
+  procedure decode_character(constant code : in code_t; variable index : inout code_index_t; variable result : out character);
+  alias encode is encode_character[character, code_index_t, code_t];
+  alias decode is decode_character[code_t, code_index_t, character];
+
+  procedure encode_bit(constant data : in bit; variable index : inout code_index_t; variable code : inout code_t);
+  procedure decode_bit(constant code : in code_t; variable index : inout code_index_t; variable result : out bit);
+  alias encode is encode_bit[bit, code_index_t, code_t];
+  alias decode is decode_bit[code_t, code_index_t, bit];
+
+  procedure encode_std_ulogic(constant data : in std_ulogic; variable index : inout code_index_t; variable code : inout code_t);
+  procedure decode_std_ulogic(constant code : in code_t; variable index : inout code_index_t; variable result : out std_ulogic);
+  alias encode is encode_std_ulogic[std_ulogic, code_index_t, code_t];
+  alias decode is decode_std_ulogic[code_t, code_index_t, std_ulogic];
+
+  procedure encode_severity_level(constant data : in severity_level; variable index : inout code_index_t; variable code : inout code_t);
+  procedure decode_severity_level(constant code : in code_t; variable index : inout code_index_t; variable result : out severity_level);
+  alias encode is encode_severity_level[severity_level, code_index_t, code_t];
+  alias decode is decode_severity_level[code_t, code_index_t, severity_level];
+
+  procedure encode_file_open_kind(constant data : in file_open_kind; variable index : inout code_index_t; variable code : inout code_t);
+  procedure decode_file_open_kind(constant code : in code_t; variable index : inout code_index_t; variable result : out file_open_kind);
+  alias encode is encode_file_open_kind[file_open_kind, code_index_t, code_t];
+  alias decode is decode_file_open_kind[code_t, code_index_t, file_open_kind];
+
+  procedure encode_file_open_status(constant data : in file_open_status; variable index : inout code_index_t; variable code : inout code_t);
+  procedure decode_file_open_status(constant code : in code_t; variable index : inout code_index_t; variable result : out file_open_status);
+  alias encode is encode_file_open_status[file_open_status, code_index_t, code_t];
+  alias decode is decode_file_open_status[code_t, code_index_t, file_open_status];
+
+  -- Predefined scalar types
+  procedure encode_integer(constant data : in integer; variable index : inout code_index_t; variable code : inout code_t);
+  procedure decode_integer(constant code : in code_t; variable index : inout code_index_t; variable result : out integer);
+  alias encode is encode_integer[integer, code_index_t, code_t];
+  alias decode is decode_integer[code_t, code_index_t, integer];
+
+  procedure encode_real(constant data : in real; variable index : inout code_index_t; variable code : inout code_t);
+  procedure decode_real(constant code : in code_t; variable index : inout code_index_t; variable result : out real);
+  alias encode is encode_real[real, code_index_t, code_t];
+  alias decode is decode_real[code_t, code_index_t, real];
+
+  procedure encode_time(constant data : in time; variable index : inout code_index_t; variable code : inout code_t);
+  procedure decode_time(constant code : in code_t; variable index : inout code_index_t; variable result : out time);
+  alias encode is encode_time[time, code_index_t, code_t];
+  alias decode is decode_time[code_t, code_index_t, time];
+
+  -- Predefined composite types (records)
+  procedure encode_complex(constant data : in complex; variable index : inout code_index_t; variable code : inout code_t);
+  procedure decode_complex(constant code : in code_t; variable index : inout code_index_t; variable result : out complex);
+  alias encode is encode_complex[complex, code_index_t, code_t];
+  alias decode is decode_complex[code_t, code_index_t, complex];
+
+  procedure encode_complex_polar(constant data : in complex_polar; variable index : inout code_index_t; variable code : inout code_t);
+  procedure decode_complex_polar(constant code : in code_t; variable index : inout code_index_t; variable result : out complex_polar);
+  alias encode is encode_complex_polar[complex_polar, code_index_t, code_t];
+  alias decode is decode_complex_polar[code_t, code_index_t, complex_polar];
+
+  -- Predefined composite types (arrays)
+  -- Note: these function encode the range of the array alongside its data. If the
+  -- array is empty(null range), its range is still encoded
+
+  procedure encode_string(constant data : in string; variable index : inout code_index_t; variable code : inout code_t);
+  procedure decode_string(constant code : in code_t; variable index : inout code_index_t; variable result : out string);
+  alias encode is encode_string[string, code_index_t, code_t];
+  alias decode is decode_string[code_t, code_index_t, string];
+
+  procedure encode_bit_array(constant data : in bit_array; variable index : inout code_index_t; variable code : inout code_t);
+  procedure decode_bit_array(constant code : in code_t; variable index : inout code_index_t; variable result : out bit_array);
+  alias encode is encode_bit_array[bit_array, code_index_t, code_t];
+  alias decode is decode_bit_array[code_t, code_index_t, bit_array];
+
+  procedure encode_bit_vector(constant data : in bit_vector; variable index : inout code_index_t; variable code : inout code_t);
+  procedure decode_bit_vector(constant code : in code_t; variable index : inout code_index_t; variable result : out bit_vector);
+  alias encode is encode_bit_vector[bit_vector, code_index_t, code_t];
+  alias decode is decode_bit_vector[code_t, code_index_t, bit_vector];
+
+  procedure encode_numeric_bit_unsigned(constant data : in ieee.numeric_bit.unsigned; variable index : inout code_index_t; variable code : inout code_t);
+  procedure decode_numeric_bit_unsigned(constant code : in code_t; variable index : inout code_index_t; variable result : out ieee.numeric_bit.unsigned);
+  alias encode is encode_numeric_bit_unsigned[ieee.numeric_bit.unsigned, code_index_t, code_t];
+  alias decode is decode_numeric_bit_unsigned[code_t, code_index_t, ieee.numeric_bit.unsigned];
+
+  procedure encode_numeric_bit_signed(constant data : in ieee.numeric_bit.signed; variable index : inout code_index_t; variable code : inout code_t);
+  procedure decode_numeric_bit_signed(constant code : in code_t; variable index : inout code_index_t; variable result : out ieee.numeric_bit.signed);
+  alias encode is encode_numeric_bit_signed[ieee.numeric_bit.signed, code_index_t, code_t];
+  alias decode is decode_numeric_bit_signed[code_t, code_index_t, ieee.numeric_bit.signed];
+
+  procedure encode_std_ulogic_array(constant data : in std_ulogic_array; variable index : inout code_index_t; variable code : inout code_t);
+  procedure decode_std_ulogic_array(constant code : in code_t; variable index : inout code_index_t; variable result : out std_ulogic_array);
+  alias encode is encode_std_ulogic_array[std_ulogic_array, code_index_t, code_t];
+  alias decode is decode_std_ulogic_array[code_t, code_index_t, std_ulogic_array];
+
+  procedure encode_std_ulogic_vector(constant data : in std_ulogic_vector; variable index : inout code_index_t; variable code : inout code_t);
+  procedure decode_std_ulogic_vector(constant code : in code_t; variable index : inout code_index_t; variable result : out std_ulogic_vector);
+  alias encode is encode_std_ulogic_vector[std_ulogic_vector, code_index_t, code_t];
+  alias decode is decode_std_ulogic_vector[code_t, code_index_t, std_ulogic_vector];
+
+  procedure encode_numeric_std_unsigned(constant data : in ieee.numeric_std.unresolved_unsigned; variable index : inout code_index_t; variable code : inout code_t);
+  procedure decode_numeric_std_unsigned(constant code : in code_t; variable index : inout code_index_t; variable result : out ieee.numeric_std.unresolved_unsigned);
+  alias encode is encode_numeric_std_unsigned[ieee.numeric_std.unresolved_unsigned, code_index_t, code_t];
+  alias decode is decode_numeric_std_unsigned[code_t, code_index_t, ieee.numeric_std.unresolved_unsigned];
+
+  procedure encode_numeric_std_signed(constant data : in ieee.numeric_std.unresolved_signed; variable index : inout code_index_t; variable code : inout code_t);
+  procedure decode_numeric_std_signed(constant code : in code_t; variable index : inout code_index_t; variable result : out ieee.numeric_std.unresolved_signed);
+  alias encode is encode_numeric_std_signed[ieee.numeric_std.unresolved_signed, code_index_t, code_t];
+  alias decode is decode_numeric_std_signed[code_t, code_index_t, ieee.numeric_std.unresolved_signed];
+
+
+  -----------------------------------------------------------------------------
+  -- Encoding of 'raw' string, 'raw' bit_array and 'raw' std_ulogic_array
+  -----------------------------------------------------------------------------
+  -- We define procedures which encode a 'string', 'bit_array' or a 'std_ulogic_array' without its range.
+  -- It can be useful when you encode a value which has always same width. For example,
+  -- integers are encoded using 'encode_raw_bit_array' because thay are always
+  -- 32 bits (or 64 bits in VHDL-2019).
+
+  -- Note that the 'encode' procedure do not have aliases procedure 'encode' as they
+  -- are homograph with the 'encode_string', 'encode_bit_array' or
+  -- 'encode_std_ulogic_array'. Same thing for decode procedure.
+
+  -- To encode/decode string with its range, use encode_string and decode_string.
+  procedure encode_raw_string(constant data : in string; variable index : inout code_index_t; variable code : inout code_t);
+  procedure decode_raw_string(constant code : in code_t; variable index : inout code_index_t; variable result : out string);
+  -- To encode/decode bit_array with its range, use encode_bit_array and decode_bit_array.
+  procedure encode_raw_bit_array(constant data : in bit_array; variable index : inout code_index_t; variable code : inout code_t);
+  procedure decode_raw_bit_array(constant code : in code_t; variable index : inout code_index_t; variable result : out bit_array);
+  -- To encode/decode std_ulogic_array with its range, use encode_std_ulogic_array and decode_std_ulogic_array.
+  procedure encode_raw_std_ulogic_array(constant data : in std_ulogic_array; variable index : inout code_index_t; variable code : inout code_t);
+  procedure decode_raw_std_ulogic_array(constant code : in code_t; variable index : inout code_index_t; variable result : out std_ulogic_array);
+
+  -- Thes functions give you the length of the encoded array depending on the
+  -- length of the array to encode
+  function code_length_raw_string(length : natural) return natural;
+  function code_length_raw_bit_array(length : natural) return natural;
+  function code_length_raw_std_ulogic_array(length : natural) return natural;
+
+  function code_length_raw_string(data : string) return natural;
+  function code_length_raw_bit_array(data : bit_array) return natural;
+  function code_length_raw_std_ulogic_array(data : std_ulogic_array) return natural;
+
+
+  -----------------------------------------------------------------------------
+  -- Encoding of predefined composite types (arrays)
+  -----------------------------------------------------------------------------
+
+  -- Two things need to be extracted from an array to encode it:
+  --  * The range of the array
+  --  * The data inside the array
+  -- The range encoding is performed by 'encode_range' and 'decode_range' functions.
+
+  -- This type is used so that we can return an array with any integer range.
+  -- It is not meant to carry any other information.
+  type range_t is array(integer range <>) of bit;
+
+  -- Encode and decode functions for range
+  procedure encode_range(
+    constant range_left : integer;
+    constant range_right : integer;
+    constant is_ascending : boolean;
+    variable index : inout code_index_t;
+    variable code : inout code_t
+  );
+  alias encode is encode_range[integer, integer, boolean, code_index_t, code_t];
+  -- Note, there is no procedure 'decode_range' because we want to retrieve an unknown range.
+  -- If we had a procedure, we would need to provide a variable to the parameter 'result' which
+  -- must be constrained. This contradicts the purpose of the functionnality.
+  -- However, there is a 'decode_range' function inside the codec.vhd package
+
+  -- Encoding length of an integer range
+  function code_length_integer_range return natural;
+
+
+  --===========================================================================
+  -- Deprecated functions. Maintained for backward compatibility
+  --===========================================================================
+
+  -- Deferred constants
+  constant integer_code_length          : positive;
+  constant boolean_code_length          : positive;
+  constant real_code_length             : positive;
+  constant std_ulogic_code_length       : positive;
+  constant bit_code_length              : positive;
+  constant time_code_length             : positive;
+  constant severity_level_code_length   : positive;
+  constant file_open_status_code_length : positive;
+  constant file_open_kind_code_length   : positive;
+  constant complex_code_length          : positive;
+  constant complex_polar_code_length    : positive;
+
+  -- This function is deprecated.
+  -- Use the 'encode_range' function instead.
+  -- If you need to encode two ranges, make two call to the 'encode_range' function.
+  function encode_array_header(
+    constant range_left1   : in code_t;
+    constant range_right1  : in code_t;
+    constant is_ascending1 : in code_t;
+    constant range_left2   : in code_t := "";
+    constant range_right2  : in code_t := "";
+    constant is_ascending2 : in code_t := "T"
+  ) return code_t;
+
+  -- This function is deprecated.
+  -- Use the 'encode_raw_bit_array' function instead.
+  function to_byte_array(value : bit_vector) return code_t;
+
+  -- This function is deprecated.
+  -- Use the 'decode_raw_bit_array' function instead.
+  function from_byte_array(byte_array : code_t) return bit_vector;
+
+end package;
+
+
 
 package body codec_builder_pkg is
   function get_simulator_resolution return time is

--- a/vunit/vhdl/data_types/src/common_pkg.vhd
+++ b/vunit/vhdl/data_types/src/common_pkg.vhd
@@ -1,0 +1,131 @@
+-- This package contains support functions for standard codec building
+--
+-- This Source Code Form is subject to the terms of the Mozilla Public
+-- License, v. 2.0. If a copy of the MPL was not distributed with this file,
+-- You can obtain one at http://mozilla.org/MPL/2.0/.
+--
+-- Copyright (c) 2014-2022, Lars Asplund lars.anders.asplund@gmail.com
+
+
+-------------------------------------------------------------------------------
+-- Package declaration
+-------------------------------------------------------------------------------
+package common_pkg is
+
+  -----------------------------------------------------------------------------
+  -- Functions
+  -----------------------------------------------------------------------------
+
+  -- Returns the ceil value of the division
+  function ceil_div(dividend : natural; divisor : natural) return natural;
+
+  -- Retrieve the time resolution of the simulator
+  function get_simulator_resolution return time;
+
+  -- Retrieve the integer width of the simulator
+  function get_simulator_integer_width return positive;
+
+
+  -----------------------------------------------------------------------------
+  -- Constant
+  -----------------------------------------------------------------------------
+
+  -- Time resolution of the simulator used
+  constant simulator_resolution : time;
+
+  -- Time resolution of the simulator used
+  constant simulator_integer_width : positive;
+
+  -- Time resolution of the simulator used
+  constant simulator_real_width : positive;
+  constant simulator_real_sign_width : positive := 1;
+  constant simulator_real_mantisse_width : positive;
+  constant simulator_real_exponent_width : positive;
+
+  -- Time resolution of the simulator used
+  constant simulator_time_width : positive := 64; -- TODO assumed value
+
+end package;
+
+
+-------------------------------------------------------------------------------
+-- Package body
+-------------------------------------------------------------------------------
+package body common_pkg is
+
+  -----------------------------------------------------------------------------
+  -- Functions
+  -----------------------------------------------------------------------------
+
+  function ceil_div(dividend : natural; divisor : natural) return natural is
+  begin
+    return (dividend + divisor - 1) / divisor;
+  end function;
+
+
+  function get_simulator_resolution return time is
+    type time_array_t is array (integer range <>) of time;
+    variable resolution : time;
+    -- Note it is important to fully constraint the constant to
+    -- insure that the loop go through the array in the wanted order
+    constant resolutions : time_array_t(1 to 8) := (
+      1.0e-15 sec, 1.0e-12 sec , 1.0e-9 sec, 1.0e-6 sec, 1.0e-3 sec, 1 sec, 1 min, 1 hr
+    );
+  begin
+    for r in resolutions'range loop
+      resolution := resolutions(r);
+      exit when resolution > 0 sec;
+    end loop;
+    return resolution;
+  end function;
+
+
+  function get_simulator_integer_width return positive is -- TBC Is this function written well enough ?
+  begin
+    if integer'high = 2_147_483_647 then
+      return 32;
+    else
+      return 64;
+    end if;
+  end function;
+
+
+  function get_simulator_real_width return positive is -- TBC Is this function written well enough ?
+  begin
+    if real'high = 1.0E308 then
+      return 32;
+    else
+      return 64;
+    end if;
+  end function;
+
+  function get_simulator_real_mantisse_width(simulator_real_width : positive) return positive is
+  begin
+    if simulator_real_width = 32 then
+      return 23;
+    else
+      return 52;
+    end if;
+  end function;
+
+  function get_simulator_real_exponent_width(simulator_real_width : positive) return positive is
+  begin
+    if simulator_real_width = 32 then
+      return 8;
+    else
+      return 11;
+    end if;
+  end function;
+
+
+  -----------------------------------------------------------------------------
+  -- Constant
+  -----------------------------------------------------------------------------
+
+  constant simulator_resolution : time := get_simulator_resolution;
+  constant simulator_integer_width : positive := get_simulator_integer_width;
+  constant simulator_real_width : positive := get_simulator_real_width;
+  constant simulator_real_mantisse_width : positive := get_simulator_real_mantisse_width(simulator_real_width);
+  constant simulator_real_exponent_width : positive := get_simulator_real_exponent_width(simulator_real_width);
+
+end package body;

--- a/vunit/vhdl/data_types/src/data_types_context.vhd
+++ b/vunit/vhdl/data_types/src/data_types_context.vhd
@@ -6,6 +6,7 @@
 
 context data_types_context is
   library vunit_lib;
+  use vunit_lib.common_pkg.all;
   use vunit_lib.types_pkg.all;
   use vunit_lib.integer_vector_ptr_pkg.all;
   use vunit_lib.integer_vector_ptr_pool_pkg.all;


### PR DESCRIPTION
Linked with issue #818 

The proposed modifications on the `codec` package are retro-compatible. The `tb_codec.vhd` has not been modified to underline this. The tb of the `com` package `tb_com_codec.vhd` has not been touched either.

The tests compile and pass for `data_type` and `com` package with Modelsim 2020.1. I will try with GHDL soon.

Here is a list of changes (non-exhaustive):

 + Add comments into the code which explains the purpose of this package and how each type is encoded.
 + Removed hard coded value in the code
 + Replace the type 'string' used to encode by an alias named 'code_t' to ease readability and maintainbility.
 + Inverse the `function` and alias `names` to ease readability, maintainbility and ease `ctrl+F`:
   ```vhdl
   function encode(constant data : std_ulogic_vector) return string;
   function decode(constant code : string) return std_ulogic_vector;
   alias encode_std_ulogic_vector is encode[std_ulogic_vector return string];
   alias decode_std_ulogic_vector is decode[string return std_ulogic_vector];
   ```
   becomes
   ```vhdl
   function encode_std_ulogic_vector(data : std_ulogic_vector) return string;
   function decode_std_ulogic_vector(code : string) return std_ulogic_vector;
   alias encode is encode_std_ulogic_vector[std_ulogic_vector return string];
   alias decode is decode_std_ulogic_vector[string return std_ulogic_vector];
   ```
 + The code length for integer automatically adapts to the width of the integer (1993/2002/2008: 32bits, 2019: 64bits). (Not tested with __VHDL-2019__).
 + Added clearly which function should be used by a VUnit user vs a VUnit advanced user vs a VUnit developer.
 + Functions `encode_array_header` and `get_range` are replaced (these names are not consistent with the other functions):
   - `function encode_range(range_left : integer; range_right : integer; is_ascending : boolean) return code_vec_t;`
   - `function decode_range(code : code_vec_t) return range_t;`
   - `encode_array_header` and `get_range` are deprecated but preserved for backward compatibility.
   - `encode_array_header` and `get_range` take the encoded string of `range_left`, `range_right` and `is_ascending` while `encode_range` and `decode_range` directly take integers and a boolean.
   - Note that `encode_array_header` can encode two ranges but it was never used for that purpose (anywhere in the VUnit repo). The `encode_range` can only encode a single range.
 + Replace the `ieee.numeric_std.unsigned` by `ieee.numeric_std.unresolved_unsigned`
 + Replace the `ieee.numeric_std.signed` by `ieee.numeric_std.unresolved_signed`
 + Simplify the local `log2` function used to encode the  `real` type by using the `ieee.math_real` package.
   The same idea could be applied to `string`, but I did not see the use case so it was not implemented.
 + For each encoded type which is a `scalar`, an `enumerated type` or a `record type`, there is a function named `function code_length_**type_name** return natural` which indicate how many characters are needed to encode a value of the selected type.
 + For each encoded type which is an `array type`, there is a function named `function code_length_**type_name**(length : natural) return natural;` which indicate how many character are needed to encode a value of the selected type.
 + The type `std_ulogic_array` is similar to the `std_ulogic_vector` but with an integer range. However, it was not the case for bit_vector. There is now a type `bit_array` for that purpose.
 + The function `to_byte_array` and `from_byte_array` are replaced (these names are not consistent with the other functions and the introduction of `bit_array` required a change of `bit_vector` to `bit_array`):
   - `function encode_raw_bit_array(data : bit_array) return code_t;`
   - `function decode_raw_bit_array(code : code_t) return bit_array;`
   - `to_byte_array` and `from_byte_array` are deprecated but preserved for backward compatibility.
 + Create a new package `common_pkg` which contains constants/fonction used by the `codec` package but not specific to it like:
   ```vhdl
   -- Retrieve the integer width of the simulator
   function get_simulator_integer_width return positive;
   ```
 + Added a page in the online documentation which shows the declaration package of the `codec.vhd` and `codec-2008p.vhd` files.
 + Updated the python code to generate the encode/decode functions for user-specified type.
