### PR TITLE
Make submodule paths relative

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "vunit/vhdl/osvvm"]
 	path = vunit/vhdl/osvvm
-	url = https://github.com/OSVVM/OSVVM.git
+	url = ../../OSVVM/OSVVM.git
 [submodule "vunit/vhdl/JSON-for-VHDL"]
 	path = vunit/vhdl/JSON-for-VHDL
-	url = https://github.com/Paebbels/JSON-for-VHDL.git
+	url = ../../Paebbels/JSON-for-VHDL.git


### PR DESCRIPTION
- Users get submodules over their preferred transport
- No need to tweak `.gitmodules` if you mirror VUnit