### PR TITLE
ci: forks push the docs to branch gh-pages

### DIFF
--- a/.github/publish_site.sh
+++ b/.github/publish_site.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env sh
+#
+# Usage: publish_site.sh [github.repository]
+# If the repository is 'VUnit/vunit', GH_DEPKEY is required.
+# Otherwise, the default token is used.
+
+set -e
+
+[ "x$1" = 'xVUnit/vunit' ] && isVUnit=1 || unset isVUnit
+
+echo "isVUnit: $isVUnit"
+
+cd $(dirname "$0")/../.tox/py311-docs/tmp/docsbuild/
+touch .nojekyll
+git init
+
+if [ -z "${isVUnit+x}" ]; then
+  cp ../../../../.git/config ./.git/config
+fi
+
+git add .
+git config --local user.email "Pages@GitHubActions"
+git config --local user.name "GitHub Actions"
+git commit -a -m "update $GITHUB_SHA"
+
+if [ -z "${isVUnit+x}" ]; then
+  git push -u origin +HEAD:gh-pages
+fi
+
+if [ -n "${isVUnit+x}" ]; then
+  git remote add origin git@github.com:VUnit/VUnit.github.io
+  eval `ssh-agent -t 60 -s`
+  echo "$GH_DEPKEY" | ssh-add -
+  mkdir -p ~/.ssh/
+  ssh-keyscan github.com >> ~/.ssh/known_hosts
+  git push -u origin +master
+  ssh-agent -k
+fi

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -37,25 +37,9 @@ jobs:
         name: VUnit-site
         path: .tox/py311-docs/tmp/docsbuild/
 
-    - name: Publish site to gh-pages
-      if: github.event_name != 'pull_request' && github.repository == 'VUnit/vunit' && github.ref_name == 'master'
-      env:
-        GH_DEPKEY: ${{ secrets.VUNIT_GITHUB_IO_DEPLOY_KEY }}
-      run: |
-        cd .tox/py311-docs/tmp/docsbuild/
-        touch .nojekyll
-
-        git init
-        git add .
-        git config --local user.email "push@gha"
-        git config --local user.name "GHA"
-        git commit -a -m "update ${{ github.sha }}"
-
-        git remote add origin git@github.com:VUnit/VUnit.github.io
-
-        eval `ssh-agent -t 60 -s`
-        echo "$GH_DEPKEY" | ssh-add -
-        mkdir -p ~/.ssh/
-        ssh-keyscan github.com >> ~/.ssh/known_hosts
-        git push -u origin +master
-        ssh-agent -k
+    - name: '🚀 Publish site'
+      if: github.event_name != 'pull_request' && github.ref_name == 'master'
+      run: >-
+        GH_DEPKEY='${{ secrets.VUNIT_GITHUB_IO_DEPLOY_KEY }}'
+        ./.github/publish_site.sh
+        '${{ github.repository }}'


### PR DESCRIPTION
Currently, documentation is only published when CI is run in this repo. That's because it's pushed to repo VUnit/vunit.github.io, which forks do not have write access to.
However, forks can use branch `gh-pages` to have docs published at `user.github.io/vunit`.
That allows contributors to see changes to the docs using CI, instead of downloading the artifact or building the docs locally.

This PR supports both use cases. In this repo, the secret SSH key is used for updating vunit.github.io. In forks, branch gh-pages is updated using the default token.