### PR TITLE
Port type signal

### DIFF
--- a/tests/unit/test_vhdl_parser.py
+++ b/tests/unit/test_vhdl_parser.py
@@ -403,6 +403,7 @@ end entity;
         self.assertEqual(ports[11].subtype_indication.code, "type_signal")
         self.assertEqual(ports[11].subtype_indication.type_mark, "type_signal")
         self.assertEqual(ports[11].subtype_indication.constraint, None)
+
     def test_parsing_simple_package_body(self):
         package_body = self.parse_single_package_body(
             """\

--- a/tests/unit/test_vhdl_parser.py
+++ b/tests/unit/test_vhdl_parser.py
@@ -297,8 +297,20 @@ end entity;
         entity = self.parse_single_entity(
             """\
 entity name is
-   port (clk : in std_logic;
-         data : out std_logic_vector(11-1 downto 0));
+port (
+    clk : in std_logic;
+    data : out std_logic_vector(11-1 downto 0);
+    signal_data2 : in std_logic;
+    data3 :\tin signal_type;
+    data4_signal : in std_logic;
+    data5\t: in type_signal;
+    signal clk2 : in std_logic;
+    signal\tdata7 : out std_logic_vector(11-1 downto 0);
+    signal signal_data8 : in std_logic;
+    signal data9 : in signal_type;
+    signal data10_signal :\tin std_logic;\t
+    signal data11 : in type_signal
+);
 end entity;
 """
         )
@@ -308,7 +320,7 @@ end entity;
         self.assertNotEqual(entity.ports, [])
 
         ports = entity.ports
-        self.assertEqual(len(ports), 2)
+        self.assertEqual(len(ports), 12)
 
         self.assertEqual(ports[0].identifier, "clk")
         self.assertEqual(ports[0].init_value, None)
@@ -323,6 +335,74 @@ end entity;
         self.assertEqual(ports[1].subtype_indication.type_mark, "std_logic_vector")
         self.assertEqual(ports[1].subtype_indication.constraint, "(11-1 downto 0)")
 
+        self.assertEqual(ports[2].identifier, "signal_data2")
+        self.assertEqual(ports[2].init_value, None)
+        self.assertEqual(ports[2].mode, "in")
+        self.assertEqual(ports[2].subtype_indication.code, "std_logic")
+        self.assertEqual(ports[2].subtype_indication.type_mark, "std_logic")
+        self.assertEqual(ports[2].subtype_indication.constraint, None)
+
+        self.assertEqual(ports[3].identifier, "data3")
+        self.assertEqual(ports[3].init_value, None)
+        self.assertEqual(ports[3].mode, "in")
+        self.assertEqual(ports[3].subtype_indication.code, "signal_type")
+        self.assertEqual(ports[3].subtype_indication.type_mark, "signal_type")
+        self.assertEqual(ports[3].subtype_indication.constraint, None)
+
+        self.assertEqual(ports[4].identifier, "data4_signal")
+        self.assertEqual(ports[4].init_value, None)
+        self.assertEqual(ports[4].mode, "in")
+        self.assertEqual(ports[4].subtype_indication.code, "std_logic")
+        self.assertEqual(ports[4].subtype_indication.type_mark, "std_logic")
+        self.assertEqual(ports[4].subtype_indication.constraint, None)
+
+        self.assertEqual(ports[5].identifier, "data5")
+        self.assertEqual(ports[5].init_value, None)
+        self.assertEqual(ports[5].mode, "in")
+        self.assertEqual(ports[5].subtype_indication.code, "type_signal")
+        self.assertEqual(ports[5].subtype_indication.type_mark, "type_signal")
+        self.assertEqual(ports[5].subtype_indication.constraint, None)
+
+        self.assertEqual(ports[6].identifier, "clk2")
+        self.assertEqual(ports[6].init_value, None)
+        self.assertEqual(ports[6].mode, "in")
+        self.assertEqual(ports[6].subtype_indication.code, "std_logic")
+        self.assertEqual(ports[6].subtype_indication.type_mark, "std_logic")
+
+        self.assertEqual(ports[7].identifier, "data7")
+        self.assertEqual(ports[7].init_value, None)
+        self.assertEqual(ports[7].mode, "out")
+        self.assertEqual(ports[7].subtype_indication.code, "std_logic_vector(11-1 downto 0)")
+        self.assertEqual(ports[7].subtype_indication.type_mark, "std_logic_vector")
+        self.assertEqual(ports[7].subtype_indication.constraint, "(11-1 downto 0)")
+
+        self.assertEqual(ports[8].identifier, "signal_data8")
+        self.assertEqual(ports[8].init_value, None)
+        self.assertEqual(ports[8].mode, "in")
+        self.assertEqual(ports[8].subtype_indication.code, "std_logic")
+        self.assertEqual(ports[8].subtype_indication.type_mark, "std_logic")
+        self.assertEqual(ports[8].subtype_indication.constraint, None)
+
+        self.assertEqual(ports[9].identifier, "data9")
+        self.assertEqual(ports[9].init_value, None)
+        self.assertEqual(ports[9].mode, "in")
+        self.assertEqual(ports[9].subtype_indication.code, "signal_type")
+        self.assertEqual(ports[9].subtype_indication.type_mark, "signal_type")
+        self.assertEqual(ports[9].subtype_indication.constraint, None)
+
+        self.assertEqual(ports[10].identifier, "data10_signal")
+        self.assertEqual(ports[10].init_value, None)
+        self.assertEqual(ports[10].mode, "in")
+        self.assertEqual(ports[10].subtype_indication.code, "std_logic")
+        self.assertEqual(ports[10].subtype_indication.type_mark, "std_logic")
+        self.assertEqual(ports[10].subtype_indication.constraint, None)
+
+        self.assertEqual(ports[11].identifier, "data11")
+        self.assertEqual(ports[11].init_value, None)
+        self.assertEqual(ports[11].mode, "in")
+        self.assertEqual(ports[11].subtype_indication.code, "type_signal")
+        self.assertEqual(ports[11].subtype_indication.type_mark, "type_signal")
+        self.assertEqual(ports[11].subtype_indication.constraint, None)
     def test_parsing_simple_package_body(self):
         package_body = self.parse_single_package_body(
             """\

--- a/tests/unit/test_vhdl_parser.py
+++ b/tests/unit/test_vhdl_parser.py
@@ -299,17 +299,17 @@ end entity;
 entity name is
 port (
     clk : in std_logic;
-    data : out std_logic_vector(11-1 downto 0);
+ \t data : out std_logic_vector(11-1 downto 0);
     signal_data2 : in std_logic;
-    data3 :\tin signal_type;
-    data4_signal : in std_logic;
+\t  data3 :\tin signal_type;
+    data4_signal : in\tstd_logic;
     data5\t: in type_signal;
-    signal clk2 : in std_logic;
+\t\tsignal clk2 : in std_logic;
     signal\tdata7 : out std_logic_vector(11-1 downto 0);
     signal signal_data8 : in std_logic;
-    signal data9 : in signal_type;
+    signal\t data9 : in signal_type;
     signal data10_signal :\tin std_logic;\t
-    signal data11 : in type_signal
+    signal \t data11 : in type_signal
 );
 end entity;
 """

--- a/vunit/vhdl_parser.py
+++ b/vunit/vhdl_parser.py
@@ -637,7 +637,9 @@ class VHDLInterfaceElement(object):
         """
         if is_signal:
             # Remove 'signal' string if a signal is being parsed
-            code = re.sub("\bsignal\b", "", code)
+            # Note, the string must be a raw string for the word boundary '\b' to work properly
+            # see documentation https://docs.python.org/3/howto/regex.html#more-metacharacters
+            code = re.sub(r"\bsignal\b", "", code)
 
         interface_element_string = code
 

--- a/vunit/vhdl_parser.py
+++ b/vunit/vhdl_parser.py
@@ -636,8 +636,8 @@ class VHDLInterfaceElement(object):
         Returns a new instance by parsing the code
         """
         if is_signal:
-            # Remove 'signal' string if a signal is beeing parsed
-            code = code.replace("signal", "")
+            # Remove 'signal' string if a signal is being parsed
+            code = re.sub("\bsignal\b", "", code)
 
         interface_element_string = code
 


### PR DESCRIPTION
The changement are those implemented by @eschmidscs in pull request #792 with the changes requested by Lars.
Note that there is also a modification of the regex from:
```python
code = re.sub("\bsignal\b", "", code)
```
to
```python
code = re.sub(r"\bsignal\b", "", code)
```
otherwise the tests fail. The [python documentation about the word boundary](https://docs.python.org/3/howto/regex.html#more-metacharacters) states:
> There are two subtleties you should remember when using this special sequence. 
> First, this is the worst collision between Python’s string literals and regular expression sequences. In Python’s string literals, \b is the backspace character, ASCII value 8. If you’re not using **raw strings**, then Python will convert the \b to a backspace, and your **RE won’t match as you expect it to**.
> Second, inside a character class, where there’s no use for this assertion, \b represents the backspace character, for compatibility with Python’s string literals.