### PR TITLE
Enable VHDL-2019 for Active-HDL.

### DIFF
--- a/docs/logging/user_guide.rst
+++ b/docs/logging/user_guide.rst
@@ -305,7 +305,7 @@ Log Location
 
 For simulators supporting VHDL-2019 VUnit adds file name
 and line number location information to all log entries. Currently
-only Riviera-PRO supports VHDL-2019 and it restricts the feature
+only Riviera-PRO and Active-HDL supports VHDL-2019 and they restrict the feature
 to **debug compiled files**. You can compile all files or just the ones
 using logging. For example,
 

--- a/tests/unit/test_activehdl_interface.py
+++ b/tests/unit/test_activehdl_interface.py
@@ -48,12 +48,12 @@ class TestActiveHDLInterface(unittest.TestCase):
 
     @mock.patch("vunit.sim_if.check_output", autospec=True, return_value="")
     @mock.patch("vunit.sim_if.activehdl.Process", autospec=True)
-    def test_compile_project_vhdl_2008(self, process, check_output):
+    def _test_compile_project_vhdl(self, standard, process, check_output):
         simif = ActiveHDLInterface(prefix="prefix", output_path=self.output_path)
         project = Project()
         project.add_library("lib", "lib_path")
         write_file("file.vhd", "")
-        project.add_source_file("file.vhd", "lib", file_type="vhdl", vhdl_standard=VHDL.standard("2008"))
+        project.add_source_file("file.vhd", "lib", file_type="vhdl", vhdl_standard=VHDL.standard(standard))
         simif.compile_project(project)
         process.assert_any_call(
             [str(Path("prefix") / "vlib"), "lib", "lib_path"],
@@ -71,7 +71,7 @@ class TestActiveHDLInterface(unittest.TestCase):
                 "-quiet",
                 "-j",
                 self.output_path,
-                "-2008",
+                f"-{standard}",
                 "-work",
                 "lib",
                 "file.vhd",
@@ -79,71 +79,17 @@ class TestActiveHDLInterface(unittest.TestCase):
             env=simif.get_env(),
         )
 
-    @mock.patch("vunit.sim_if.check_output", autospec=True, return_value="")
-    @mock.patch("vunit.sim_if.activehdl.Process", autospec=True)
-    def test_compile_project_vhdl_2002(self, process, check_output):
-        simif = ActiveHDLInterface(prefix="prefix", output_path=self.output_path)
-        project = Project()
-        project.add_library("lib", "lib_path")
-        write_file("file.vhd", "")
-        project.add_source_file("file.vhd", "lib", file_type="vhdl", vhdl_standard=VHDL.standard("2002"))
-        simif.compile_project(project)
-        process.assert_any_call(
-            [str(Path("prefix") / "vlib"), "lib", "lib_path"],
-            cwd=self.output_path,
-            env=simif.get_env(),
-        )
-        process.assert_called_with(
-            [str(Path("prefix") / "vmap"), "lib", "lib_path"],
-            cwd=self.output_path,
-            env=simif.get_env(),
-        )
-        check_output.assert_called_once_with(
-            [
-                str(Path("prefix") / "vcom"),
-                "-quiet",
-                "-j",
-                self.output_path,
-                "-2002",
-                "-work",
-                "lib",
-                "file.vhd",
-            ],
-            env=simif.get_env(),
-        )
+    def test_compile_project_vhdl_2019(self):
+        self._test_compile_project_vhdl("2019")
 
-    @mock.patch("vunit.sim_if.check_output", autospec=True, return_value="")
-    @mock.patch("vunit.sim_if.activehdl.Process", autospec=True)
-    def test_compile_project_vhdl_93(self, process, check_output):
-        simif = ActiveHDLInterface(prefix="prefix", output_path=self.output_path)
-        project = Project()
-        project.add_library("lib", "lib_path")
-        write_file("file.vhd", "")
-        project.add_source_file("file.vhd", "lib", file_type="vhdl", vhdl_standard=VHDL.standard("93"))
-        simif.compile_project(project)
-        process.assert_any_call(
-            [str(Path("prefix") / "vlib"), "lib", "lib_path"],
-            cwd=self.output_path,
-            env=simif.get_env(),
-        )
-        process.assert_called_with(
-            [str(Path("prefix") / "vmap"), "lib", "lib_path"],
-            cwd=self.output_path,
-            env=simif.get_env(),
-        )
-        check_output.assert_called_once_with(
-            [
-                str(Path("prefix") / "vcom"),
-                "-quiet",
-                "-j",
-                self.output_path,
-                "-93",
-                "-work",
-                "lib",
-                "file.vhd",
-            ],
-            env=simif.get_env(),
-        )
+    def test_compile_project_vhdl_2008(self):
+        self._test_compile_project_vhdl("2008")
+
+    def test_compile_project_vhdl_2002(self):
+        self._test_compile_project_vhdl("2002")
+
+    def test_compile_project_vhdl_93(self):
+        self._test_compile_project_vhdl("93")
 
     @mock.patch("vunit.sim_if.check_output", autospec=True, return_value="")
     @mock.patch("vunit.sim_if.activehdl.Process", autospec=True)

--- a/vunit/sim_if/activehdl.py
+++ b/vunit/sim_if/activehdl.py
@@ -15,7 +15,6 @@ import re
 import logging
 from ..exceptions import CompileError
 from ..ostools import Process, write_file, file_exists, renew_path
-from ..vhdl_standard import VHDL
 from ..test.suites import get_result_file_name
 from . import SimulatorInterface, ListOfStringOption, StringOption
 from .vsim_simulator_mixin import get_is_test_suite_done_tcl, fix_path
@@ -109,10 +108,7 @@ class ActiveHDLInterface(SimulatorInterface):
         """
         Convert standard to format of Active-HDL command line flag
         """
-        if vhdl_standard <= VHDL.STD_2008:
-            return f"-{vhdl_standard!s}"
-
-        raise ValueError(f"Invalid VHDL standard {vhdl_standard!s}")
+        return f"-{vhdl_standard!s}"
 
     def compile_vhdl_file_command(self, source_file):
         """


### PR DESCRIPTION
As a consequence the location of a log call will be included in the log entry.