### PR TITLE
Use Python 3.10 in images.

### DIFF
--- a/.github/images.sh
+++ b/.github/images.sh
@@ -4,7 +4,7 @@
 set -e
 
 docker build \
-  --build-arg IMAGE="python:3-slim-bullseye" \
+  --build-arg IMAGE="python:3.10-slim-bullseye" \
   --build-arg LLVM_VER=9 \
   --build-arg GNAT_VER=9 \
   --target vunit \


### PR DESCRIPTION
Intention is to move to Python 3.11. The purpose of this is to quickly make build go green.