### PR TITLE
modelsim ini options for GUI mode

### DIFF
--- a/vunit/sim_if/__init__.py
+++ b/vunit/sim_if/__init__.py
@@ -400,6 +400,27 @@ class ListOfStringOption(Option):
         except TypeError:
             fail()
 
+class DictOfStringOption(Option):
+    """
+    Must be a dictinary of strings
+    """
+
+    def validate(self, value):
+        def fail():
+            raise ValueError(f"Option {self.name!r} must be a dictionary of strings. Got {value!r}")
+
+        if not isinstance(value, dict):
+            fail()
+
+        try:
+            for name, elem in value.items():
+                if not is_string_not_iterable(name):
+                    fail()
+                if not is_string_not_iterable(elem):
+                    fail()
+        except TypeError:
+            fail()
+
 
 class VHDLAssertLevelOption(Option):
     """


### PR DESCRIPTION
modelsim ini options for GUI mode now can setup with via "modelsim.vsim_ini.gui" sim option.

* usage: 
```
simwave = "wave.do"
UI.set_sim_option("modelsim.vsim_ini.gui", { "ShutdownFile": str(simwave.resolve()) });
```

this provides option in modelsim.ini for GUI-mode simulation:
```
[vsim]
ShutdownFile=wave.do
```
That saves all wave-setup on UI close
