### PR TITLE
Unaligned addresses with axi_read_slave

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,10 +1,10 @@
 name: 'coverage'
 
 on:
-  push:
+#  push:
   workflow_dispatch:
-  schedule:
-    - cron: '0 0 * * 5'
+#  schedule:
+#    - cron: '0 0 * * 5'
 
 jobs:
 
@@ -18,7 +18,7 @@ jobs:
 
     - uses: actions/setup-python@v4
       with:
-        python-version: '3.11'
+        python-version: '3.13'
 
     - name: Run coverage
       run: |
@@ -28,7 +28,7 @@ jobs:
     - name: Report coverage
       run: ./.github/run.sh coverage report -m --skip-covered
 
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
         name: VUnit_coverage
         path: htmlcov

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -32,7 +32,7 @@ jobs:
     - name: Build docs
       run: tox -e py311-docs -- --color
 
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
         name: VUnit-site
         path: .tox/py311-docs/tmp/docsbuild/

--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -52,12 +52,13 @@ jobs:
     steps:
 
     - name: 🧰 Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: '🛳️ Build container image'
       run: |
+        echo '${{ github.token }}' | docker login ghcr.io -u gha --password-stdin
         docker build -t ghcr.io/vunit/dev/nvc -<<EOF
-        FROM gcr.io/hdl-containers/nvc
+        FROM ghcr.io/nickg/nvc
 
         RUN apt-get update -qq \
          && DEBIAN_FRONTEND=noninteractive apt-get -y install --no-install-recommends \
@@ -66,7 +67,8 @@ jobs:
          && update-ca-certificates \
          && rm -rf /var/lib/apt/lists/*
 
-        RUN pip install -U tox colorama coverage --progress-bar off
+        RUN python3 -m pip install -U pip --break-system-packages --progress-bar off \
+         && python3 -m pip install -U tox colorama coverage --break-system-packages --progress-bar off
         EOF
 
     - name: '🛰️ Push container image to registry'

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -49,7 +49,7 @@ jobs:
       matrix:
         include:
           - { py: '3.11' , task: 311-lint }
-          - { py: '3.7'  , task: 37-unit }
+          - { py: '3.8'  , task: 38-unit }
           - { py: '3.11' , task: 311-unit }
     name: '🐧 Ubuntu · ${{ matrix.task }}'
     steps:
@@ -80,8 +80,8 @@ jobs:
       fail-fast: false
       matrix:
         task: [
-          {do: 311-acceptance,  tag: llvm},
-          {do: 311-vcomponents, tag: mcode},
+          {do: 313-acceptance,  tag: llvm},
+          {do: 313-vcomponents, tag: mcode},
         ]
     name: '🛳️ Container · ${{ matrix.task.do }} · ${{ matrix.task.tag }}'
     steps:
@@ -98,27 +98,27 @@ jobs:
 # Docker (Linux) tests (NVC)
 #
 
-  nvc:
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        task: [
-          {do: 39-acceptance},
-          {do: 39-vcomponents},
-        ]
-    name: '🛳️ Container · ${{ matrix.task.do }} · NVC'
-    steps:
+#  nvc:
+#    runs-on: ubuntu-latest
+#    strategy:
+#      fail-fast: false
+#      matrix:
+#        task: [
+#          {do: 311-acceptance},
+#          {do: 311-vcomponents},
+#        ]
+#    name: '🛳️ Container · ${{ matrix.task.do }} · NVC'
+#    steps:
 
-    - name: '🧰 Checkout'
-      uses: actions/checkout@v3
-      with:
-        submodules: recursive
+#    - name: '🧰 Checkout'
+#      uses: actions/checkout@v3
+#     with:
+#        submodules: recursive
 
-    - name: '🚧 Run job'
-      uses: docker://ghcr.io/vunit/dev/nvc
-      with:
-        args: tox -e py${{ matrix.task.do }}-nvc
+#    - name: '🚧 Run job'
+#      uses: docker://ghcr.io/vunit/dev/nvc
+#      with:
+#        args: tox -e py${{ matrix.task.do }}-nvc
 
 #
 # Windows (MSYS2) with 'nightly' GHDL
@@ -154,9 +154,10 @@ jobs:
         submodules: recursive
 
     - name: '⚙️ Setup GHDL'
-      uses: ghdl/setup-ghdl-ci@master
+      uses: ghdl/setup-ghdl@main
       with:
-        backend: llvm
+        backend: mcode
+        runtime: mingw64
 
     - name: '🐍 Install dependencies'
       run: pip install -U tox --progress-bar off
@@ -174,7 +175,7 @@ jobs:
       - fmt
       - lin
       - ghdl
-      - nvc
+#      - nvc
       - win
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
     name: '🚀 Deploy'

--- a/docs/news.d/1158.misc.rst
+++ b/docs/news.d/1158.misc.rst
@@ -1,1 +1,0 @@
-Restrict setup tools to pre-82, as the deprecated pkg_resources is still used.

--- a/docs/news.d/1158.misc.rst
+++ b/docs/news.d/1158.misc.rst
@@ -1,0 +1,1 @@
+Restrict setup tools to pre-82, as the deprecated pkg_resources is still used.

--- a/docs/release_notes/4.7.1.rst
+++ b/docs/release_notes/4.7.1.rst
@@ -1,0 +1,5 @@
+
+Miscellaneous
+~~~~~~~~~~~~~
+
+- Restrict setup tools to pre-82, as the deprecated pkg_resources is still used. (:vunit_issue:`1158`)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 requires = [
-    "setuptools >= 35.0.2",
+    "setuptools >= 35.0.2, <82.0.0",
     "setuptools_scm >= 2.0.0, <3"
 ]
 build-backend = "setuptools.build_meta"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,7 +54,7 @@ underlines = ["-", "~"]
 [tool.tox]
 legacy_tox_ini = """
 [tox]
-envlist = py{36,37,38,39,310,311}-{fmt,unit,lint,docs}, py{36,37,38,39,310,311}-{acceptance,vcomponents}-{activehdl,ghdl,modelsim,nvc,rivierapro}, py{36,37,38,39,310,311}-coverage
+envlist = py{36,37,38,39,310,311}-{fmt,unit,lint,docs}, py{36,37,38,39,310,311,313}-{acceptance,vcomponents}-{activehdl,ghdl,modelsim,nvc,rivierapro}, py{36,37,38,39,310,311}-coverage
 isolated_build = True
 
 [testenv]
@@ -62,15 +62,15 @@ recreate=True
 passenv=ALDEC_LICENSE_FILE
 
 deps=
-    fmt: black
+    fmt: black==23.3.0
     pytest
     lint: pycodestyle
-    lint: pylint
+    lint: pylint==2.17.2
     lint: mypy
     lint: Pygments
-    coverage: coverage
+    coverage: coverage==7.2.0
     coverage: pycodestyle
-    coverage: pylint
+    coverage: pylint==2.17.2
     coverage: mypy
     coverage: Pygments
     docs: docutils

--- a/tests/acceptance/test_artificial.py
+++ b/tests/acceptance/test_artificial.py
@@ -27,7 +27,7 @@ class TestVunitArtificial(unittest.TestCase):
     """
 
     def setUp(self):
-        if simulator_is("activehdl"):
+        if simulator_is("activehdl", "nvc"):
             self.output_path = str(ROOT / "artificial_out")
         else:
             # Spaces in path intentional to verify that it is supported

--- a/tools/build_docs.py
+++ b/tools/build_docs.py
@@ -26,14 +26,12 @@ def main():
     Build documentation/website
     """
     create_release_notes()
-    copyfile(str(ROOT / 'LICENSE.rst'), str(ROOT / 'docs/license.rst'))
+    copyfile(str(ROOT / "LICENSE.rst"), str(ROOT / "docs/license.rst"))
     check_call(
-        [
-            sys.executable,
-            "-m",
-            "sphinx"
-        ] + ([] if len(argv) < 2 else argv[2:]) + [
-            "-TEWanb",
+        [sys.executable, "-m", "sphinx"]
+        + ([] if len(argv) < 2 else argv[2:])
+        + [
+            "-TEanb",
             "html",
             Path(__file__).parent.parent / "docs",
             argv[1],

--- a/vunit/about.py
+++ b/vunit/about.py
@@ -69,4 +69,4 @@ def version():
     return VERSION
 
 
-VERSION = "4.7.0"
+VERSION = "4.7.1"

--- a/vunit/sim_if/ghdl.py
+++ b/vunit/sim_if/ghdl.py
@@ -126,7 +126,7 @@ class GHDLInterface(SimulatorInterface):  # pylint: disable=too-many-instance-at
         Determine the GHDL backend
         """
         mapping = {
-            r"mcode code generator": "mcode",
+            r"mcode (JIT )?code generator": "mcode",
             r"llvm (\d+\.\d+\.\d+ )?code generator": "llvm",
             r"GCC (back-end|\d+\.\d+\.\d+) code generator": "gcc",
         }
@@ -137,7 +137,7 @@ class GHDLInterface(SimulatorInterface):  # pylint: disable=too-many-instance-at
                 LOGGER.debug("Detected GHDL %s", match.group(0))
                 return backend
 
-        LOGGER.error("Could not detect known LLVM backend by parsing 'ghdl --version'")
+        LOGGER.error("Could not detect known backend by parsing 'ghdl --version'")
         print(f"Expected to find one of {mapping.keys()!r}")
         print("== Output of 'ghdl --version'" + ("=" * 60))
         print(output)

--- a/vunit/vhdl/verification_components/src/axi_read_slave.vhd
+++ b/vunit/vhdl/verification_components/src/axi_read_slave.vhd
@@ -100,7 +100,7 @@ begin
 
       if beats > 0 and (rvalid = '0' or rready = '1') and not self.should_stall_data then
         rvalid <= '1';
-        rdata  <= (others => '-');
+        rdata  <= (rdata'range => '-');
         for j in 0 to burst.size-1 loop
           idx := (address + j) mod self.data_size;
 

--- a/vunit/vhdl/verification_components/src/axi_read_slave.vhd
+++ b/vunit/vhdl/verification_components/src/axi_read_slave.vhd
@@ -99,8 +99,8 @@ begin
       if beats > 0 and (rvalid = '0' or rready = '1') and not self.should_stall_data then
         rvalid <= '1';
         for j in 0 to burst.size-1 loop
-          idx := (address + j) mod self.data_size;
-          rdata(8*idx+7 downto 8*idx) <= std_logic_vector(to_unsigned(read_byte(axi_slave.p_memory, address+j), 8));
+          idx := address - (address mod self.data_size) + j;
+          rdata(8*j+7 downto 8*j) <= std_logic_vector(to_unsigned(read_byte(axi_slave.p_memory, idx), 8));
         end loop;
 
         if burst.burst_type = axi_burst_type_incr then

--- a/vunit/vhdl/verification_components/src/axi_read_slave.vhd
+++ b/vunit/vhdl/verification_components/src/axi_read_slave.vhd
@@ -100,7 +100,13 @@ begin
         rvalid <= '1';
         for j in 0 to burst.size-1 loop
           idx := address - (address mod self.data_size) + j;
-          rdata(8*j+7 downto 8*j) <= std_logic_vector(to_unsigned(read_byte(axi_slave.p_memory, idx), 8));
+
+          --Don't try to read lower than the burst's base addr; only kicks in when unaligned
+          if idx >= burst.address then
+            rdata(8*j+7 downto 8*j) <= std_logic_vector(to_unsigned(read_byte(axi_slave.p_memory, idx), 8));
+          else
+            rdata(8*j+7 downto 8*j) <= (others => '-');
+          end if;
         end loop;
 
         if burst.burst_type = axi_burst_type_incr then

--- a/vunit/vhdl/verification_components/src/axi_read_slave.vhd
+++ b/vunit/vhdl/verification_components/src/axi_read_slave.vhd
@@ -11,6 +11,7 @@ use ieee.numeric_std.all;
 use work.axi_pkg.all;
 use work.axi_slave_private_pkg.all;
 use work.queue_pkg.all;
+use work.logger_pkg.all;
 context work.com_context;
 context work.vc_context;
 
@@ -58,6 +59,7 @@ begin
 
     variable response_time : time;
     variable has_response_time : boolean := false;
+    variable logger : logger_t := get_logger("axi_process");
   begin
     assert arid'length = rid'length report "arid vs rid data width mismatch";
     -- Initialization
@@ -92,20 +94,21 @@ begin
           beats := burst.length;
           rid <= std_logic_vector(to_unsigned(burst.id, rid'length));
           rresp <= axi_resp_okay;
-          address := burst.address;
+          address := burst.address - (burst.address mod self.data_size); --aligned address
         end if;
       end if;
 
       if beats > 0 and (rvalid = '0' or rready = '1') and not self.should_stall_data then
         rvalid <= '1';
         for j in 0 to burst.size-1 loop
-          idx := address - (address mod self.data_size) + j;
+          idx := (address + j) mod self.data_size;
 
           --Don't try to read lower than the burst's base addr; only kicks in when unaligned
-          if idx >= burst.address then
-            rdata(8*j+7 downto 8*j) <= std_logic_vector(to_unsigned(read_byte(axi_slave.p_memory, idx), 8));
+          if address >= burst.address then
+            debug(logger, "RD addr " & integer'image(address+j) & ", put in byte lane " & integer'image(idx));
+            rdata(8*idx+7 downto 8*idx) <= std_logic_vector(to_unsigned(read_byte(axi_slave.p_memory, address+j), 8));
           else
-            rdata(8*j+7 downto 8*j) <= (others => '-');
+            rdata(8*idx+7 downto 8*idx) <= (others => '-');
           end if;
         end loop;
 

--- a/vunit/vhdl/verification_components/src/axi_slave_private_pkg.vhd
+++ b/vunit/vhdl/verification_components/src/axi_slave_private_pkg.vhd
@@ -432,7 +432,7 @@ package body axi_slave_private_pkg is
       variable first_page, last_page : integer;
     begin
       first_address := burst.address - (burst.address mod data_size); -- Aligned
-      last_address := burst.address + burst.size*burst.length - 1;
+      last_address := first_address + burst.size*burst.length - 1;
 
       first_page := first_address / 4096;
       last_page := last_address / 4096;

--- a/vunit/vhdl/verification_components/test/tb_axi_read_slave.vhd
+++ b/vunit/vhdl/verification_components/test/tb_axi_read_slave.vhd
@@ -71,13 +71,19 @@ begin
 
     procedure read_data(id : std_logic_vector; address : natural; size : natural; resp : axi_resp_t; last : boolean) is
       variable idx : integer;
+      variable addr : integer;
+      variable logger : logger_t := get_logger("read_data");
     begin
       rready <= '1';
       wait until (rvalid and rready) = '1' and rising_edge(clk);
       rready <= '0';
+      addr := address - (address mod size); --align address to transfer size
       for i in 0 to size-1 loop
-        idx := (address + i) mod data_size; -- Align data bus
-        check_equal(rdata(8*idx+7 downto 8*idx), read_byte(memory, address+i));
+        idx := ((addr mod data_size) + i); --idx is the byte lane for this value
+        if addr >= address then
+          debug(logger, "RD addr " & integer'image(addr+i) & ", got " & integer'image(read_byte(memory, addr+i)) & ", compare to rdata byte lane " & integer'image(idx));
+          check_equal(rdata(8*idx+7 downto 8*idx), read_byte(memory, addr+i), result("for rdata in byte lane " & integer'image(idx)));
+        end if;
       end loop;
       check_equal(rid, id, "rid");
       check_equal(rresp, resp, "rresp");
@@ -86,7 +92,8 @@ begin
 
     procedure transfer(log_size, len : natural;
                        id : std_logic_vector;
-                       burst : std_logic_vector) is
+                       burst : std_logic_vector;
+                       alignment : positive := 4096) is
       variable buf : buffer_t;
       variable size : natural;
       variable data : integer_vector_ptr_t;
@@ -94,7 +101,7 @@ begin
       size := 2**log_size;
       random_integer_vector_ptr(rnd, data, size * len, 0, 255);
 
-      buf := allocate(memory, 8 * len, alignment => 4096);
+      buf := allocate(memory, 8 * len, alignment => alignment);
       for i in 0 to length(data)-1 loop
         write_byte(memory, base_address(buf)+i, get(data, i));
       end loop;
@@ -131,8 +138,27 @@ begin
             assert false;
         end case;
 
-        log_size := rnd.RandInt(0, 3);
-        transfer(log_size, len, id, burst);
+        log_size := rnd.RandInt(0, log_data_size-1);
+        transfer(log_size, len, id, burst, alignment => 4096);
+      end loop;
+
+    elsif run("Test unaligned read") then
+      for test_idx in 0 to 32-1 loop
+
+        id := rnd.RandSlv(arid'length);
+        case rnd.RandInt(1) is
+          when 0 =>
+            burst := axi_burst_type_fixed;
+            len := 1;
+          when 1 =>
+            burst := axi_burst_type_incr;
+            len := rnd.RandInt(1, 2**arlen'length);
+          when others =>
+            assert false;
+        end case;
+
+        log_size := rnd.RandInt(0, log_data_size-1);
+        transfer(log_size, len, id, burst, alignment => rnd.RandInt(1, log_data_size));
       end loop;
 
     elsif run("Test random data stall") then


### PR DESCRIPTION
Fixing how `axi_read_slave` handles unaligned addresses.

Let's say your memory looks like this:
    byte 0 = 0x00
    byte 1 = 0x01
    byte 2 = 0x02
    byte 3 = 0x03
    byte 4 = 0x04
    byte 5 = 0x05

AXI4 read request looks like this:
    bus width = 4 bytes
    ARADR = 2
    ARLEN = 0 (1 word)

On RDATA I would expect to see `0x03020100` or maybe `0x0302----` since the lower 2 bytes aren't valid.

Instead you get `0x03020504` for the first transfer, `0x07060908` for the second, etc. This change fixes the rotated data.

Mentioned in #851 but not exactly the same issue.