### PR TITLE
Allow multiply and divide within component instantiations.

### DIFF
--- a/docs/news.d/966.feature.rst
+++ b/docs/news.d/966.feature.rst
@@ -1,0 +1,1 @@
+Allow multiply and divide within component instantiations.

--- a/vunit/vhdl_parser.py
+++ b/vunit/vhdl_parser.py
@@ -86,7 +86,7 @@ class VHDLDesignFile(object):  # pylint: disable=too-many-instance-attributes
 
     _component_re = re.compile(
         r"[a-zA-Z]\w*\s*\:\s*(?:component)?\s*(?:(?:[a-zA-Z]\w*)\.)?([a-zA-Z]\w*)\s*"
-        r"(?:generic|port) map\s*\([\s\w\=\>\,\.\)\(\+\-\'\"]*\);",
+        r"(?:generic|port) map\s*\([\s\w\=\>\,\.\)\(\+\-\*\/\'\"]*\);",
         re.IGNORECASE,
     )
 


### PR DESCRIPTION
I recently was getting black boxes because in my instantiation of a component, I had port map lines like
```
       mask => mask(j)(G_DWIDTH/8-1 downto 0),
```
This was because the component search regex was not matching the `/` character.

(I was compiling with the `--minimal` argument)