### PR TITLE
Fix some Vivado issues (SystemVerilog support, space in file name, environment variable)

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -30,6 +30,7 @@ needs_sphinx = "3.0"
 
 extensions = [
     "sphinx.ext.autodoc",
+    "sphinx.ext.autosummary",
     "sphinx.ext.extlinks",
     "sphinx.ext.intersphinx",
     "sphinx.ext.todo",
@@ -113,7 +114,7 @@ htmlhelp_basename = "VUnitDoc"
 # -- InterSphinx --------------------------------------------------------------
 
 intersphinx_mapping = {
-    "python": ("https://docs.python.org/3.8/", None),
+    "python": ("https://docs.python.org/3/", None),
     "pytest": ("https://docs.pytest.org/en/latest/", None),
     "osvb": ("https://umarcor.github.io/osvb", None),
 }

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -49,6 +49,7 @@ often"* approach through automation. :ref:`Read more <about>`
    py/ui
    hdl_libraries
    examples
+   tool_integration/index
 
 .. toctree::
    :caption: Continuous Integration

--- a/docs/tool_integration/index.rst
+++ b/docs/tool_integration/index.rst
@@ -1,0 +1,11 @@
+.. _tool_integration:
+
+Tool Integration
+================
+There are additional integration support available for selected tools.
+
+Vivado Integration
+==================
+
+.. automodule:: vunit.vivado
+   :members:

--- a/vunit/vivado/__init__.py
+++ b/vunit/vivado/__init__.py
@@ -13,3 +13,5 @@ from vunit.vivado.vivado import (
     add_from_compile_order_file,
     create_compile_order_file,
 )
+
+__all__ = ["run_vivado", "add_from_compile_order_file", "create_compile_order_file"]


### PR DESCRIPTION
Closes #686
Closes #796 
Closes #811

Not sure where it can be tested. Didn't really find a test file for vivado.py?

The vivado module is not in the documentation? So not really clear where I should document the environment variable. (But I can improve the documentation for `run_vivado`.