### PR TITLE
allow use modelsim predefined external libs 

### DIFF
--- a/vunit/project.py
+++ b/vunit/project.py
@@ -83,28 +83,37 @@ class Project(object):  # pylint: disable=too-many-instance-attributes
     def add_library(
         self,
         logical_name,
-        directory: Union[str, Path],
+        directory: Union[str, Path] = None,
         vhdl_standard: VHDLStandard = VHDL.STD_2008,
         is_external=False,
     ):
         """
         Add library to project with logical_name located or to be located in directory
         is_external -- Library is assumed to a black-box
+        
+        :param directory: The path to the external library directory
+                                if None - supposes simulator provides library_name
         """
         self._validate_new_library_name(logical_name)
 
-        dpath = Path(directory)
-        dstr = str(directory)
-
-        if is_external:
-            if not dpath.exists():
-                raise ValueError(f"External library {dstr!r} does not exist")
-
-            if not dpath.is_dir():
-                raise ValueError(f"External library must be a directory. Got {dstr!r}")
+        if directory :
+            dpath = Path(directory)
+            dstr = str(directory)
+    
+            if is_external:
+                if not dpath.exists():
+                    raise ValueError(f"External library {dstr!r} does not exist")
+    
+                if not dpath.is_dir():
+                    raise ValueError(f"External library must be a directory. Got {dstr!r}")
+            
+            LOGGER.debug("Adding library %s with path %s", logical_name, dstr)
+        else:
+            dstr = None
+            is_external = True
+            LOGGER.debug("Use library %s", logical_name)
 
         library = Library(logical_name, dstr, vhdl_standard, is_external=is_external)
-        LOGGER.debug("Adding library %s with path %s", logical_name, dstr)
 
         self._libraries[logical_name] = library
         self._lower_library_names_dict[logical_name.lower()] = library.name

--- a/vunit/sim_if/modelsim.py
+++ b/vunit/sim_if/modelsim.py
@@ -202,6 +202,15 @@ class ModelSimInterface(VsimSimulatorMixin, SimulatorInterface):  # pylint: disa
         """
         mapped_libraries = mapped_libraries if mapped_libraries is not None else {}
 
+        if library_name in mapped_libraries:
+            if mapped_libraries[library_name] == path:
+                return
+            elif path is None:  # use existing map 
+                return
+        
+        if path is None:
+            raise ValueError(f"External library {library_name!r} does not exist")
+            
         apath = str(Path(path).parent.resolve())
 
         if not file_exists(apath):
@@ -210,9 +219,6 @@ class ModelSimInterface(VsimSimulatorMixin, SimulatorInterface):  # pylint: disa
         if not file_exists(path):
             proc = Process([str(Path(self._prefix) / "vlib"), "-unix", path], env=self.get_env())
             proc.consume_output(callback=None)
-
-        if library_name in mapped_libraries and mapped_libraries[library_name] == path:
-            return
 
         cfg = parse_modelsimini(self._sim_cfg_file_name)
         cfg.set("Library", library_name, path)

--- a/vunit/ui/__init__.py
+++ b/vunit/ui/__init__.py
@@ -207,12 +207,13 @@ class VUnit(object):  # pylint: disable=too-many-instance-attributes, too-many-p
 
         return VHDL.standard(vhdl_standard)
 
-    def add_external_library(self, library_name, path: Union[str, Path], vhdl_standard: Optional[str] = None):
+    def add_external_library(self, library_name, path: Union[str, Path] = None, vhdl_standard: Optional[str] = None):
         """
         Add an externally compiled library as a black-box
 
         :param library_name: The name of the external library
         :param path: The path to the external library directory
+                              if None - supposes simulator provides library_name
         :param vhdl_standard: The VHDL standard used to compile files,
                               if None the VUNIT_VHDL_STANDARD environment variable is used
         :returns: The created :class:`.Library` object
@@ -225,9 +226,12 @@ class VUnit(object):  # pylint: disable=too-many-instance-attributes, too-many-p
 
         """
 
+        if path:
+            path = Path(path).resolve()
+        
         self._project.add_library(
             library_name,
-            Path(path).resolve(),
+            path,
             self._which_vhdl_standard(vhdl_standard),
             is_external=True,
         )


### PR DESCRIPTION
add_external_library( path = None ...) - allow use external library provided by simulator.

* Need when dependancy evaluation can't investigate all libraries - for example when verlog modules relates to verilog libraries, and there is no sv package, that handle it.

* implemented for Modelsim interface  - use external library from ini for that external library whithout path