### PR TITLE
Osvvm memory pkg build based on generic support

### DIFF
--- a/vunit/builtins.py
+++ b/vunit/builtins.py
@@ -179,6 +179,7 @@ in your VUnit Git repository? You have to do this first if installing using setu
                     "ScoreboardPkg_int.vhd",
                     "ScoreboardPkg_slv.vhd",
                     "MemoryPkg.vhd",
+                    "MemoryGenericPkg.vhd",
                 ]
             ):
                 continue
@@ -189,6 +190,7 @@ in your VUnit Git repository? You have to do this first if installing using setu
                     "ScoreboardPkg_int_c.vhd",
                     "ScoreboardPkg_slv_c.vhd",
                     "MemoryPkg_c.vhd",
+                    "MemoryPkg_orig_c.vhd",
                 ]
             ):
                 continue

--- a/vunit/builtins.py
+++ b/vunit/builtins.py
@@ -178,6 +178,7 @@ in your VUnit Git repository? You have to do this first if installing using setu
                     "ScoreboardGenericPkg.vhd",
                     "ScoreboardPkg_int.vhd",
                     "ScoreboardPkg_slv.vhd",
+                    "MemoryPkg.vhd",
                 ]
             ):
                 continue
@@ -187,6 +188,7 @@ in your VUnit Git repository? You have to do this first if installing using setu
                 in [
                     "ScoreboardPkg_int_c.vhd",
                     "ScoreboardPkg_slv_c.vhd",
+                    "MemoryPkg_c.vhd",
                 ]
             ):
                 continue


### PR DESCRIPTION
Analog to Osvvm included `osvvm.pro` built the correct MemoryPkg files based on simulator support for generic packages