### PR TITLE
ci: add workflow_dispatch

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -2,6 +2,7 @@ name: 'coverage'
 
 on:
   push:
+  workflow_dispatch:
   schedule:
     - cron: '0 0 * * 5'
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,6 +1,9 @@
 name: 'docs'
 
-on: [ push, pull_request ]
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
 
 env:
   # https://github.com/tox-dev/tox/issues/1468

--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -5,6 +5,7 @@ on:
     paths:
       - '.github/workflows/images.yml'
       - '.github/images.sh'
+  workflow_dispatch:
   schedule:
     - cron: '0 0 * * 5'
 

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -3,6 +3,7 @@ name: 'push'
 on:
   push:
   pull_request:
+  workflow_dispatch:
   schedule:
     - cron: '0 0 * * 5'
 


### PR DESCRIPTION
This PR adds trigger condition `workflow_dispatch` to the CI workflows in order to allow triggering them manually. See https://github.blog/changelog/2020-07-06-github-actions-manual-triggers-with-workflow_dispatch/.

This allows to, for instance, use the web interface to trigger branch nvc and test https://github.com/VUnit/vunit/pull/904#issuecomment-1455073983 without force-pushing or updating the branch.