### PR TITLE
Allow recent versions of GCC to be recognized

### DIFF
--- a/vunit/sim_if/ghdl.py
+++ b/vunit/sim_if/ghdl.py
@@ -128,7 +128,7 @@ class GHDLInterface(SimulatorInterface):  # pylint: disable=too-many-instance-at
         mapping = {
             r"mcode code generator": "mcode",
             r"llvm (\d+\.\d+\.\d+ )?code generator": "llvm",
-            r"GCC back-end code generator": "gcc",
+            r"GCC ((\d+\.\d+\.\d+)|back-end) code generator": "gcc",
         }
         output = cls._get_version_output(prefix)
         for name, backend in mapping.items():


### PR DESCRIPTION
When using VUnit with i.e. GCC 12.0.0 the compiler does not get recognized because VUnit tries to match "GCC back-end code generator" exactly. Atleast with GHDL 3.0.0 with GCC 12.0.0 will produce the following output:
```
GHDL 3.0.0-dev (tarball) [Dunoon edition]
 Compiled with GNAT Version: 12.1.0
 GCC 12.2.1 code generator```

I have updated the regular expression to fix this issue but remaining the old behaviour at the same time. 