### PR TITLE
Patch questa 2022.4 2

### DIFF
--- a/vunit/vhdl/verification_components/src/uart_master.vhd
+++ b/vunit/vhdl/verification_components/src/uart_master.vhd
@@ -40,7 +40,7 @@ begin
     begin
       debug("Sending " & to_string(data));
       send_bit(not uart.p_idle_state);
-      for i in 0 to data'length-1 loop
+      for i in data'length-1 downto 0 loop
         send_bit(data(i));
       end loop;
       send_bit(uart.p_idle_state);

--- a/vunit/vhdl/verification_components/src/uart_pkg.vhd
+++ b/vunit/vhdl/verification_components/src/uart_pkg.vhd
@@ -19,6 +19,7 @@ package uart_pkg is
     p_actor : actor_t;
     p_baud_rate : natural;
     p_idle_state : std_logic;
+    p_swap_bit_order : boolean;
   end record;
 
   type uart_slave_t is record
@@ -40,8 +41,10 @@ package uart_pkg is
   constant default_baud_rate : natural := 115200;
   constant default_idle_state : std_logic := '1';
   constant default_data_length : positive := 8;
+  constant default_swap_bit_order : boolean := false;
   impure function new_uart_master(initial_baud_rate : natural := default_baud_rate;
-                                  idle_state : std_logic := default_idle_state) return uart_master_t;
+                                  idle_state : std_logic := default_idle_state;
+                                  swap_bit_order : boolean := default_swap_bit_order) return uart_master_t;
   impure function new_uart_slave(initial_baud_rate : natural := default_baud_rate;
                                  idle_state : std_logic := default_idle_state;
                                  data_length : positive := default_data_length) return uart_slave_t;
@@ -57,11 +60,13 @@ end package;
 package body uart_pkg is
 
   impure function new_uart_master(initial_baud_rate : natural := default_baud_rate;
-                                  idle_state : std_logic := default_idle_state) return uart_master_t is
+                                  idle_state : std_logic := default_idle_state;
+                                  swap_bit_order : boolean := default_swap_bit_order) return uart_master_t is
   begin
     return (p_actor => new_actor,
             p_baud_rate => initial_baud_rate,
-            p_idle_state => idle_state);
+            p_idle_state => idle_state,
+            p_swap_bit_order => swap_bit_order);
   end;
 
   impure function new_uart_slave(initial_baud_rate : natural := default_baud_rate;


### PR DESCRIPTION
Workaround for issue #889.  It adds a swap_bit_order argument to the uart_master_t record used to initialize the uart_master VC.

This allows to use:
```vhdl
  constant master_uart_a   : uart_master_t   := new_uart_master(swap_bit_order => true);
```
in a testbench that runs with questasim 2022.2_4.  Default (false) is the old behaviour.

Remaining issue: the example testcase tb_uart_lib.tb_uart_rx.test_receives_one_byte' would still fail if run with questasim 2022.4_2 because tb_uart_rx is unchanged.