### PR TITLE
Minimize imports in an effort to lower simulation setup time

### DIFF
--- a/vunit/vhdl/check/src/check.vhd
+++ b/vunit/vhdl/check/src/check.vhd
@@ -6,15 +6,6 @@
 --
 -- Copyright (c) 2014-2024, Lars Asplund lars.anders.asplund@gmail.com
 
-library ieee;
-use ieee.std_logic_1164.all;
-use ieee.numeric_std.all;
-use std.textio.all;
-use work.checker_pkg.all;
-use work.string_ops.all;
-use work.location_pkg.all;
-use work.integer_vector_ptr_pkg.all;
-
 package body check_pkg is
   type boolean_vector is array (natural range <>) of boolean;
 

--- a/vunit/vhdl/check/src/check_api.vhd
+++ b/vunit/vhdl/check/src/check_api.vhd
@@ -10,12 +10,16 @@
 library ieee;
 use ieee.std_logic_1164.all;
 use ieee.numeric_std.all;
+
 use std.textio.all;
+
 use work.checker_pkg.all;
-use work.logger_pkg.all;
+use work.event_common_pkg.any_event_t;
+use work.event_common_pkg.notify;
+use work.integer_vector_ptr_pkg.all;
 use work.log_levels_pkg.all;
+use work.logger_pkg.logger_t;
 use work.string_ops.all;
-use work.event_common_pkg.all;
 use work.string_ptr_pkg.all;
 
 package check_pkg is

--- a/vunit/vhdl/com/src/com.vhd
+++ b/vunit/vhdl/com/src/com.vhd
@@ -9,18 +9,12 @@
 library ieee;
 use ieee.std_logic_1164.all;
 
-context work.vunit_context;
-
-use work.queue_pkg.all;
-use work.queue_2008p_pkg.all;
-use work.queue_pool_pkg.all;
-use work.integer_vector_ptr_pkg.all;
-use work.string_ptr_pkg.all;
-use work.codec_pkg.all;
-use work.com_support_pkg.all;
-use work.com_messenger_pkg.all;
 use work.com_common_pkg.all;
+use work.com_messenger_pkg.all;
+use work.com_support_pkg.all;
 use work.logger_pkg.all;
+use work.queue_pkg.all;
+use work.queue_pool_pkg.all;
 
 use std.textio.all;
 

--- a/vunit/vhdl/com/src/com_api.vhd
+++ b/vunit/vhdl/com/src/com_api.vhd
@@ -11,11 +11,9 @@ library ieee;
 use ieee.std_logic_1164.all;
 
 use work.com_types_pkg.all;
-use work.queue_pkg.all;
-use work.integer_vector_ptr_pkg.all;
-use work.string_ptr_pkg.all;
-use work.id_pkg.all;
-use work.event_private_pkg.all;
+use work.id_pkg.id_t;
+use work.event_private_pkg.new_basic_event;
+use work.event_private_pkg.com_net_event;
 
 package com_pkg is
   -- Global predefined network. See network_t description in com_types.vhd for

--- a/vunit/vhdl/com/src/com_common.vhd
+++ b/vunit/vhdl/com/src/com_common.vhd
@@ -9,10 +9,11 @@
 library ieee;
 use ieee.std_logic_1164.all;
 
-use work.com_messenger_pkg.all;
-use work.com_types_pkg.all;
-use work.event_common_pkg.all;
-use work.event_private_pkg.all;
+use work.com_messenger_pkg.messenger_t;
+use work.com_types_pkg.com_status_t;
+use work.event_common_pkg.notify;
+use work.event_common_pkg.is_active;
+use work.event_private_pkg.basic_event_t;
 
 package com_common_pkg is
   shared variable messenger :       messenger_t;

--- a/vunit/vhdl/com/src/com_debug_codec_builder.vhd
+++ b/vunit/vhdl/com/src/com_debug_codec_builder.vhd
@@ -6,10 +6,9 @@
 --
 -- Copyright (c) 2014-2024, Lars Asplund lars.anders.asplund@gmail.com
 
-library vunit_lib;
-context vunit_lib.vunit_context;
-
 use std.textio.all;
+
+use work.string_ops.all;
 
 package com_debug_codec_builder_pkg is
   -----------------------------------------------------------------------------

--- a/vunit/vhdl/com/src/com_messenger.vhd
+++ b/vunit/vhdl/com/src/com_messenger.vhd
@@ -12,7 +12,6 @@ use work.com_support_pkg.all;
 use work.queue_pkg.all;
 use work.queue_pool_pkg.all;
 use work.string_ptr_pkg.all;
-use work.codec_pkg.all;
 use work.logger_pkg.all;
 use work.log_levels_pkg.all;
 use work.id_pkg.all;

--- a/vunit/vhdl/com/src/com_support.vhd
+++ b/vunit/vhdl/com/src/com_support.vhd
@@ -4,8 +4,9 @@
 --
 -- Copyright (c) 2014-2024, Lars Asplund lars.anders.asplund@gmail.com
 
-context work.vunit_context;
 use work.com_types_pkg.all;
+use work.logger_pkg.all;
+use work.string_ops.all;
 
 package com_support_pkg is
 

--- a/vunit/vhdl/com/src/com_types.vhd
+++ b/vunit/vhdl/com/src/com_types.vhd
@@ -24,7 +24,7 @@ use work.queue_pkg.all;
 use work.queue_2008p_pkg.all;
 use work.queue_pool_pkg.all;
 use work.dict_pkg.all;
-use work.event_private_pkg.all;
+use work.event_private_pkg.basic_event_t;
 
 package com_types_pkg is
 

--- a/vunit/vhdl/core/src/core_pkg.vhd
+++ b/vunit/vhdl/core/src/core_pkg.vhd
@@ -5,6 +5,7 @@
 -- Copyright (c) 2014-2024, Lars Asplund lars.anders.asplund@gmail.com
 
 use std.textio.all;
+
 use work.stop_pkg;
 use work.integer_vector_ptr_pkg.all;
 use work.string_ptr_pkg.all;

--- a/vunit/vhdl/data_types/src/dict_pkg-body.vhd
+++ b/vunit/vhdl/data_types/src/dict_pkg-body.vhd
@@ -4,20 +4,6 @@
 --
 -- Copyright (c) 2014-2024, Lars Asplund lars.anders.asplund@gmail.com
 
-library ieee;
-use ieee.std_logic_1164.all;
-use ieee.math_complex.all;
-use ieee.numeric_bit.all;
-use ieee.numeric_std.all;
-
-use work.string_ptr_pkg.all;
-use work.string_ptr_pool_pkg.all;
-use work.integer_vector_ptr_pkg.all;
-use work.integer_vector_ptr_pool_pkg.all;
-use work.codec_pkg.all;
-use work.data_types_private_pkg.all;
-use work.queue_pkg.all;
-
 package body dict_pkg is
   constant int_pool : integer_vector_ptr_pool_t := new_integer_vector_ptr_pool;
   constant str_pool : string_ptr_pool_t := new_string_ptr_pool;

--- a/vunit/vhdl/data_types/src/dict_pkg.vhd
+++ b/vunit/vhdl/data_types/src/dict_pkg.vhd
@@ -14,15 +14,14 @@ use ieee.math_complex.all;
 use ieee.numeric_bit.all;
 use ieee.numeric_std.all;
 
-use work.string_ptr_pkg.all;
-use work.string_ptr_pool_pkg.all;
-use work.integer_vector_ptr_pkg.all;
-use work.integer_vector_ptr_pool_pkg.all;
 use work.codec_pkg.all;
 use work.data_types_private_pkg.all;
-use work.queue_pkg.all;
 use work.integer_array_pkg.all;
-use work.byte_vector_ptr_pkg.all;
+use work.integer_vector_ptr_pkg.all;
+use work.integer_vector_ptr_pool_pkg.all;
+use work.queue_pkg.all;
+use work.string_ptr_pkg.all;
+use work.string_ptr_pool_pkg.all;
 
 package dict_pkg is
   type dict_t is record

--- a/vunit/vhdl/data_types/src/integer_array_pkg-body.vhd
+++ b/vunit/vhdl/data_types/src/integer_array_pkg-body.vhd
@@ -4,10 +4,6 @@
 --
 -- Copyright (c) 2014-2024, Lars Asplund lars.anders.asplund@gmail.com
 
-use std.textio.all;
-use work.codec_pkg.all;
-use work.codec_builder_pkg.all;
-
 package body integer_array_pkg is
   type binary_file_t is file of character;
 

--- a/vunit/vhdl/data_types/src/integer_array_pkg.vhd
+++ b/vunit/vhdl/data_types/src/integer_array_pkg.vhd
@@ -4,6 +4,10 @@
 --
 -- Copyright (c) 2014-2024, Lars Asplund lars.anders.asplund@gmail.com
 
+use std.textio.all;
+
+use work.codec_builder_pkg.all;
+use work.codec_pkg.all;
 use work.integer_vector_ptr_pkg.all;
 
 package integer_array_pkg is

--- a/vunit/vhdl/data_types/src/integer_vector_ptr_pkg.vhd
+++ b/vunit/vhdl/data_types/src/integer_vector_ptr_pkg.vhd
@@ -10,11 +10,10 @@
 -- into a singleton datastructure of integer vector access types.
 --
 
-use work.types_pkg.all;
-use work.external_integer_vector_pkg.all;
-
-use work.codec_pkg.all;
 use work.codec_builder_pkg.all;
+use work.codec_pkg.all;
+use work.external_integer_vector_pkg.all;
+use work.types_pkg.all;
 
 package integer_vector_ptr_pkg is
 

--- a/vunit/vhdl/data_types/src/integer_vector_ptr_pool_pkg.vhd
+++ b/vunit/vhdl/data_types/src/integer_vector_ptr_pool_pkg.vhd
@@ -8,7 +8,6 @@ library ieee;
 use ieee.std_logic_1164.all;
 
 use work.integer_vector_ptr_pkg.all;
-use work.queue_pkg.all;
 
 package integer_vector_ptr_pool_pkg is
   type integer_vector_ptr_pool_t is record

--- a/vunit/vhdl/data_types/src/queue_pkg-2008p.vhd
+++ b/vunit/vhdl/data_types/src/queue_pkg-2008p.vhd
@@ -8,10 +8,9 @@ library ieee;
 use ieee.fixed_pkg.all;
 use ieee.float_pkg.all;
 
-use work.queue_pkg.all;
 use work.codec_2008p_pkg.all;
-use work.codec_builder_2008p_pkg.all;
 use work.data_types_private_pkg.all;
+use work.queue_pkg.all;
 
 package queue_2008p_pkg is
   procedure push (

--- a/vunit/vhdl/data_types/src/queue_pkg-body.vhd
+++ b/vunit/vhdl/data_types/src/queue_pkg-body.vhd
@@ -4,12 +4,6 @@
 --
 -- Copyright (c) 2014-2024, Lars Asplund lars.anders.asplund@gmail.com
 
-library ieee;
-use ieee.math_real.all;
-use ieee.math_complex.all;
-use work.codec_pkg.all;
-use work.codec_builder_pkg.all;
-
 package body queue_pkg is
   constant tail_idx : natural := 0;
   constant head_idx : natural := 1;

--- a/vunit/vhdl/data_types/src/queue_pkg.vhd
+++ b/vunit/vhdl/data_types/src/queue_pkg.vhd
@@ -5,14 +5,19 @@
 -- Copyright (c) 2014-2024, Lars Asplund lars.anders.asplund@gmail.com
 
 library ieee;
-use ieee.std_logic_1164.all;
 use ieee.math_complex.all;
+use ieee.math_real.all;
 use ieee.numeric_bit.all;
 use ieee.numeric_std.all;
+use ieee.std_logic_1164.all;
+
+use work.codec_builder_pkg.all;
+use work.codec_pkg.all;
+use work.data_types_private_pkg.all;
+use work.integer_array_pkg.integer_array_t;
+use work.integer_array_pkg.null_integer_array;
 use work.integer_vector_ptr_pkg.all;
 use work.string_ptr_pkg.all;
-use work.integer_array_pkg.all;
-use work.data_types_private_pkg.all;
 
 package queue_pkg is
   type queue_t is record

--- a/vunit/vhdl/data_types/src/string_ptr_pkg.vhd
+++ b/vunit/vhdl/data_types/src/string_ptr_pkg.vhd
@@ -11,10 +11,10 @@
 --
 
 use work.types_pkg.all;
+use work.codec_builder_pkg.decode;
+use work.codec_builder_pkg.integer_code_length;
+use work.codec_pkg.encode;
 use work.external_string_pkg.all;
-
-use work.codec_pkg.all;
-use work.codec_builder_pkg.all;
 
 package string_ptr_pkg is
 

--- a/vunit/vhdl/data_types/src/string_ptr_pool_pkg.vhd
+++ b/vunit/vhdl/data_types/src/string_ptr_pool_pkg.vhd
@@ -8,7 +8,6 @@ library ieee;
 use ieee.std_logic_1164.all;
 
 use work.string_ptr_pkg.all;
-use work.queue_pkg.all;
 use work.integer_vector_ptr_pkg.all;
 
 package string_ptr_pool_pkg is

--- a/vunit/vhdl/dictionary/src/dictionary.vhd
+++ b/vunit/vhdl/dictionary/src/dictionary.vhd
@@ -6,9 +6,10 @@
 --
 -- Copyright (c) 2014-2024, Lars Asplund lars.anders.asplund@gmail.com
 
+use std.textio.all;
+
 use work.string_ops.all;
 use work.logger_pkg.all;
-use std.textio.all;
 
 package dictionary is
   subtype frozen_dictionary_t is string;

--- a/vunit/vhdl/logging/src/common_log_pkg-body.vhd
+++ b/vunit/vhdl/logging/src/common_log_pkg-body.vhd
@@ -4,10 +4,6 @@
 --
 -- Copyright (c) 2014-2024, Lars Asplund lars.anders.asplund@gmail.com
 
-use work.ansi_pkg.all;
-use work.log_levels_pkg.all;
-use work.string_ops.upper;
-
 package body common_log_pkg is
   constant is_original_pkg : boolean := true;
 

--- a/vunit/vhdl/logging/src/common_log_pkg.vhd
+++ b/vunit/vhdl/logging/src/common_log_pkg.vhd
@@ -6,6 +6,10 @@
 
 use std.textio.all;
 
+use work.ansi_pkg.all;
+use work.log_levels_pkg.all;
+use work.string_ops.upper;
+
 package common_log_pkg is
   -- Deferred constant set to true in the native implementation of the package.
   -- Must be set to false in alternative implementations.

--- a/vunit/vhdl/logging/src/file_pkg.vhd
+++ b/vunit/vhdl/logging/src/file_pkg.vhd
@@ -5,6 +5,7 @@
 -- Copyright (c) 2014-2024, Lars Asplund lars.anders.asplund@gmail.com
 
 use std.textio.all;
+
 use work.integer_vector_ptr_pkg.all;
 use work.string_ptr_pkg.all;
 use work.common_log_pkg.all;

--- a/vunit/vhdl/logging/src/log_handler_pkg-body.vhd
+++ b/vunit/vhdl/logging/src/log_handler_pkg-body.vhd
@@ -4,17 +4,6 @@
 --
 -- Copyright (c) 2014-2024, Lars Asplund lars.anders.asplund@gmail.com
 
-use std.textio.all;
-
-library vunit_lib;
-use vunit_lib.string_ptr_pkg.all;
-use vunit_lib.integer_vector_ptr_pkg.all;
-
-use work.ansi_pkg.all;
-use work.string_ops.upper;
-use work.file_pkg.all;
-use work.common_log_pkg.all;
-
 package body log_handler_pkg is
 
   constant display_handler_id_number : natural := 0;

--- a/vunit/vhdl/logging/src/log_handler_pkg.vhd
+++ b/vunit/vhdl/logging/src/log_handler_pkg.vhd
@@ -4,8 +4,15 @@
 --
 -- Copyright (c) 2014-2024, Lars Asplund lars.anders.asplund@gmail.com
 
+use std.textio.all;
+
+use work.ansi_pkg.all;
+use work.common_log_pkg.all;
+use work.file_pkg.all;
 use work.integer_vector_ptr_pkg.all;
 use work.log_levels_pkg.all;
+use work.string_ops.upper;
+use work.string_ptr_pkg.all;
 
 package log_handler_pkg is
   type deprecated_log_format_t is (

--- a/vunit/vhdl/logging/src/log_levels_pkg-body.vhd
+++ b/vunit/vhdl/logging/src/log_levels_pkg-body.vhd
@@ -4,10 +4,6 @@
 --
 -- Copyright (c) 2014-2024, Lars Asplund lars.anders.asplund@gmail.com
 
-use work.string_ptr_pkg.all;
-use work.integer_vector_ptr_pkg.all;
-use work.core_pkg.all;
-
 package body log_levels_pkg is
 
   type levels_t is record

--- a/vunit/vhdl/logging/src/log_levels_pkg.vhd
+++ b/vunit/vhdl/logging/src/log_levels_pkg.vhd
@@ -4,8 +4,10 @@
 --
 -- Copyright (c) 2014-2024, Lars Asplund lars.anders.asplund@gmail.com
 
-use work.string_ptr_pkg.all;
 use work.ansi_pkg.all;
+use work.core_pkg.all;
+use work.integer_vector_ptr_pkg.all;
+use work.string_ptr_pkg.all;
 
 package log_levels_pkg is
 

--- a/vunit/vhdl/logging/src/logger_pkg-body.vhd
+++ b/vunit/vhdl/logging/src/logger_pkg-body.vhd
@@ -4,17 +4,6 @@
 --
 -- Copyright (c) 2014-2024, Lars Asplund lars.anders.asplund@gmail.com
 
-use work.string_ptr_pkg.all;
-use work.integer_vector_ptr_pkg.all;
-use work.queue_pkg.all;
-use work.core_pkg.core_failure;
-use std.textio.all;
-use work.string_ops.all;
-use work.print_pkg.print;
-use work.ansi_pkg.all;
-use work.location_pkg.all;
-use work.id_pkg.all;
-
 package body logger_pkg is
   constant global_log_count : integer_vector_ptr_t := new_integer_vector_ptr(1, value => 0);
   constant p_mock_queue_length : integer_vector_ptr_t := new_integer_vector_ptr(1, value => 0);

--- a/vunit/vhdl/logging/src/logger_pkg.vhd
+++ b/vunit/vhdl/logging/src/logger_pkg.vhd
@@ -4,10 +4,18 @@
 --
 -- Copyright (c) 2014-2024, Lars Asplund lars.anders.asplund@gmail.com
 
-use work.log_levels_pkg.all;
-use work.log_handler_pkg.all;
-use work.integer_vector_ptr_pkg.all;
+use std.textio.all;
+
+use work.ansi_pkg.all;
+use work.core_pkg.core_failure;
 use work.id_pkg.all;
+use work.integer_vector_ptr_pkg.all;
+use work.location_pkg.all;
+use work.log_handler_pkg.all;
+use work.log_levels_pkg.all;
+use work.print_pkg.print;
+use work.queue_pkg.all;
+use work.string_ops.all;
 
 package logger_pkg is
 

--- a/vunit/vhdl/logging/src/print_pkg-body.vhd
+++ b/vunit/vhdl/logging/src/print_pkg-body.vhd
@@ -4,8 +4,6 @@
 --
 -- Copyright (c) 2014-2024, Lars Asplund lars.anders.asplund@gmail.com
 
-use work.log_handler_pkg.stdout_file_name;
-
 package body print_pkg is
 
   procedure print(constant str : in string; file f : text) is

--- a/vunit/vhdl/logging/src/print_pkg.vhd
+++ b/vunit/vhdl/logging/src/print_pkg.vhd
@@ -6,6 +6,8 @@
 
 use std.textio.all;
 
+use work.log_handler_pkg.stdout_file_name;
+
 package print_pkg is
 
   -- Print to an open file object. No internal flushing.

--- a/vunit/vhdl/random/src/random_pkg.vhd
+++ b/vunit/vhdl/random/src/random_pkg.vhd
@@ -7,13 +7,11 @@
 -- Optional package that includes random functions for the data_types based on
 -- OSVVM
 
-library vunit_lib;
-context vunit_lib.vunit_context;
-use vunit_lib.integer_vector_ptr_pkg.all;
-use vunit_lib.integer_array_pkg.all;
-
 library osvvm;
-use osvvm.RandomPkg.all;
+use osvvm.RandomPkg.RandomPType;
+
+use work.integer_vector_ptr_pkg.all;
+use work.integer_array_pkg.all;
 
 package random_pkg is
   procedure random_integer_vector_ptr(variable rnd : inout RandomPType;

--- a/vunit/vhdl/verification_components/src/avalon_master.vhd
+++ b/vunit/vhdl/verification_components/src/avalon_master.vhd
@@ -7,20 +7,20 @@
 -- Avalon Memory Mapped Master BFM
 -- TODO:
 -- - handle byteenable in bursts
+
 library ieee;
 use ieee.std_logic_1164.all;
 use ieee.numeric_std.all;
 
-use work.queue_pkg.all;
-use work.bus_master_pkg.all;
-context work.com_context;
-use work.com_types_pkg.all;
-use work.logger_pkg.all;
-use work.check_pkg.all;
-use work.sync_pkg.all;
-
 library osvvm;
-use osvvm.RandomPkg.all;
+use osvvm.RandomPkg.RandomPType;
+
+use work.bus_master_pkg.all;
+use work.check_pkg.all;
+use work.com_pkg.all;
+use work.com_types_pkg.all;
+use work.queue_pkg.all;
+use work.sync_pkg.all;
 
 entity avalon_master is
   generic (

--- a/vunit/vhdl/verification_components/src/avalon_pkg.vhd
+++ b/vunit/vhdl/verification_components/src/avalon_pkg.vhd
@@ -4,13 +4,15 @@
 --
 -- Copyright (c) 2014-2024, Lars Asplund lars.anders.asplund@gmail.com
 -- Author Slawomir Siluk slaweksiluk@gazeta.pl
+
 library ieee;
 use ieee.std_logic_1164.all;
 
-use work.queue_pkg.all;
+use work.com_pkg.new_actor;
+use work.com_types_pkg.actor_t;
 use work.logger_pkg.all;
-use work.memory_pkg.all;
-context work.com_context;
+use work.memory_pkg.memory_t;
+use work.memory_pkg.to_vc_interface;
 
 package avalon_pkg is
 

--- a/vunit/vhdl/verification_components/src/avalon_sink.vhd
+++ b/vunit/vhdl/verification_components/src/avalon_sink.vhd
@@ -11,13 +11,13 @@
 library ieee;
 use ieee.std_logic_1164.all;
 
-context work.vunit_context;
-context work.com_context;
-use work.stream_slave_pkg.all;
-use work.avalon_stream_pkg.all;
-
 library osvvm;
-use osvvm.RandomPkg.all;
+use osvvm.RandomPkg.RandomPType;
+
+use work.avalon_stream_pkg.all;
+use work.com_pkg.all;
+use work.com_types_pkg.all;
+use work.stream_slave_pkg.stream_pop_msg;
 
 entity avalon_sink is
   generic (

--- a/vunit/vhdl/verification_components/src/avalon_slave.vhd
+++ b/vunit/vhdl/verification_components/src/avalon_slave.vhd
@@ -11,13 +11,13 @@ library ieee;
 use ieee.std_logic_1164.all;
 use ieee.numeric_std.all;
 
-context work.vunit_context;
-context work.com_context;
-use work.memory_pkg.all;
-use work.avalon_pkg.all;
-
 library osvvm;
-use osvvm.RandomPkg.all;
+use osvvm.RandomPkg.RandomPType;
+
+use work.avalon_pkg.avalon_slave_t;
+use work.com_pkg.all;
+use work.com_types_pkg.all;
+use work.memory_pkg.all;
 
 entity avalon_slave is
   generic (

--- a/vunit/vhdl/verification_components/src/avalon_source.vhd
+++ b/vunit/vhdl/verification_components/src/avalon_source.vhd
@@ -5,18 +5,19 @@
 -- Copyright (c) 2014-2024, Lars Asplund lars.anders.asplund@gmail.com
 -- Author Slawomir Siluk slaweksiluk@gazeta.pl
 -- Avalon-St Source Verification Component
+
 library ieee;
 use ieee.std_logic_1164.all;
 
-context work.vunit_context;
-context work.com_context;
-use work.stream_master_pkg.all;
-use work.avalon_stream_pkg.all;
-use work.queue_pkg.all;
-use work.sync_pkg.all;
-
 library osvvm;
-use osvvm.RandomPkg.all;
+use osvvm.RandomPkg.RandomPType;
+
+use work.avalon_stream_pkg.all;
+use work.com_pkg.receive;
+use work.com_pkg.net;
+use work.com_types_pkg.all;
+use work.stream_master_pkg.stream_push_msg;
+use work.sync_pkg.handle_sync_message;
 
 entity avalon_source is
   generic (

--- a/vunit/vhdl/verification_components/src/avalon_stream_pkg.vhd
+++ b/vunit/vhdl/verification_components/src/avalon_stream_pkg.vhd
@@ -7,11 +7,11 @@
 library ieee;
 use ieee.std_logic_1164.all;
 
+use work.com_pkg.all;
+use work.com_types_pkg.all;
 use work.logger_pkg.all;
-use work.stream_master_pkg.all;
-use work.stream_slave_pkg.all;
-context work.com_context;
-context work.data_types_context;
+use work.stream_master_pkg.stream_master_t;
+use work.stream_slave_pkg.stream_slave_t;
 
 package avalon_stream_pkg is
 

--- a/vunit/vhdl/verification_components/src/axi_lite_master.vhd
+++ b/vunit/vhdl/verification_components/src/axi_lite_master.vhd
@@ -8,15 +8,21 @@
 library ieee;
 use ieee.std_logic_1164.all;
 
-use work.queue_pkg.all;
-use work.bus_master_pkg.all;
-use work.sync_pkg.all;
-use work.axi_pkg.all;
-use work.axi_slave_pkg.all;
-use work.axi_slave_private_pkg.all;
 use work.axi_lite_master_pkg.all;
-context work.com_context;
-context work.vunit_context;
+use work.axi_pkg.all;
+use work.axi_slave_private_pkg.check_axi_resp;
+use work.bus_master_pkg.address_length;
+use work.bus_master_pkg.bus_master_t;
+use work.bus_master_pkg.byte_enable_length;
+use work.bus_master_pkg.data_length;
+use work.com_pkg.net;
+use work.com_pkg.receive;
+use work.com_pkg.reply;
+use work.com_types_pkg.all;
+use work.log_levels_pkg.all;
+use work.logger_pkg.all;
+use work.queue_pkg.all;
+use work.sync_pkg.all;
 
 entity axi_lite_master is
   generic(

--- a/vunit/vhdl/verification_components/src/axi_lite_master_pkg.vhd
+++ b/vunit/vhdl/verification_components/src/axi_lite_master_pkg.vhd
@@ -11,8 +11,9 @@ use ieee.numeric_std.all;
 
 use work.axi_pkg.all;
 use work.bus_master_pkg.all;
-context work.com_context;
-context work.vunit_context;
+use work.com_pkg.send;
+use work.com_types_pkg.all;
+use work.logger_pkg.all;
 
 package axi_lite_master_pkg is
 

--- a/vunit/vhdl/verification_components/src/axi_read_slave.vhd
+++ b/vunit/vhdl/verification_components/src/axi_read_slave.vhd
@@ -9,10 +9,10 @@ use ieee.std_logic_1164.all;
 use ieee.numeric_std.all;
 
 use work.axi_pkg.all;
+use work.axi_slave_pkg.axi_slave_t;
 use work.axi_slave_private_pkg.all;
-use work.queue_pkg.all;
-context work.com_context;
-context work.vc_context;
+use work.com_pkg.net;
+use work.memory_pkg.read_byte;
 
 entity axi_read_slave is
   generic (

--- a/vunit/vhdl/verification_components/src/axi_slave_pkg.vhd
+++ b/vunit/vhdl/verification_components/src/axi_slave_pkg.vhd
@@ -7,11 +7,13 @@
 library ieee;
 use ieee.std_logic_1164.all;
 
-use work.queue_pkg.all;
+use work.axi_statistics_pkg.axi_statistics_t;
+use work.axi_statistics_pkg.deallocate;
+use work.com_pkg.all;
+use work.com_types_pkg.all;
 use work.logger_pkg.all;
-use work.memory_pkg.all;
-context work.com_context;
-use work.axi_statistics_pkg.all;
+use work.memory_pkg.memory_t;
+use work.memory_pkg.to_vc_interface;
 
 package axi_slave_pkg is
   subtype probability_t is real range 0.0 to 1.0;

--- a/vunit/vhdl/verification_components/src/axi_slave_private_pkg.vhd
+++ b/vunit/vhdl/verification_components/src/axi_slave_private_pkg.vhd
@@ -12,15 +12,21 @@ use ieee.numeric_std.all;
 
 use std.textio.all;
 
-use work.axi_pkg.all;
-use work.queue_pkg.all;
-use work.integer_vector_ptr_pkg.all;
-context work.vunit_context;
-context work.com_context;
-context work.vc_context;
-
 library osvvm;
-use osvvm.RandomPkg.all;
+use osvvm.RandomPkg.RandomPType;
+
+use work.axi_pkg.all;
+use work.axi_slave_pkg.all;
+use work.axi_statistics_pkg.all;
+use work.bus_master_pkg.bus_master_t;
+use work.com_pkg.receive;
+use work.com_pkg.reply;
+use work.com_pkg.acknowledge;
+use work.com_types_pkg.all;
+use work.integer_vector_ptr_pkg.all;
+use work.log_levels_pkg.all;
+use work.logger_pkg.all;
+use work.queue_pkg.all;
 
 package axi_slave_private_pkg is
 

--- a/vunit/vhdl/verification_components/src/axi_stream_master.vhd
+++ b/vunit/vhdl/verification_components/src/axi_stream_master.vhd
@@ -7,16 +7,17 @@
 library ieee;
 use ieee.std_logic_1164.all;
 
-context work.vunit_context;
-context work.com_context;
-use work.stream_master_pkg.all;
-use work.axi_stream_pkg.all;
-use work.axi_stream_private_pkg.all;
-use work.queue_pkg.all;
-use work.sync_pkg.all;
-
 library osvvm;
 use osvvm.RandomPkg.RandomPType;
+
+use work.axi_stream_pkg.all;
+use work.axi_stream_private_pkg.probability_stall_axi_stream;
+use work.com_pkg.net;
+use work.com_pkg.receive;
+use work.com_types_pkg.all;
+use work.queue_pkg.all;
+use work.stream_master_pkg.stream_push_msg;
+use work.sync_pkg.all;
 
 entity axi_stream_master is
   generic (

--- a/vunit/vhdl/verification_components/src/axi_stream_monitor.vhd
+++ b/vunit/vhdl/verification_components/src/axi_stream_monitor.vhd
@@ -7,9 +7,13 @@
 library ieee;
 use ieee.std_logic_1164.all;
 
-context work.vunit_context;
-context work.com_context;
 use work.axi_stream_pkg.all;
+use work.com_pkg.net;
+use work.com_pkg.publish;
+use work.com_types_pkg.msg_t;
+use work.log_levels_pkg.all;
+use work.logger_pkg.all;
+use work.string_ops.all;
 
 entity axi_stream_monitor is
   generic (

--- a/vunit/vhdl/verification_components/src/axi_stream_pkg.vhd
+++ b/vunit/vhdl/verification_components/src/axi_stream_pkg.vhd
@@ -10,12 +10,11 @@ use ieee.std_logic_1164.all;
 use work.logger_pkg.all;
 use work.checker_pkg.all;
 use work.check_pkg.all;
-use work.stream_master_pkg.all;
-use work.stream_slave_pkg.all;
-use work.sync_pkg.all;
-context work.vunit_context;
-context work.com_context;
-context work.data_types_context;
+use work.stream_master_pkg.stream_master_t;
+use work.stream_slave_pkg.stream_slave_t;
+use work.sync_pkg.sync_handle_t;
+use work.com_pkg.all;
+use work.com_types_pkg.all;
 
 package axi_stream_pkg is
 

--- a/vunit/vhdl/verification_components/src/axi_stream_protocol_checker.vhd
+++ b/vunit/vhdl/verification_components/src/axi_stream_protocol_checker.vhd
@@ -10,9 +10,15 @@ use ieee.numeric_std_unsigned.all;
 
 use std.textio.all;
 
-context work.vunit_context;
-context work.com_context;
 use work.axi_stream_pkg.all;
+use work.check_pkg.all;
+use work.checker_pkg.all;
+use work.event_common_pkg.is_active;
+use work.integer_array_pkg.all;
+use work.log_levels_pkg.all;
+use work.logger_pkg.all;
+use work.run_pkg.all;
+use work.run_types_pkg.all;
 
 entity axi_stream_protocol_checker is
   generic (

--- a/vunit/vhdl/verification_components/src/axi_stream_slave.vhd
+++ b/vunit/vhdl/verification_components/src/axi_stream_slave.vhd
@@ -7,18 +7,22 @@
 library ieee;
 use ieee.std_logic_1164.all;
 
-context work.vunit_context;
-context work.com_context;
-use work.stream_slave_pkg.all;
-use work.axi_stream_pkg.all;
-use work.axi_stream_private_pkg.all;
-use work.sync_pkg.all;
-use work.string_ptr_pkg.all;
-use work.event_common_pkg.all;
-use work.event_pkg.all;
-
 library osvvm;
 use osvvm.RandomPkg.RandomPType;
+
+use work.check_pkg.all;
+use work.com_pkg.all;
+use work.com_types_pkg.all;
+use work.id_pkg.all;
+use work.queue_pkg.all;
+use work.stream_slave_pkg.stream_pop_msg;
+use work.axi_stream_pkg.all;
+use work.axi_stream_private_pkg.probability_stall_axi_stream;
+use work.sync_pkg.all;
+use work.string_ptr_pkg.all;
+use work.event_common_pkg.is_active;
+use work.event_common_pkg.notify;
+use work.event_pkg.all;
 
 entity axi_stream_slave is
   generic (

--- a/vunit/vhdl/verification_components/src/axi_write_slave.vhd
+++ b/vunit/vhdl/verification_components/src/axi_write_slave.vhd
@@ -11,11 +11,11 @@ use ieee.numeric_std.all;
 use work.axi_pkg.all;
 use work.axi_slave_pkg.all;
 use work.axi_slave_private_pkg.all;
-use work.queue_pkg.all;
-use work.memory_pkg.all;
+use work.com_pkg.net;
 use work.integer_vector_ptr_pkg.all;
 use work.integer_vector_ptr_pool_pkg.all;
-context work.com_context;
+use work.memory_pkg.all;
+use work.queue_pkg.all;
 
 entity axi_write_slave is
   generic (

--- a/vunit/vhdl/verification_components/src/bus2memory.vhd
+++ b/vunit/vhdl/verification_components/src/bus2memory.vhd
@@ -8,9 +8,11 @@ library ieee;
 use ieee.std_logic_1164.all;
 use ieee.numeric_std.all;
 
-context work.com_context;
-use work.queue_pkg.all;
 use work.bus_master_pkg.all;
+use work.com_pkg.net;
+use work.com_pkg.receive;
+use work.com_pkg.reply;
+use work.com_types_pkg.all;
 use work.memory_pkg.all;
 
 entity bus2memory is

--- a/vunit/vhdl/verification_components/src/bus_master_pkg-body.vhd
+++ b/vunit/vhdl/verification_components/src/bus_master_pkg-body.vhd
@@ -4,15 +4,6 @@
 --
 -- Copyright (c) 2014-2024, Lars Asplund lars.anders.asplund@gmail.com
 
-library ieee;
-use ieee.std_logic_1164.all;
-use ieee.numeric_std.all;
-
-use work.queue_pkg.all;
-use work.sync_pkg.all;
-use work.queue_pkg.all;
-use work.check_pkg.all;
-
 package body bus_master_pkg is
 
   impure function new_bus(data_length : natural;

--- a/vunit/vhdl/verification_components/src/bus_master_pkg.vhd
+++ b/vunit/vhdl/verification_components/src/bus_master_pkg.vhd
@@ -7,12 +7,14 @@
 -- Defines bus master verification component interface
 
 library ieee;
+use ieee.numeric_std.all;
 use ieee.std_logic_1164.all;
 
+use work.com_pkg.all;
+use work.com_types_pkg.all;
 use work.logger_pkg.all;
-context work.com_context;
-use work.sync_pkg.all;
 use work.queue_pkg.all;
+use work.sync_pkg.all;
 
 package bus_master_pkg is
 

--- a/vunit/vhdl/verification_components/src/memory_pkg-body.vhd
+++ b/vunit/vhdl/verification_components/src/memory_pkg-body.vhd
@@ -4,9 +4,6 @@
 --
 -- Copyright (c) 2014-2024, Lars Asplund lars.anders.asplund@gmail.com
 
-library ieee;
-use ieee.numeric_std.all;
-
 package body memory_pkg is
 
   constant num_bytes_idx : natural := 0;

--- a/vunit/vhdl/verification_components/src/memory_pkg.vhd
+++ b/vunit/vhdl/verification_components/src/memory_pkg.vhd
@@ -7,12 +7,13 @@
 -- Model of a memory address space
 
 library ieee;
+use ieee.numeric_std.all;
 use ieee.std_logic_1164.all;
 
-use work.types_pkg.all;
-use work.string_ptr_pkg.all;
 use work.integer_vector_ptr_pkg.all;
 use work.logger_pkg.all;
+use work.string_ptr_pkg.all;
+use work.types_pkg.byte_t;
 
 package memory_pkg is
 

--- a/vunit/vhdl/verification_components/src/ram_master.vhd
+++ b/vunit/vhdl/verification_components/src/ram_master.vhd
@@ -9,10 +9,14 @@ library ieee;
 use ieee.std_logic_1164.all;
 use ieee.numeric_std.all;
 
-use work.queue_pkg.all;
 use work.bus_master_pkg.all;
-use work.sync_pkg.all;
-context work.com_context;
+use work.com_pkg.net;
+use work.com_pkg.receive;
+use work.com_pkg.reply;
+use work.com_types_pkg.all;
+use work.queue_pkg.all;
+use work.sync_pkg.handle_wait_until_idle;
+use work.sync_pkg.wait_until_idle_msg;
 
 entity ram_master is
   generic (

--- a/vunit/vhdl/verification_components/src/signal_checker_pkg.vhd
+++ b/vunit/vhdl/verification_components/src/signal_checker_pkg.vhd
@@ -7,10 +7,11 @@
 library ieee;
 use ieee.std_logic_1164.all;
 
-context work.vunit_context;
-context work.com_context;
-
-use work.sync_pkg.all;
+use work.com_pkg.new_actor;
+use work.com_pkg.send;
+use work.com_types_pkg.all;
+use work.logger_pkg.all;
+use work.sync_pkg.wait_until_idle;
 
 package signal_checker_pkg is
   type signal_checker_t is record

--- a/vunit/vhdl/verification_components/src/std_logic_checker.vhd
+++ b/vunit/vhdl/verification_components/src/std_logic_checker.vhd
@@ -7,11 +7,15 @@
 library ieee;
 use ieee.std_logic_1164.all;
 
-context work.vunit_context;
-context work.data_types_context;
-context work.com_context;
+use work.com_pkg.net;
+use work.com_pkg.receive;
+use work.com_pkg.reply;
+use work.com_types_pkg.all;
+use work.logger_pkg.all;
+use work.queue_pkg.all;
 use work.signal_checker_pkg.all;
-use work.sync_pkg.all;
+use work.sync_pkg.wait_until_idle_msg;
+use work.sync_pkg.wait_until_idle_reply_msg;
 
 entity std_logic_checker is
   generic (

--- a/vunit/vhdl/verification_components/src/stream_master_pkg-body.vhd
+++ b/vunit/vhdl/verification_components/src/stream_master_pkg-body.vhd
@@ -4,12 +4,6 @@
 --
 -- Copyright (c) 2014-2024, Lars Asplund lars.anders.asplund@gmail.com
 
-library ieee;
-use ieee.std_logic_1164.all;
-
-context work.vunit_context;
-context work.com_context;
-
 package body stream_master_pkg is
   impure function new_stream_master return stream_master_t is
   begin

--- a/vunit/vhdl/verification_components/src/stream_master_pkg.vhd
+++ b/vunit/vhdl/verification_components/src/stream_master_pkg.vhd
@@ -9,8 +9,9 @@
 library ieee;
 use ieee.std_logic_1164.all;
 
-context work.vunit_context;
-context work.com_context;
+use work.com_pkg.new_actor;
+use work.com_pkg.send;
+use work.com_types_pkg.all;
 
 package stream_master_pkg is
   -- Stream master handle

--- a/vunit/vhdl/verification_components/src/stream_slave_pkg.vhd
+++ b/vunit/vhdl/verification_components/src/stream_slave_pkg.vhd
@@ -9,8 +9,9 @@
 library ieee;
 use ieee.std_logic_1164.all;
 
-context work.vunit_context;
-context work.com_context;
+use work.check_pkg.all;
+use work.com_pkg.all;
+use work.com_types_pkg.all;
 
 package stream_slave_pkg is
   -- Stream slave handle

--- a/vunit/vhdl/verification_components/src/sync_pkg-body.vhd
+++ b/vunit/vhdl/verification_components/src/sync_pkg-body.vhd
@@ -4,10 +4,6 @@
 --
 -- Copyright (c) 2014-2024, Lars Asplund lars.anders.asplund@gmail.com
 
-context work.vunit_context;
-use work.queue_pkg.all;
-context work.com_context;
-
 package body sync_pkg is
   procedure wait_until_idle(signal net : inout network_t;
                             handle     :       sync_handle_t) is

--- a/vunit/vhdl/verification_components/src/sync_pkg.vhd
+++ b/vunit/vhdl/verification_components/src/sync_pkg.vhd
@@ -6,8 +6,10 @@
 
 -- Defines synchronization verification component interface VCI
 
-context work.vunit_context;
-context work.com_context;
+use work.com_pkg.request;
+use work.com_pkg.send;
+use work.com_pkg.reply;
+use work.com_types_pkg.all;
 
 package sync_pkg is
 

--- a/vunit/vhdl/verification_components/src/uart_master.vhd
+++ b/vunit/vhdl/verification_components/src/uart_master.vhd
@@ -7,13 +7,13 @@
 library ieee;
 use ieee.std_logic_1164.all;
 
-library vunit_lib;
-context vunit_lib.vunit_context;
-context vunit_lib.com_context;
-use vunit_lib.stream_master_pkg.all;
-use vunit_lib.uart_pkg.all;
-use vunit_lib.queue_pkg.all;
-use vunit_lib.sync_pkg.all;
+use work.com_pkg.net;
+use work.com_pkg.receive;
+use work.com_types_pkg.all;
+use work.logger_pkg.all;
+use work.stream_master_pkg.stream_push_msg;
+use work.sync_pkg.handle_sync_message;
+use work.uart_pkg.all;
 
 entity uart_master is
   generic (

--- a/vunit/vhdl/verification_components/src/uart_pkg.vhd
+++ b/vunit/vhdl/verification_components/src/uart_pkg.vhd
@@ -7,12 +7,12 @@
 library ieee;
 use ieee.std_logic_1164.all;
 
-context work.com_context;
-use work.stream_master_pkg.all;
-use work.stream_slave_pkg.all;
-use work.sync_pkg.all;
-use work.integer_vector_ptr_pkg.all;
-use work.queue_pkg.all;
+use work.com_pkg.new_actor;
+use work.com_pkg.send;
+use work.com_types_pkg.all;
+use work.stream_master_pkg.stream_master_t;
+use work.stream_slave_pkg.stream_slave_t;
+use work.sync_pkg.sync_handle_t;
 
 package uart_pkg is
   type uart_master_t is record

--- a/vunit/vhdl/verification_components/src/uart_slave.vhd
+++ b/vunit/vhdl/verification_components/src/uart_slave.vhd
@@ -7,12 +7,13 @@
 library ieee;
 use ieee.std_logic_1164.all;
 
-library vunit_lib;
-context vunit_lib.vunit_context;
-context vunit_lib.com_context;
-use vunit_lib.stream_slave_pkg.all;
-use vunit_lib.uart_pkg.all;
-use vunit_lib.queue_pkg.all;
+use work.com_pkg.net;
+use work.com_pkg.receive;
+use work.com_pkg.reply;
+use work.com_types_pkg.all;
+use work.queue_pkg.all;
+use work.stream_slave_pkg.stream_pop_msg;
+use work.uart_pkg.all;
 
 entity uart_slave is
   generic (

--- a/vunit/vhdl/verification_components/src/wishbone_master.vhd
+++ b/vunit/vhdl/verification_components/src/wishbone_master.vhd
@@ -9,17 +9,16 @@
 library ieee;
 use ieee.std_logic_1164.all;
 
-use work.queue_pkg.all;
+library osvvm;
+use osvvm.RandomPkg.RandomPType;
+
 use work.bus_master_pkg.all;
-context work.com_context;
+use work.com_pkg.all;
+use work.queue_pkg.all;
 use work.com_types_pkg.all;
-use work.logger_pkg.all;
 use work.check_pkg.all;
 use work.log_levels_pkg.all;
 use work.sync_pkg.all;
-
-library osvvm;
-use osvvm.RandomPkg.all;
 
 entity wishbone_master is
   generic (

--- a/vunit/vhdl/verification_components/src/wishbone_pkg.vhd
+++ b/vunit/vhdl/verification_components/src/wishbone_pkg.vhd
@@ -4,13 +4,15 @@
 --
 -- Copyright (c) 2014-2024, Lars Asplund lars.anders.asplund@gmail.com
 -- Author Slawomir Siluk slaweksiluk@gazeta.pl
+
 library ieee;
 use ieee.std_logic_1164.all;
 
-use work.queue_pkg.all;
+use work.com_pkg.new_actor;
+use work.com_types_pkg.actor_t;
 use work.logger_pkg.all;
-use work.memory_pkg.all;
-context work.com_context;
+use work.memory_pkg.memory_t;
+use work.memory_pkg.to_vc_interface;
 
 package wishbone_pkg is
 

--- a/vunit/vhdl/verification_components/src/wishbone_slave.vhd
+++ b/vunit/vhdl/verification_components/src/wishbone_slave.vhd
@@ -13,13 +13,16 @@ library ieee;
 use ieee.std_logic_1164.all;
 use ieee.numeric_std.all;
 
-context work.vunit_context;
-context work.com_context;
-use work.memory_pkg.all;
-use work.wishbone_pkg.all;
-
 library osvvm;
-use osvvm.RandomPkg.all;
+use osvvm.RandomPkg.RandomPType;
+
+use work.com_pkg.net;
+use work.com_pkg.receive;
+use work.com_pkg.send;
+use work.com_types_pkg.all;
+use work.memory_pkg.read_word;
+use work.memory_pkg.write_word;
+use work.wishbone_pkg.all;
 
 entity wishbone_slave is
   generic (


### PR DESCRIPTION
These changes represent a 21% reduction of execution time for the 460 test cases in hdl-modules repo: https://github.com/hdl-modules/hdl-modules For some small testbenches, the reduction is as much as 42%. Note that this repo contains only small to medium sized testbenches (1-10 seconds, with most around 1-4 seconds).

This is all using the GHDL simulator with GCC backend on Linux. With ModelSim Intel FPGA starter edition 2020.1, the reductions is negligible (1-2%).

This change:

1. Stop using "context" in all VUnit packages. In most packages, importing with context includes a lot more than what is actually used.

2. Stop using "use work.x_pkg.all" in cases where only 1-3 things are used from the package. Instead, one explicit "use" clause for the things that are actually used.

   * Not done for the most common packages (run_pkg, check_pkg, logger_pkg).

   * Not done for includes from very small packages.

3. For packages that have head and body in different files, move all imports to the head file. As they were, split between the files, there was a lot of overlap of imports, and it what hard to get an overview of what is actually imported and what is actually used.


The first point represents roughly 80% of the performance gain.

Note that in order to reach the performance gains listed above, the corresponding changes have to be made to all testbenches and simulation code in the user repo also. If the testbench includes "vunit_context", "com_context" etc, the performance gains will not be realized since everything will be imported anyway.