### PR TITLE
sim_if/nvc.py: add a new nvc.global_flags option

### DIFF
--- a/docs/news.d/948.feature.rst
+++ b/docs/news.d/948.feature.rst
@@ -1,0 +1,2 @@
+[NVC] New simulation and compile option ``nvc.global_flags`` can be used
+to pass arbitrary flags to ``nvc``.

--- a/docs/py/opts.rst
+++ b/docs/py/opts.rst
@@ -27,6 +27,14 @@ The following compilation options are known.
    Extra arguments passed to ModelSim ``vlog`` command when compiling Verilog files.
    Must be a list of strings.
 
+``nvc.a_flags``
+   Extra arguments passed to ``nvc -a`` command during compilation.
+   Must be a list of strings.
+
+``nvc.global_flags``
+   Extra global arguments to pass to ``nvc`` before the ``-a`` command.
+   Must be a list of strings.
+
 ``rivierapro.vcom_flags``
    Extra arguments passed to Riviera PRO ``vcom`` command when compiling VHDL files.
    Must be a list of strings.
@@ -193,3 +201,20 @@ The following simulation options are known.
    user from sourcing a list of scripts directly. The following is the current work
    around to sourcing multiple user TCL-files:
    ``source <path/to/script.tcl>``
+
+``nvc.elab_flags``
+   Extra elaboration flags passed to ``nvc -e``.
+   Must be a list of strings.
+
+``nvc.global_flags``
+   Extra global arguments to pass to ``nvc`` before the ``-e`` or ``-r``
+   commands.
+   Must be a list of strings.
+
+``nvc.heap_size``
+   Simulation heap size.
+   Must be a string, for example ``"64m"``.
+
+``nvc.sim_flags``
+   Extra simulation flags passed to ``nvc -r``.
+   Must be a list of strings.

--- a/vunit/sim_if/nvc.py
+++ b/vunit/sim_if/nvc.py
@@ -35,10 +35,12 @@ class NVCInterface(SimulatorInterface):  # pylint: disable=too-many-instance-att
     supports_colors_in_gui = True
 
     compile_options = [
+        ListOfStringOption("nvc.global_flags"),
         ListOfStringOption("nvc.a_flags"),
     ]
 
     sim_options = [
+        ListOfStringOption("nvc.global_flags"),
         ListOfStringOption("nvc.sim_flags"),
         ListOfStringOption("nvc.elab_flags"),
         StringOption("nvc.heap_size"),
@@ -225,6 +227,8 @@ class NVCInterface(SimulatorInterface):  # pylint: disable=too-many-instance-att
             source_file.get_vhdl_standard(), source_file.library.name, source_file.library.directory
         )
 
+        cmd += source_file.compile_options.get("nvc.global_flags", [])
+
         cmd += ["-a"]
         cmd += source_file.compile_options.get("nvc.a_flags", [])
 
@@ -252,6 +256,7 @@ class NVCInterface(SimulatorInterface):  # pylint: disable=too-many-instance-att
         cmd = self._get_command(self._vhdl_standard, config.library_name, libdir)
 
         cmd += ["-H", config.sim_options.get("nvc.heap_size", "64m")]
+        cmd += config.sim_options.get("nvc.global_flags", [])
 
         cmd += ["-e"]
 


### PR DESCRIPTION
This can be set for compilation/simulation to pass additional global arguments to the nvc command. See issue #946.