### PR TITLE
Fix error with NVC and the --gui flag

### DIFF
--- a/docs/news.d/926.feature.rst
+++ b/docs/news.d/926.feature.rst
@@ -1,0 +1,1 @@
+Add NVC simulator support.

--- a/docs/news.d/930.feature.rst
+++ b/docs/news.d/930.feature.rst
@@ -1,0 +1,1 @@
+Add NVC simulator support.

--- a/vunit/sim_if/nvc.py
+++ b/vunit/sim_if/nvc.py
@@ -286,7 +286,7 @@ class NVCInterface(SimulatorInterface):  # pylint: disable=too-many-instance-att
             status = False
 
         if self._gui and not elaborate_only:
-            cmd = ["gtkwave"] + shlex.split(self._gtkwave_args) + [wave_file]
+            cmd = ["gtkwave"] + shlex.split(self._gtkwave_args) + [str(wave_file)]
 
             init_file = config.sim_options.get(self.name + ".gtkwave_script.gui", None)
             if init_file is not None:


### PR DESCRIPTION
Fixes #926

https://github.com/VUnit/vunit/issues/926#issuecomment-1514649824 by  @umarcor 

> For reference, in GHDL the Path is converted to str in
https://github.com/VUnit/vunit/blob/1bc4d060aaeadc80a1f95df1965906870b37e752/vunit/sim_if/ghdl.py#L338

Yeah, the GHDL interface does the string conversion earlier:

https://github.com/VUnit/vunit/blob/fc91e48dbf9daa1029d14758e8395c2836dd81b8/vunit/sim_if/ghdl.py#L330-L340

But the path is still useful (for checking if the file exists and so on), so the code ends up converting back and forth between `Path` and `str` everywhere. Is it not better to wait with the string conversion until a string is required, like what I did in cc5c6073756394ed689256c727595e724885d974?

I could add a commit to refactor the Path handling in the GHDL (or NVC?) interface, if you want it to be more consistent.