### PR TITLE
Move project metadata to pyproject.toml

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,3 @@
+recursive-include vunit/ *.tcl
+recursive-include vunit/vhdl/ *
+recursive-include vunit/verilog/ *.sv *.v *.svh

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,9 +1,55 @@
 [build-system]
-requires = [
-    "setuptools >= 35.0.2",
-    "setuptools_scm >= 2.0.0, <3"
-]
+requires = ["setuptools >= 35.0.2", "setuptools_scm >= 2.0.0, <3"]
 build-backend = "setuptools.build_meta"
+
+[project]
+name = "vunit_hdl"
+authors = [{ name = "Lars Asplund", email = "lars.anders.asplund@gmail.com" }]
+license = { text = "Mozilla Public License 2.0 (MPL 2.0)" }
+description = "VUnit is an open source unit testing framework for VHDL/SystemVerilog."
+readme = "README.md"
+requires-python = ">=3.7"
+classifiers = [
+    "Development Status :: 5 - Production/Stable",
+    "License :: OSI Approved :: Mozilla Public License 2.0 (MPL 2.0)",
+    "Natural Language :: English",
+    "Intended Audience :: Developers",
+    "Programming Language :: Python :: 3.7",
+    "Programming Language :: Python :: 3.8",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Operating System :: Microsoft :: Windows",
+    "Operating System :: MacOS :: MacOS X",
+    "Operating System :: POSIX :: Linux",
+    "Topic :: Software Development :: Testing",
+    "Topic :: Scientific/Engineering :: Electronic Design Automation (EDA)",
+]
+dependencies = ["colorama"]
+dynamic = ["version"]
+
+[project.urls]
+Homepage = "https://vunit.github.io"
+Repository = "https://github.com/VUnit/vunit"
+
+[tool.setuptools]
+zip-safe = false
+packages = [
+    "tests",
+    "tests.lint",
+    "tests.unit",
+    "tests.acceptance",
+    "vunit",
+    "vunit.com",
+    "vunit.parsing",
+    "vunit.parsing.verilog",
+    "vunit.sim_if",
+    "vunit.test",
+    "vunit.ui",
+    "vunit.vivado",
+]
+
+[tool.setuptools.dynamic]
+version = {attr = "vunit.about.version"}
 
 [tool.black]
 line-length = 120
@@ -12,7 +58,7 @@ line-length = 120
 package = "vunit"
 package_dir = "vunit"
 single_file = false
-filename="docs/news.inc"
+filename = "docs/news.inc"
 directory = "docs/news.d/"
 title_format = false
 issue_format = ":vunit_issue:`{issue}`"

--- a/setup.py
+++ b/setup.py
@@ -8,84 +8,14 @@
 PyPI setup script
 """
 
-import os
-import sys
+from glob import glob
 from pathlib import Path
 from logging import warning
 from setuptools import setup
 
-# Ensure that the source tree is on the sys path
-sys.path.insert(0, str(Path(__file__).parent.resolve()))
+setup()
 
-from vunit.about import version, doc  # pylint: disable=wrong-import-position
-from vunit.builtins import osvvm_is_installed  # pylint: disable=wrong-import-position
-
-
-def find_all_files(directory, endings=None):
-    """
-    Recursively find all files within directory
-    """
-    result = []
-    for root, _, filenames in os.walk(directory):
-        for filename in filenames:
-            ending = os.path.splitext(filename)[-1]
-            if endings is None or ending in endings:
-                result.append(str(Path(root) / filename))
-    return result
-
-
-DATA_FILES = []
-DATA_FILES += find_all_files("vunit", endings=[".tcl"])
-DATA_FILES += find_all_files(str(Path("vunit") / "vhdl"))
-DATA_FILES += find_all_files(str(Path("vunit") / "verilog"), endings=[".v", ".sv", ".svh"])
-DATA_FILES = [os.path.relpath(file_name, "vunit") for file_name in DATA_FILES]
-
-setup(
-    name="vunit_hdl",
-    version=version(),
-    packages=[
-        "tests",
-        "tests.lint",
-        "tests.unit",
-        "tests.acceptance",
-        "vunit",
-        "vunit.com",
-        "vunit.parsing",
-        "vunit.parsing.verilog",
-        "vunit.sim_if",
-        "vunit.test",
-        "vunit.ui",
-        "vunit.vivado",
-    ],
-    package_data={"vunit": DATA_FILES},
-    zip_safe=False,
-    url="https://github.com/VUnit/vunit",
-    classifiers=[
-        "Development Status :: 5 - Production/Stable",
-        "License :: OSI Approved :: Mozilla Public License 2.0 (MPL 2.0)",
-        "Natural Language :: English",
-        "Intended Audience :: Developers",
-        "Programming Language :: Python :: 3.7",
-        "Programming Language :: Python :: 3.8",
-        "Programming Language :: Python :: 3.9",
-        "Programming Language :: Python :: 3.10",
-        "Operating System :: Microsoft :: Windows",
-        "Operating System :: MacOS :: MacOS X",
-        "Operating System :: POSIX :: Linux",
-        "Topic :: Software Development :: Testing",
-        "Topic :: Scientific/Engineering :: Electronic Design Automation (EDA)",
-    ],
-    python_requires=">=3.6",
-    install_requires=["colorama"],
-    requires=["colorama"],
-    license="Mozilla Public License 2.0 (MPL 2.0)",
-    author="Lars Asplund",
-    author_email="lars.anders.asplund@gmail.com",
-    description="VUnit is an open source unit testing framework for VHDL/SystemVerilog.",
-    long_description=doc(),
-)
-
-if not osvvm_is_installed():
+if len(glob(str(Path(__file__).parent / "vunit" / "vhdl" / "osvvm" / "*.vhd"))) == 0:
     warning(
         """
 Found no OSVVM VHDL files. If you're installing from a Git repository and plan to use VUnit's integration


### PR DESCRIPTION
Move project metadata from `setup.py` to `pyproject.toml`. This change should make project more future-proof as the Python ecosystem is moving to `pyproject.toml` format. Moreover, it fixes problems with dependency definitions (as they are defined statically).