### PR TITLE
ci: run windows tests with py310

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -104,10 +104,10 @@ jobs:
       fail-fast: false
       matrix:
         task: [
-          39-acceptance-ghdl,
-          39-vcomponents-ghdl,
-          39-lint,
-          39-unit,
+          310-acceptance-ghdl,
+          310-vcomponents-ghdl,
+          310-lint,
+          310-unit,
         ]
     name: '🟦 Windows · nightly · ${{ matrix.task }}'
     defaults:


### PR DESCRIPTION
The current default Python version on MSYS2 is 3.10, but we are still using `py39` in the CI jobs. This PR updates them to use `py310`.