### PR TITLE
ci/push: remove job win-tagged

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -97,7 +97,7 @@ jobs:
 # Windows (MSYS2) with 'nightly' GHDL
 #
 
-  win-setup:
+  win:
     runs-on: windows-latest
     strategy:
       fail-fast: false
@@ -138,60 +138,12 @@ jobs:
       run: tox -e py${{ matrix.task }} -- --color=yes
 
 #
-# Windows with latest tagged GHDL
-#
-
-  win-tagged:
-    runs-on: windows-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        task: [
-          37-acceptance-ghdl,
-          37-vcomponents-ghdl,
-          37-lint,
-          37-unit,
-        ]
-    name: '🧊 Windows · tagged · ${{ matrix.task }}'
-    steps:
-
-    - name: '🧰 Checkout'
-      uses: actions/checkout@v2
-      with:
-        submodules: recursive
-
-    - name: '🐍 Setup Python'
-      uses: actions/setup-python@v2
-      with:
-        python-version: '3.10'
-
-    - name: '🐍 Install dependencies'
-      run: |
-        pip install -U pip --progress-bar off
-        pip install -U virtualenv tox --progress-bar off
-
-    - name: '⚙️ Install GHDL'
-      if: endsWith( matrix.task, '-ghdl' )
-      shell: bash
-      run: |
-        curl -fsSL -o ghdl.zip https://github.com/ghdl/ghdl/releases/download/v0.37/ghdl-0.37-mingw32-mcode.zip
-        7z x ghdl.zip "-o../ghdl" -y
-        mv ../ghdl/GHDL/0.37-mingw32-mcode/ ../ghdl-v0.37
-        rm -rf ../ghdl ghdl.zip
-
-    - name: '🚧 Run job'
-      shell: bash
-      run: |
-        export PATH=$PATH:$(pwd)/../ghdl-v0.37/bin
-        tox -e py${{ matrix.task }} -- --color=yes
-
-#
 # Deploy to PyPI
 #
 
   deploy:
     runs-on: ubuntu-latest
-    needs: [ fmt, lin, docker, win-setup, win-tagged ]
+    needs: [ fmt, lin, docker, win ]
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
     name: '🚀 Deploy'
     steps:


### PR DESCRIPTION
When bumping OSVVM to 2022.01, 2022.02, 2022.03 or 2022.04, the CI jobs using GHDL v0.37 are failing: https://github.com/VUnit/vunit/actions/runs/2309887908. All other jobs do pass. Hence, I believe it is some bug which was fixed in recent versions of GHDL.

v0.37 is several years old, and there are no more recent ZIP releases of GHDL. Therefore, this PR removes jobs 'win-tagged' from the CI workflow. We do still run tests on Windows using MSYS2 and [ghdl/setup-ghdl-ci](https://github.com/ghdl/setup-ghdl-ci).