### PR TITLE
sim_if/nvc.py: quote words with spaces in printed command

### DIFF
--- a/docs/news.d/940.misc.rst
+++ b/docs/news.d/940.misc.rst
@@ -1,0 +1,1 @@
+[NVC] Multi-word command line arguments are now quoted in the log.

--- a/vunit/sim_if/nvc.py
+++ b/vunit/sim_if/nvc.py
@@ -275,7 +275,7 @@ class NVCInterface(SimulatorInterface):  # pylint: disable=too-many-instance-att
             if wave_file:
                 cmd += [f"--wave={wave_file}"]
 
-        print(" ".join(cmd))
+        print(" ".join([f"'{word}'" if " " in word else word for word in cmd]))
 
         status = True
 


### PR DESCRIPTION
This allows the command to be directly copied and pasted without having to quote e.g. the JSON in the `-g` argument.