### PR TITLE
Fix the example with json4vhdl and invalid xml characters

### DIFF
--- a/examples/vhdl/json4vhdl/src/test/tb_json_gens.vhd
+++ b/examples/vhdl/json4vhdl/src/test/tb_json_gens.vhd
@@ -26,7 +26,7 @@ begin
       constant img_arr : integer_vector := jsonGetIntegerArray(JSONContent, "Image");
     begin
       -- Content extracted from the JSON
-      info("JSONContent: " & lf & JSONContent.Content);
+      info("JSONContent: " & lf & jsonGetContent(JSONContent));
 
       -- Integer array, extracted by function jsonGetIntegerArray with data from the JSON
       for i in 0 to img_arr'length-1 loop

--- a/examples/vhdl/json4vhdl/src/test/tb_json_gens.vhd
+++ b/examples/vhdl/json4vhdl/src/test/tb_json_gens.vhd
@@ -21,12 +21,12 @@ architecture tb of tb_json_gens is
 begin
   main: process
 
-    procedure run_test(JSONContent : T_JSON) is
+    procedure run_test(JSONContext : T_JSON) is
       -- get array of integers from JSON content
-      constant img_arr : integer_vector := jsonGetIntegerArray(JSONContent, "Image");
+      constant img_arr : integer_vector := jsonGetIntegerArray(JSONContext, "Image");
     begin
       -- Content extracted from the JSON
-      info("JSONContent: " & lf & jsonGetContent(JSONContent));
+      info("JSONContent: " & lf & jsonGetContent(JSONContext));
 
       -- Integer array, extracted by function jsonGetIntegerArray with data from the JSON
       for i in 0 to img_arr'length-1 loop
@@ -34,14 +34,14 @@ begin
       end loop;
 
       -- Image dimensions as strings, get from the content from the JSON file
-      info("Image: " & jsonGetString(JSONContent, "Image/0") & ',' & jsonGetString(JSONContent, "Image/1"));
+      info("Image: " & jsonGetString(JSONContext, "Image/0") & ',' & jsonGetString(JSONContext, "Image/1"));
 
       -- Some other content, deep in the JSON
-      info("Platform/ML505/FPGA: " & jsonGetString(JSONContent, "Platform/ML505/FPGA"));
-      info("Platform/KC705/IIC/0/Devices/0/Name: " & jsonGetString(JSONContent, "Platform/KC705/IIC/0/Devices/0/Name"));
+      info("Platform/ML505/FPGA: " & jsonGetString(JSONContext, "Platform/ML505/FPGA"));
+      info("Platform/KC705/IIC/0/Devices/0/Name: " & jsonGetString(JSONContext, "Platform/KC705/IIC/0/Devices/0/Name"));
     end procedure;
 
-    procedure run_record_test(JSONContent : T_JSON) is
+    procedure run_record_test(JSONContext : T_JSON) is
       type img_t is record
         image_width     : positive;
         image_height    : positive;
@@ -50,29 +50,29 @@ begin
 
       -- fill img_t with content extracted from a JSON input
       constant img : img_t := (
-        image_width     => positive'value( jsonGetString(JSONContent, "Image/0") ),
-        image_height    => positive'value( jsonGetString(JSONContent, "Image/1") ),
-        dump_debug_data => jsonGetBoolean(JSONContent, "dump_debug_data")
+        image_width     => positive'value( jsonGetString(JSONContext, "Image/0") ),
+        image_height    => positive'value( jsonGetString(JSONContext, "Image/1") ),
+        dump_debug_data => jsonGetBoolean(JSONContext, "dump_debug_data")
       );
     begin
       -- Image dimensions in a record, filled with data from the stringified generic
       info("Image: " & integer'image(img.image_width) & ',' & integer'image(img.image_height));
     end procedure;
 
-    variable JSONContent : T_JSON;
+    variable JSONContext : T_JSON;
 
   begin
     test_runner_setup(runner, runner_cfg);
     while test_suite loop
       info("RAW generic: " & tb_cfg);
       if run("stringified JSON generic") then
-        JSONContent := jsonLoad(tb_cfg);
-        run_test(JSONContent);
-        run_record_test(JSONContent);
+        JSONContext := jsonLoad(tb_cfg);
+        run_test(JSONContext);
+        run_record_test(JSONContext);
       elsif run("b16encoded stringified JSON generic") then
-        JSONContent := jsonLoad(tb_cfg);
-        run_test(JSONContent);
-        run_record_test(JSONContent);
+        JSONContext := jsonLoad(tb_cfg);
+        run_test(JSONContext);
+        run_record_test(JSONContext);
       elsif run("JSON file path generic") then
         run_test(jsonLoad(tb_path & tb_cfg));
       elsif run("b16encoded JSON file path generic") then


### PR DESCRIPTION
Correct how JSON content is printed in the example (see #356)
Do not close the issue, we have to open a new one to track the way to handle log files with ESC characters 👍 