### PR TITLE
Add fst wave export for GHDL

### DIFF
--- a/docs/news.d/969.feature.rst
+++ b/docs/news.d/969.feature.rst
@@ -1,0 +1,1 @@
+Added support for exporting `fst` waveforms in GHDL through the `--gtkwave-fmt=fst` CLI argument.

--- a/vunit/sim_if/ghdl.py
+++ b/vunit/sim_if/ghdl.py
@@ -55,9 +55,9 @@ class GHDLInterface(SimulatorInterface):  # pylint: disable=too-many-instance-at
         group = parser.add_argument_group("ghdl", description="GHDL specific flags")
         group.add_argument(
             "--gtkwave-fmt",
-            choices=["vcd", "ghw"],
+            choices=["vcd", "ghw","fst"],
             default=None,
-            help="Save .vcd or .ghw to open in gtkwave",
+            help="Save .vcd, .fst, or .ghw to open in gtkwave",
         )
         group.add_argument("--gtkwave-args", default="", help="Arguments to pass to gtkwave")
 
@@ -297,6 +297,8 @@ class GHDLInterface(SimulatorInterface):  # pylint: disable=too-many-instance-at
                 sim += [f"--wave={wave_file!s}"]
             elif self._gtkwave_fmt == "vcd":
                 sim += [f"--vcd={wave_file!s}"]
+            elif self._gtkwave_fmt == "fst":
+                sim += [f"--fst={wave_file!s}"]
 
         if not ghdl_e:
             cmd += sim


### PR DESCRIPTION
Hello,

I just made a small addition to the `--gtkwave-fmt` argument to enable `fst` waveforms in GHDL. This is quite useful for large designs.