### PR TITLE
Remove redundant directory from Riviera-PRO dataset path

### DIFF
--- a/vunit/sim_if/rivierapro.py
+++ b/vunit/sim_if/rivierapro.py
@@ -291,7 +291,7 @@ class RivieraProInterface(VsimSimulatorMixin, SimulatorInterface):
         pli_str = " ".join(f'-pli "{fix_path(name)}"' for name in config.sim_options.get("pli", []))
 
         vsim_flags = [
-            f"-dataset {{{fix_path(str(Path(output_path) / 'dataset.asdb'))!s}}}",
+            f"-dataset {{{fix_path(str(output_path))!s}}}",
             pli_str,
             set_generic_str,
         ]


### PR DESCRIPTION
The `-dataset` argument for Riviera-PRO vsim command points to directory, not file:
`-dataset <DIR>`

Filename dataset.asdb is hardcoded and cannot be changed.
Current usage (`-dataset output_path/dataset.asdb`) results in creating redundant directory:
`output_path/dataset.asdb/dataset.asdb`