### PR TITLE
Fix pip package name in Installing page

### DIFF
--- a/docs/installing.rst
+++ b/docs/installing.rst
@@ -84,13 +84,13 @@ The recommended way to get VUnit is to install the :ref:`latest stable release <
 
 .. code-block:: console
 
-   > pip install vunit_hdl
+   > pip install vunit-hdl
 
 Once installed, VUnit may be updated to new versions via a similar method:
 
 .. code-block:: console
 
-   > pip install -U vunit_hdl
+   > pip install -U vunit-hdl
 
 .. _installing_master:
 


### PR DESCRIPTION
The `pip` command seems to refer to the wrong package name.

Looks like the correct package is https://pypi.org/project/vunit-hdl/.