### PR TITLE
Add py.typed

### DIFF
--- a/docs/news.d/991.feature.rst
+++ b/docs/news.d/991.feature.rst
@@ -1,0 +1,1 @@
+Add ``py.typed`` file to indicate the existence of Python typing hints.


### PR DESCRIPTION
So that code that uses VUnit can be type checked with mypy against VUnit's type hints.

See here for background: https://peps.python.org/pep-0561/

I verified that the file is included in the PyPI releases by running "python3 setup sdist" and checking that it was present in "vunit/py.typed" in the release zip.