### PR TITLE
sim_if/ghdl: remove 'ghdl.flags'

### DIFF
--- a/docs/news.d/932.breaking.rst
+++ b/docs/news.d/932.breaking.rst
@@ -1,0 +1,2 @@
+[GHDL] Remove ``ghdl.flags``; use ``ghdl.a_flags`` instead.
+

--- a/docs/py/opts.rst
+++ b/docs/py/opts.rst
@@ -11,9 +11,6 @@ The following compilation options are known.
    Extra arguments passed to ``ghdl -a`` command during compilation.
    Must be a list of strings.
 
-``ghdl.flags``
-  Deprecated alias of ``ghdl.a_flags``. It will be removed in future releases.
-
 ``incisive.irun_vhdl_flags``
    Extra arguments passed to the Incisive ``irun`` command when compiling VHDL files.
    Must be a list of strings.

--- a/examples/vhdl/array/run.py
+++ b/examples/vhdl/array/run.py
@@ -26,7 +26,7 @@ SRC_PATH = Path(__file__).parent / "src"
 
 VU.add_library("lib").add_source_files([SRC_PATH / "*.vhd", SRC_PATH / "test" / "*.vhd"])
 
-VU.set_compile_option("ghdl.flags", ["-frelaxed"])
+VU.set_compile_option("ghdl.a_flags", ["-frelaxed"])
 VU.set_sim_option("ghdl.elab_flags", ["-frelaxed"])
 
 VU.set_compile_option("nvc.a_flags", ["--relaxed"])

--- a/tests/unit/test_ghdl_interface.py
+++ b/tests/unit/test_ghdl_interface.py
@@ -204,7 +204,7 @@ warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE."""
         project = Project()
         project.add_library("lib", "lib_path")
         source_file = project.add_source_file("file.vhd", "lib", file_type="vhdl")
-        source_file.set_compile_option("ghdl.flags", ["custom", "flags"])
+        source_file.set_compile_option("ghdl.a_flags", ["custom", "flags"])
         simif.compile_project(project)
         check_output.assert_called_once_with(
             [

--- a/tests/unit/test_project.py
+++ b/tests/unit/test_project.py
@@ -970,7 +970,7 @@ endpackage
         self.update(file3)
         self.assert_should_recompile([])
 
-        file2.set_compile_option("ghdl.flags", ["--no-vital-checks"])
+        file2.set_compile_option("ghdl.a_flags", ["--no-vital-checks"])
         self.assert_should_recompile([file2, file3])
 
     def test_should_recompile_files_after_changing_vhdl_standard(self):
@@ -991,37 +991,37 @@ endpackage
     def test_add_compile_option(self):
         self.project.add_library("lib", "lib_path")
         file1 = self.add_source_file("lib", "file.vhd", "")
-        file1.add_compile_option("ghdl.flags", ["--foo"])
-        self.assertEqual(file1.get_compile_option("ghdl.flags"), ["--foo"])
-        file1.add_compile_option("ghdl.flags", ["--bar"])
-        self.assertEqual(file1.get_compile_option("ghdl.flags"), ["--foo", "--bar"])
-        file1.set_compile_option("ghdl.flags", ["--xyz"])
-        self.assertEqual(file1.get_compile_option("ghdl.flags"), ["--xyz"])
+        file1.add_compile_option("ghdl.a_flags", ["--foo"])
+        self.assertEqual(file1.get_compile_option("ghdl.a_flags"), ["--foo"])
+        file1.add_compile_option("ghdl.a_flags", ["--bar"])
+        self.assertEqual(file1.get_compile_option("ghdl.a_flags"), ["--foo", "--bar"])
+        file1.set_compile_option("ghdl.a_flags", ["--xyz"])
+        self.assertEqual(file1.get_compile_option("ghdl.a_flags"), ["--xyz"])
 
     def test_add_compile_option_does_not_mutate_argument(self):
         self.project.add_library("lib", "lib_path")
         file1 = self.add_source_file("lib", "file.vhd", "")
         options = ["--foo"]
-        file1.add_compile_option("ghdl.flags", options)
+        file1.add_compile_option("ghdl.a_flags", options)
         options[0] = "--xyz"
-        self.assertEqual(file1.get_compile_option("ghdl.flags"), ["--foo"])
-        file1.add_compile_option("ghdl.flags", ["--bar"])
+        self.assertEqual(file1.get_compile_option("ghdl.a_flags"), ["--foo"])
+        file1.add_compile_option("ghdl.a_flags", ["--bar"])
         self.assertEqual(options, ["--xyz"])
 
     def test_set_compile_option_does_not_mutate_argument(self):
         self.project.add_library("lib", "lib_path")
         file1 = self.add_source_file("lib", "file.vhd", "")
         options = ["--foo"]
-        file1.set_compile_option("ghdl.flags", options)
+        file1.set_compile_option("ghdl.a_flags", options)
         options[0] = "--xyz"
-        self.assertEqual(file1.get_compile_option("ghdl.flags"), ["--foo"])
+        self.assertEqual(file1.get_compile_option("ghdl.a_flags"), ["--foo"])
 
     def test_compile_option_validation(self):
         self.project.add_library("lib", "lib_path")
         source_file = self.add_source_file("lib", "file.vhd", "")
         self.assertRaises(ValueError, source_file.set_compile_option, "foo", None)
-        self.assertRaises(ValueError, source_file.set_compile_option, "ghdl.flags", None)
-        self.assertRaises(ValueError, source_file.add_compile_option, "ghdl.flags", None)
+        self.assertRaises(ValueError, source_file.set_compile_option, "ghdl.a_flags", None)
+        self.assertRaises(ValueError, source_file.add_compile_option, "ghdl.a_flags", None)
         self.assertRaises(ValueError, source_file.get_compile_option, "foo")
 
     def test_should_recompile_files_affected_by_change_with_later_timestamp(self):

--- a/tests/unit/test_ui.py
+++ b/tests/unit/test_ui.py
@@ -925,17 +925,17 @@ Listed 2 files""".splitlines()
 
         # Use methods on all types of interface objects
         for obj in [source_file, ui, lib, lib.get_source_files(file_name), ui.get_libraries("lib")]:
-            obj.set_compile_option("ghdl.flags", [])
-            self.assertEqual(source_file.get_compile_option("ghdl.flags"), [])
+            obj.set_compile_option("ghdl.a_flags", [])
+            self.assertEqual(source_file.get_compile_option("ghdl.a_flags"), [])
 
-            obj.add_compile_option("ghdl.flags", ["1"])
-            self.assertEqual(source_file.get_compile_option("ghdl.flags"), ["1"])
+            obj.add_compile_option("ghdl.a_flags", ["1"])
+            self.assertEqual(source_file.get_compile_option("ghdl.a_flags"), ["1"])
 
-            obj.add_compile_option("ghdl.flags", ["2"])
-            self.assertEqual(source_file.get_compile_option("ghdl.flags"), ["1", "2"])
+            obj.add_compile_option("ghdl.a_flags", ["2"])
+            self.assertEqual(source_file.get_compile_option("ghdl.a_flags"), ["1", "2"])
 
-            obj.set_compile_option("ghdl.flags", ["3"])
-            self.assertEqual(source_file.get_compile_option("ghdl.flags"), ["3"])
+            obj.set_compile_option("ghdl.a_flags", ["3"])
+            self.assertEqual(source_file.get_compile_option("ghdl.a_flags"), ["3"])
 
     def test_default_vhdl_standard_is_used(self):
         file_name = "foo.vhd"


### PR DESCRIPTION
As discussed in #763, the deprecation of `ghdl.flags` was announced several years ago.
Since we are in a breaking window (in preparation for v5), it's time to remove it.