### PR TITLE
Fix check_relation using default checker

### DIFF
--- a/vunit/vhdl/check/src/check.vhd
+++ b/vunit/vhdl/check/src/check.vhd
@@ -2263,7 +2263,7 @@ package body check_pkg is
     variable pass : boolean;
   begin
     -- pragma translate_off
-    check_relation(default_checker, pass, (expr = '1'), msg, level, context_msg, path_offset, line_num, file_name);
+    check_relation(checker, pass, (expr = '1'), msg, level, context_msg, path_offset, line_num, file_name);
     -- pragma translate_on
     return pass;
   end;


### PR DESCRIPTION
I am working on adding unused code warnings to VHDL LS and noticed that the `checker` argument to this procedure was unused.