### PR TITLE
Replace inspect method removed in Python 3.11

### DIFF
--- a/vunit/configuration.py
+++ b/vunit/configuration.py
@@ -145,7 +145,7 @@ class Configuration(object):  # pylint: disable=too-many-instance-attributes
         if self.pre_config is None:
             return True
 
-        args = inspect.getargspec(self.pre_config).args  # pylint: disable=deprecated-method
+        args = inspect.getfullargspec(self.pre_config).args
 
         kwargs = {
             "output_path": output_path,
@@ -165,7 +165,7 @@ class Configuration(object):  # pylint: disable=too-many-instance-attributes
         if self.post_check is None:
             return True
 
-        args = inspect.getargspec(self.post_check).args  # pylint: disable=deprecated-method
+        args = inspect.getfullargspec(self.post_check).args
 
         kwargs = {"output_path": lambda: output_path, "output": read_output}
 


### PR DESCRIPTION
`getargspec` was removed in 3.11 (after a long deprecation period) and can be replaced with `getfullargspec`.