### PR TITLE
Create release notes for v4.7.0 using towncrier

### DIFF
--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -250,15 +250,16 @@ Make sure to use full sentences in the **past or present tense** and use punctua
 Each file should be named like ``<issue #>.<type>.rst``, where ``<issue #>`` is the
 GitHub issue or pull request number, and ``<type>`` is one of:
 
-* ``breaking``: a change which may break existing functionality, such as feature removal
-  or behavior change
-* ``bugfix``: fixes a bug
-* ``change``: backwards compatible features or improvements
-* ``deprecation``: feature deprecation
-* ``misc``: a ticket was closed, but it is not necessarily important for the user
+* ``breaking``:may break existing functionality; such as feature removal or behavior change.
+* ``bugfix``: fixes a bug.
+* ``doc``: related to the documentation.
+* ``deprecation``: feature deprecation.
+* ``feature``: backwards compatible feature addition or improvement.
+* ``misc``: a ticket was closed, but it is not necessarily important for the user.
 
 For example: ``123.feature.rst``, ``456.bugfix.rst``.
 
-``towncrier`` preserves multiple paragraphs and formatting
-(code blocks, lists, and so on), but for entries other than features, it is usually
-better to stick to a single paragraph to keep it concise.
+.. HINT::
+  ``towncrier`` preserves multiple paragraphs and formatting
+  (code blocks, lists, and so on), but for entries other than features, it is usually better to stick
+  to a single paragraph to keep it concise.

--- a/docs/installing.rst
+++ b/docs/installing.rst
@@ -80,7 +80,7 @@ VHDL or SystemVerilog
 Using the Python Package Manager
 ================================
 
-The recommended way to get VUnit is to install the :ref:`latest stable release <latest_release>` via `pip <https://pip.pypa.io/en/stable/>`__:
+The recommended way to get VUnit is to install the :ref:`latest stable release <release:latest>` via `pip <https://pip.pypa.io/en/stable/>`__:
 
 .. code-block:: console
 

--- a/docs/news.d/+2896a1e3.feature.rst
+++ b/docs/news.d/+2896a1e3.feature.rst
@@ -1,0 +1,1 @@
+Introduce new class ``LibraryList`` and add method to get list of libraries from VUnit object.

--- a/docs/news.d/+758b9e47.deprecation.rst
+++ b/docs/news.d/+758b9e47.deprecation.rst
@@ -1,0 +1,1 @@
+[JSON-for-VHDL] Bump to ``95e848b8``.

--- a/docs/news.d/+84eedd22.misc.rst
+++ b/docs/news.d/+84eedd22.misc.rst
@@ -1,0 +1,1 @@
+Add utilities to create HTML from code snippets and VUnit logs.

--- a/docs/news.d/+953d1904.doc.rst
+++ b/docs/news.d/+953d1904.doc.rst
@@ -1,0 +1,1 @@
+Add blog post on VUnit's relation to other frameworks.

--- a/docs/news.d/+9775342d.doc.rst
+++ b/docs/news.d/+9775342d.doc.rst
@@ -1,0 +1,1 @@
+Add blog post on FPGA World 2022 in Stockholm.

--- a/docs/news.d/+cba27423.deprecation.rst
+++ b/docs/news.d/+cba27423.deprecation.rst
@@ -1,0 +1,1 @@
+Python 3.6 was EOL in Dec 2021; use Python 3.7 as the minimum tested version.

--- a/docs/news.d/356.bugfix.rst
+++ b/docs/news.d/356.bugfix.rst
@@ -1,0 +1,1 @@
+[JSON-for-VHDL] Fix invalid XML characters in the example.

--- a/docs/news.d/44.feature.rst
+++ b/docs/news.d/44.feature.rst
@@ -1,0 +1,1 @@
+Add NVC simulator support.

--- a/docs/news.d/559.deprecation.rst
+++ b/docs/news.d/559.deprecation.rst
@@ -1,0 +1,2 @@
+Add ``compile_builtins`` deprecation warning.
+Use ``add_vhdl_builtins`` and/or ``add_verilog_builtins`` instead.

--- a/docs/news.d/573.bugfix.rst
+++ b/docs/news.d/573.bugfix.rst
@@ -1,0 +1,1 @@
+Fix AXI Stream slave back to back transfers.

--- a/docs/news.d/576.doc.rst
+++ b/docs/news.d/576.doc.rst
@@ -1,0 +1,1 @@
+Add timing diagrams to the Check Library user guide.

--- a/docs/news.d/621.bugfix.rst
+++ b/docs/news.d/621.bugfix.rst
@@ -1,0 +1,1 @@
+[Riviera-PRO] Fix for RUNTIME_0232 and RUNTIME_022 messages.

--- a/docs/news.d/642.bugfix.rst
+++ b/docs/news.d/642.bugfix.rst
@@ -1,0 +1,1 @@
+Fix delta cycle race conditions.

--- a/docs/news.d/754.deprecation.rst
+++ b/docs/news.d/754.deprecation.rst
@@ -1,0 +1,1 @@
+[OSVVM] Bump to 2022.04.

--- a/docs/news.d/757.deprecation.rst
+++ b/docs/news.d/757.deprecation.rst
@@ -1,0 +1,2 @@
+Add ``compile_builtins`` deprecation warning.
+Use ``add_vhdl_builtins`` and/or ``add_verilog_builtins`` instead.

--- a/docs/news.d/757.doc.rst
+++ b/docs/news.d/757.doc.rst
@@ -1,0 +1,1 @@
+Add ``add_vhdl_builtins`` and ``add_verilog_builtins``.

--- a/docs/news.d/767.feature.rst
+++ b/docs/news.d/767.feature.rst
@@ -1,0 +1,1 @@
+Skip addition of built-in dependencies (OSVVM and/or JSON-for-VHDL) if the library is added previously.

--- a/docs/news.d/768.bugfix.rst
+++ b/docs/news.d/768.bugfix.rst
@@ -1,0 +1,1 @@
+Skip non-generic OSVVM packages when the simulator supports generics.

--- a/docs/news.d/769.bugfix.rst
+++ b/docs/news.d/769.bugfix.rst
@@ -1,0 +1,1 @@
+Skip non-generic OSVVM packages when the simulator supports generics.

--- a/docs/news.d/771.feature.rst
+++ b/docs/news.d/771.feature.rst
@@ -1,0 +1,1 @@
+Skip addition of built-in dependencies (OSVVM and/or JSON-for-VHDL) if the library is added previously.

--- a/docs/news.d/773.bugfix.rst
+++ b/docs/news.d/773.bugfix.rst
@@ -1,0 +1,1 @@
+Fix location preprocessor casing bug.

--- a/docs/news.d/774.bugfix.rst
+++ b/docs/news.d/774.bugfix.rst
@@ -1,0 +1,1 @@
+Fix location preprocessor casing bug.

--- a/docs/news.d/777.deprecation.rst
+++ b/docs/news.d/777.deprecation.rst
@@ -1,0 +1,2 @@
+Add ``compile_builtins`` deprecation warning.
+Use ``add_vhdl_builtins`` and/or ``add_verilog_builtins`` instead.

--- a/docs/news.d/778.deprecation.rst
+++ b/docs/news.d/778.deprecation.rst
@@ -1,0 +1,2 @@
+Add ``compile_builtins`` deprecation warning.
+Use ``add_vhdl_builtins`` and/or ``add_verilog_builtins`` instead.

--- a/docs/news.d/779.doc.rst
+++ b/docs/news.d/779.doc.rst
@@ -1,0 +1,1 @@
+Add section Overview, including a diagram.

--- a/docs/news.d/780.deprecation.rst
+++ b/docs/news.d/780.deprecation.rst
@@ -1,0 +1,1 @@
+[OSVVM] Bump to 2022.04.

--- a/docs/news.d/781.bugfix.rst
+++ b/docs/news.d/781.bugfix.rst
@@ -1,0 +1,1 @@
+Support detecting and failing on ambiguous direct entity instantiations.

--- a/docs/news.d/782.bugfix.rst
+++ b/docs/news.d/782.bugfix.rst
@@ -1,0 +1,1 @@
+[Vivado] Add flag ``fail_on_non_hdl_files``.

--- a/docs/news.d/786.bugfix.rst
+++ b/docs/news.d/786.bugfix.rst
@@ -1,0 +1,1 @@
+[Vivado] Add flag ``fail_on_non_hdl_files``.

--- a/docs/news.d/790.deprecation.rst
+++ b/docs/news.d/790.deprecation.rst
@@ -1,0 +1,1 @@
+[OSVVM] Bump to 2022.04.

--- a/docs/news.d/792.bugfix.rst
+++ b/docs/news.d/792.bugfix.rst
@@ -1,0 +1,1 @@
+Fix parsing of port type starting with signal.

--- a/docs/news.d/794.bugfix.rst
+++ b/docs/news.d/794.bugfix.rst
@@ -1,0 +1,1 @@
+Fix false pass.

--- a/docs/news.d/797.bugfix.rst
+++ b/docs/news.d/797.bugfix.rst
@@ -1,0 +1,1 @@
+Fix axi_lite_master wait behaviour if idle.

--- a/docs/news.d/801.doc.rst
+++ b/docs/news.d/801.doc.rst
@@ -1,0 +1,1 @@
+Improve documentation for ``pre_config`` and ``post_check``.

--- a/docs/news.d/810.doc.rst
+++ b/docs/news.d/810.doc.rst
@@ -1,0 +1,1 @@
+Improve help of CLI option ``--clean``.

--- a/docs/news.d/813.bugfix.rst
+++ b/docs/news.d/813.bugfix.rst
@@ -1,0 +1,1 @@
+Fix delta cycle race conditions.

--- a/docs/news.d/815.feature.rst
+++ b/docs/news.d/815.feature.rst
@@ -1,0 +1,1 @@
+Add method to get list of libraries from VUnit object.

--- a/docs/news.d/816.doc.rst
+++ b/docs/news.d/816.doc.rst
@@ -1,0 +1,1 @@
+ Added LibraryList.

--- a/docs/news.d/819.bugfix.rst
+++ b/docs/news.d/819.bugfix.rst
@@ -1,0 +1,1 @@
+Handle PermissionError while listing available simulators.

--- a/docs/news.d/820.bugfix.rst
+++ b/docs/news.d/820.bugfix.rst
@@ -1,0 +1,1 @@
+Handle PermissionError while listing available simulators.

--- a/docs/news.d/821.doc.rst
+++ b/docs/news.d/821.doc.rst
@@ -1,0 +1,1 @@
+Fix typos.

--- a/docs/news.d/823.doc.rst
+++ b/docs/news.d/823.doc.rst
@@ -1,0 +1,1 @@
+Add timing diagrams to the Check Library user guide.

--- a/docs/news.d/825.bugfix.rst
+++ b/docs/news.d/825.bugfix.rst
@@ -1,0 +1,1 @@
+[Riviera-PRO] Fix for RUNTIME_0232 and RUNTIME_022 messages.

--- a/docs/news.d/826.bugfix.rst
+++ b/docs/news.d/826.bugfix.rst
@@ -1,0 +1,1 @@
+Fix parsing of port type starting with signal.

--- a/docs/news.d/827.deprecation.rst
+++ b/docs/news.d/827.deprecation.rst
@@ -1,0 +1,1 @@
+[OSVVM] Bump to 2022.04.

--- a/docs/news.d/830.feature.rst
+++ b/docs/news.d/830.feature.rst
@@ -1,0 +1,1 @@
+Make ``dict_t`` type generic.

--- a/docs/news.d/832.doc.rst
+++ b/docs/news.d/832.doc.rst
@@ -1,0 +1,1 @@
+Fix typos.

--- a/docs/news.d/834.doc.rst
+++ b/docs/news.d/834.doc.rst
@@ -1,0 +1,1 @@
+Clarify that ``VUNIT_SIMULATOR`` is set to ``modelsim`` when using Questa.

--- a/docs/news.d/835.feature.rst
+++ b/docs/news.d/835.feature.rst
@@ -1,0 +1,1 @@
+Make ``dict_t`` type generic.

--- a/docs/news.d/838.bugfix.rst
+++ b/docs/news.d/838.bugfix.rst
@@ -1,0 +1,1 @@
+[ModelSim/Questa] Workaround for compilation bug.

--- a/docs/news.d/840.bugfix.rst
+++ b/docs/news.d/840.bugfix.rst
@@ -1,0 +1,1 @@
+[ModelSim/Questa] Workaround for compilation bug.

--- a/docs/news.d/845.bugfix.rst
+++ b/docs/news.d/845.bugfix.rst
@@ -1,0 +1,1 @@
+[JSON-for-VHDL] Fix invalid XML characters in the example.

--- a/docs/news.d/849.doc.rst
+++ b/docs/news.d/849.doc.rst
@@ -1,0 +1,1 @@
+Improve documentation for ``pre_config`` and ``post_check``.

--- a/docs/news.d/850.doc.rst
+++ b/docs/news.d/850.doc.rst
@@ -1,0 +1,1 @@
+Clarify that ``VUNIT_SIMULATOR`` is set to ``modelsim`` when using Questa.

--- a/docs/news.d/852.bugfix.rst
+++ b/docs/news.d/852.bugfix.rst
@@ -1,0 +1,1 @@
+Support generics with explicit constant declaration.

--- a/docs/news.d/854.bugfix.rst
+++ b/docs/news.d/854.bugfix.rst
@@ -1,0 +1,1 @@
+Support generics with explicit constant declaration.

--- a/docs/news.d/855.doc.rst
+++ b/docs/news.d/855.doc.rst
@@ -1,0 +1,1 @@
+Improve help of CLI option ``--clean``.

--- a/docs/news.d/856.bugfix.rst
+++ b/docs/news.d/856.bugfix.rst
@@ -1,0 +1,1 @@
+Fix axi_lite_master wait behaviour if idle.

--- a/docs/news.d/858.bugfix.rst
+++ b/docs/news.d/858.bugfix.rst
@@ -1,0 +1,1 @@
+Fix AXI Stream slave back to back transfers.

--- a/docs/news.d/868.misc.rst
+++ b/docs/news.d/868.misc.rst
@@ -1,0 +1,1 @@
+Replace ``inspect.getargspec`` method, removed in Python 3.11.

--- a/docs/news.d/870.misc.rst
+++ b/docs/news.d/870.misc.rst
@@ -1,0 +1,1 @@
+Test support on Python 3.11.

--- a/docs/news.d/872.feature.rst
+++ b/docs/news.d/872.feature.rst
@@ -1,0 +1,1 @@
+Add support for byte enable to Avalon slave.

--- a/docs/news.d/874.doc.rst
+++ b/docs/news.d/874.doc.rst
@@ -1,0 +1,1 @@
+Improve documentation of ``check_enabled``.

--- a/docs/news.d/875.feature.rst
+++ b/docs/news.d/875.feature.rst
@@ -1,0 +1,1 @@
+[Active-HDL] Enable VHDL-2019.

--- a/docs/news.d/887.doc.rst
+++ b/docs/news.d/887.doc.rst
@@ -1,0 +1,1 @@
+Added Identity package user guide.

--- a/docs/news.d/887.feature.rst
+++ b/docs/news.d/887.feature.rst
@@ -1,0 +1,1 @@
+Add Identity package.

--- a/docs/news.d/888.doc.rst
+++ b/docs/news.d/888.doc.rst
@@ -1,0 +1,1 @@
+Added Identity package user guide.

--- a/docs/news.d/898.bugfix.rst
+++ b/docs/news.d/898.bugfix.rst
@@ -1,0 +1,1 @@
+Detect GHDL backend with newer GCC|LLVM.

--- a/docs/news.d/901.bugfix.rst
+++ b/docs/news.d/901.bugfix.rst
@@ -1,0 +1,1 @@
+Detect GHDL backend with newer GCC|LLVM.

--- a/docs/news.d/903.feature.rst
+++ b/docs/news.d/903.feature.rst
@@ -1,0 +1,1 @@
+[VHDL-2019] Support interface lists with trailing comma.

--- a/docs/news.d/904.feature.rst
+++ b/docs/news.d/904.feature.rst
@@ -1,0 +1,1 @@
+Add NVC simulator support.

--- a/docs/news.d/908.feature.rst
+++ b/docs/news.d/908.feature.rst
@@ -1,0 +1,1 @@
+[VHDL-2019] Add method ``supports_vhdl_call_paths`` to the simulator interface.

--- a/docs/news.d/911.misc.rst
+++ b/docs/news.d/911.misc.rst
@@ -1,0 +1,1 @@
+[CI] Add workflow_dispatch.

--- a/docs/news.d/917.misc.rst
+++ b/docs/news.d/917.misc.rst
@@ -1,0 +1,1 @@
+[CI] Add NVC jobs.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,13 +32,18 @@ underlines = ["-", "~"]
     showcontent = true
 
     [[tool.towncrier.type]]
-    directory = "change"
-    name = "Changes"
+    directory = "deprecation"
+    name = "Deprecations"
     showcontent = true
 
     [[tool.towncrier.type]]
-    directory = "deprecation"
-    name = "Deprecations"
+    directory = "doc"
+    name = "Documentation"
+    showcontent = true
+
+    [[tool.towncrier.type]]
+    directory = "feature"
+    name = "Features"
     showcontent = true
 
     [[tool.towncrier.type]]

--- a/tools/create_release_notes.py
+++ b/tools/create_release_notes.py
@@ -50,7 +50,9 @@ def create_release_notes():
             is_last = idx == len(releases) - 1
 
             if release.is_latest:
-                fptr.write(".. _latest_release:\n\n")
+                fptr.write(".. _release:latest:\n\n")
+
+            fptr.write(f".. _release:{release.name}:\n\n")
 
             title = f":vunit_commit:`{release.name!s} <{release.tag!s}>` - {release.date.strftime('%Y-%m-%d')!s}"
             if release.is_latest:
@@ -66,9 +68,7 @@ def create_release_notes():
                     f"<https://github.com/VUnit/vunit/compare/{releases[idx + 1].tag!s}...{release.tag!s}>`__"
                 )
 
-            fptr.write("\n\n")
-
-            fptr.write(f".. include:: {relpath(release.file_name, source_path)!s}\n")
+            fptr.write(f"\n\n.. include:: {relpath(release.file_name, source_path)!s}\n\n")
 
 
 class Release(object):


### PR DESCRIPTION
~**This is not to be merge yet!**~

This PR is related to #885.

In preparation for releasing v4.7.0, I run two queries in GitHub's GraphQL Explorer and I saved the results in two JSON files. Then, I wrote a Python script that takes those JSON files and generates a markdown file for each issue|pr or commit. I run the script and added all the files to the PR. Note that:

- "issues" are issues or PRs which are milestoned.
- "commits" are the last 100 commits in branch `master`. Hence, there are 17 commits missing (the first after tag v4.6.0).

Yet to be done:

- ~Configure towncrier to use markdown: https://towncrier.readthedocs.io/en/stable/markdown.html~
- Cleanup all the files added in this PR to only keep the ones that are meaningful for end-users.
- ~Add myst-parser to include the changelog in release_notes.~

/cc @GlenNicholls 