### PR TITLE
Add GHDL backend detection support for mcode JIT

### DIFF
--- a/docs/news.d/1005.feature.rst
+++ b/docs/news.d/1005.feature.rst
@@ -1,0 +1,1 @@
+[GHDL] Add support for mcode JIT in backend detection.

--- a/tests/unit/test_ghdl_interface.py
+++ b/tests/unit/test_ghdl_interface.py
@@ -87,6 +87,19 @@ warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
         check_output.return_value = version
         self.assertEqual(GHDLInterface.determine_backend("prefix"), "mcode")
 
+        version = b"""\
+GHDL 5.0.0-dev (4.0.0.r9.g77785e49e) [Dunoon edition]
+ Compiled with GNAT Version: 10.5.0
+ static elaboration, mcode JIT code generator
+Written by Tristan Gingold.
+
+Copyright (C) 2003 - 2024 Tristan Gingold.
+GHDL is free software, covered by the GNU General Public License.  There is NO
+warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+"""
+        check_output.return_value = version
+        self.assertEqual(GHDLInterface.determine_backend("prefix"), "mcode")
+
     @mock.patch("subprocess.check_output", autospec=True)
     def test_parses_gcc_backend(self, check_output):
         version = b"""\

--- a/vunit/sim_if/ghdl.py
+++ b/vunit/sim_if/ghdl.py
@@ -125,7 +125,7 @@ class GHDLInterface(SimulatorInterface):  # pylint: disable=too-many-instance-at
         Determine the GHDL backend
         """
         mapping = {
-            r"mcode code generator": "mcode",
+            r"mcode (JIT )?code generator": "mcode",
             r"llvm (\d+\.\d+\.\d+ )?code generator": "llvm",
             r"GCC (back-end|\d+\.\d+\.\d+) code generator": "gcc",
         }


### PR DESCRIPTION
Ongoing work on the GHDL master branch to use JIT makes VUnit backend detection fail. This makes all GitHub projects that use https://github.com/ghdl/setup-ghdl-ci with VUnit in their CI fail.

This commit adapts the regular expression so it works with newer as well as older GHDL versions with the mcode backend. As for the other backends, it looks like (https://github.com/ghdl/ghdl/commit/4b20cd9e67282b14232d7ff7f6d81df1155fb611#diff-0dc1fb1faeb66cc2780208579bbbe6a87011ad37a31f3d84dd64ff2224111fb6R530) they should all be affected by this change in the "ghdl --version" output. Or at least the LLVM backend?

I don't have access to GHDL built with GCC or LLVM, frankly I don't know how to build them. But I know that this PR fixes the issue for mcode. Perhaps there will be error reports or PRs from other people who use GCC/LLVM in the future.