### PR TITLE
Fix issues when trying to parameterize Verilog modules

### DIFF
--- a/vunit/ui/library.py
+++ b/vunit/ui/library.py
@@ -486,9 +486,12 @@ class Library(object):
         :returns: A :class:`.TestBench` object
         :raises: KeyError
         """
-        name = name.lower()
-
-        return TestBench(self._test_bench_list.get_test_bench(self._library_name, name), self)
+        name_lower = name.lower()
+        
+        try:
+            return TestBench(self._test_bench_list.get_test_bench(self._library_name, name_lower), self)
+        except:
+            return TestBench(self._test_bench_list.get_test_bench(self._library_name, name), self)
 
     def get_test_benches(self, pattern="*", allow_empty=False):
         """


### PR DESCRIPTION
This fixes #944 by trying to execute an original version (case-insensitive for VHDL compatibility) with the fall-back for use with Verilog and non-lower-case module names.