### PR TITLE
Enchance time reporting in report.py and runner.py

### DIFF
--- a/docs/news.d/1025.feature.rst
+++ b/docs/news.d/1025.feature.rst
@@ -1,0 +1,1 @@
+Update time reporting from test results. Also add timestamps when starting tests.

--- a/docs/release_notes/4.8.0.rst
+++ b/docs/release_notes/4.8.0.rst
@@ -1,0 +1,5 @@
+Features
+~~~~~~~~
+
+- Update time reporting from test results.
+- Add timestamps to run tests.

--- a/docs/release_notes/4.8.0.rst
+++ b/docs/release_notes/4.8.0.rst
@@ -1,5 +1,0 @@
-Features
-~~~~~~~~
-
-- Update time reporting from test results.
-- Add timestamps to run tests.

--- a/tests/unit/test_test_report.py
+++ b/tests/unit/test_test_report.py
@@ -163,7 +163,6 @@ Elapsed time was 45.0 s
         self.assertTrue(report.result_of("passed_test2").passed)
         self.assertTrue(report.result_of("passed_test3").passed)
 
-
     def test_report_with_long_tests(self):
         report = self._report_with_long_tests()
         report.set_real_total_time(3700.0)
@@ -193,7 +192,6 @@ Elapsed time was 1 h 1 min 40.0 s
         self.assertTrue(report.result_of("passed_test3").passed)
         self.assertTrue(report.result_of("passed_test4").passed)
         self.assertTrue(report.result_of("passed_test5").passed)
-
 
     def test_report_with_no_tests(self):
         report = self._new_report()
@@ -383,9 +381,9 @@ Elapsed time was 1 h 1 min 40.0 s
     def _report_with_mixed_length_tests(self):
         "@returns A report with various long tests"
         report = self._new_report()
-        report.add_result("passed_test0", PASSED,  time=0.2, output_file_name=self.output_file_name)
-        report.add_result("passed_test1", PASSED,  time=2.1, output_file_name=self.output_file_name)
-        report.add_result("passed_test2", PASSED,  time=5.3, output_file_name=self.output_file_name)
+        report.add_result("passed_test0", PASSED, time=0.2, output_file_name=self.output_file_name)
+        report.add_result("passed_test1", PASSED, time=2.1, output_file_name=self.output_file_name)
+        report.add_result("passed_test2", PASSED, time=5.3, output_file_name=self.output_file_name)
         report.add_result("passed_test3", PASSED, time=60.3, output_file_name=self.output_file_name)
         report.set_expected_num_tests(4)
         return report
@@ -393,11 +391,11 @@ Elapsed time was 1 h 1 min 40.0 s
     def _report_with_long_tests(self):
         "@returns A report with various long tests"
         report = self._new_report()
-        report.add_result("passed_test0", PASSED,    time=0.2, output_file_name=self.output_file_name)
-        report.add_result("passed_test1", PASSED,    time=2.1, output_file_name=self.output_file_name)
-        report.add_result("passed_test2", PASSED,   time=10.3, output_file_name=self.output_file_name)
-        report.add_result("passed_test3", PASSED,   time=60.1, output_file_name=self.output_file_name)
-        report.add_result("passed_test4", PASSED,  time=615.1, output_file_name=self.output_file_name)
+        report.add_result("passed_test0", PASSED, time=0.2, output_file_name=self.output_file_name)
+        report.add_result("passed_test1", PASSED, time=2.1, output_file_name=self.output_file_name)
+        report.add_result("passed_test2", PASSED, time=10.3, output_file_name=self.output_file_name)
+        report.add_result("passed_test3", PASSED, time=60.1, output_file_name=self.output_file_name)
+        report.add_result("passed_test4", PASSED, time=615.1, output_file_name=self.output_file_name)
         report.add_result("passed_test5", PASSED, time=3780.1, output_file_name=self.output_file_name)
         report.set_expected_num_tests(6)
         return report

--- a/tests/unit/test_test_report.py
+++ b/tests/unit/test_test_report.py
@@ -93,9 +93,9 @@ Elapsed time was 1.0 s
             self.report_to_str(report),
             """\
 ==== Summary ========================
-{gi}pass{x} passed_test  (2.0 s)
+{gi}pass{x} passed_test  ( 2.0 s)
 {ri}fail{x} failed_test0 (11.1 s)
-{ri}fail{x} failed_test1 (3.0 s)
+{ri}fail{x} failed_test1 ( 3.0 s)
 =====================================
 {gi}pass{x} 1 of 3
 {ri}fail{x} 2 of 3
@@ -136,6 +136,64 @@ Elapsed time was 3.0 s
         self.assertTrue(report.result_of("passed_test").passed)
         self.assertTrue(report.result_of("skipped_test").skipped)
         self.assertTrue(report.result_of("failed_test").failed)
+
+    def test_report_with_mixed_length_tests(self):
+        report = self._report_with_mixed_length_tests()
+        report.set_real_total_time(45.0)
+        self.assertEqual(
+            self.report_to_str(report),
+            """\
+==== Summary ========================
+{gi}pass{x} passed_test0 (       0.2 s)
+{gi}pass{x} passed_test1 (       2.1 s)
+{gi}pass{x} passed_test2 (       5.3 s)
+{gi}pass{x} passed_test3 (1 min  0.3 s)
+=====================================
+{gi}pass{x} 4 of 4
+=====================================
+Total time was 1 min 7.9 s
+Elapsed time was 45.0 s
+=====================================
+{gi}All passed!{x}
+""",
+        )
+        self.assertTrue(report.all_ok())
+        self.assertTrue(report.result_of("passed_test0").passed)
+        self.assertTrue(report.result_of("passed_test1").passed)
+        self.assertTrue(report.result_of("passed_test2").passed)
+        self.assertTrue(report.result_of("passed_test3").passed)
+
+
+    def test_report_with_long_tests(self):
+        report = self._report_with_long_tests()
+        report.set_real_total_time(3700.0)
+        self.assertEqual(
+            self.report_to_str(report),
+            """\
+==== Summary ========================
+{gi}pass{x} passed_test0 (            0.2 s)
+{gi}pass{x} passed_test1 (            2.1 s)
+{gi}pass{x} passed_test2 (           10.3 s)
+{gi}pass{x} passed_test3 (     1 min  0.1 s)
+{gi}pass{x} passed_test4 (    10 min 15.1 s)
+{gi}pass{x} passed_test5 (1 h  3 min  0.1 s)
+=====================================
+{gi}pass{x} 6 of 6
+=====================================
+Total time was 1 h 14 min 27.9 s
+Elapsed time was 1 h 1 min 40.0 s
+=====================================
+{gi}All passed!{x}
+""",
+        )
+        self.assertTrue(report.all_ok())
+        self.assertTrue(report.result_of("passed_test0").passed)
+        self.assertTrue(report.result_of("passed_test1").passed)
+        self.assertTrue(report.result_of("passed_test2").passed)
+        self.assertTrue(report.result_of("passed_test3").passed)
+        self.assertTrue(report.result_of("passed_test4").passed)
+        self.assertTrue(report.result_of("passed_test5").passed)
+
 
     def test_report_with_no_tests(self):
         report = self._new_report()
@@ -320,6 +378,28 @@ Elapsed time was 3.0 s
         report.add_result("skipped_test", SKIPPED, time=0.0, output_file_name=self.output_file_name)
         report.add_result("failed_test", FAILED, time=3.0, output_file_name=self.output_file_name)
         report.set_expected_num_tests(3)
+        return report
+
+    def _report_with_mixed_length_tests(self):
+        "@returns A report with various long tests"
+        report = self._new_report()
+        report.add_result("passed_test0", PASSED,  time=0.2, output_file_name=self.output_file_name)
+        report.add_result("passed_test1", PASSED,  time=2.1, output_file_name=self.output_file_name)
+        report.add_result("passed_test2", PASSED,  time=5.3, output_file_name=self.output_file_name)
+        report.add_result("passed_test3", PASSED, time=60.3, output_file_name=self.output_file_name)
+        report.set_expected_num_tests(4)
+        return report
+
+    def _report_with_long_tests(self):
+        "@returns A report with various long tests"
+        report = self._new_report()
+        report.add_result("passed_test0", PASSED,    time=0.2, output_file_name=self.output_file_name)
+        report.add_result("passed_test1", PASSED,    time=2.1, output_file_name=self.output_file_name)
+        report.add_result("passed_test2", PASSED,   time=10.3, output_file_name=self.output_file_name)
+        report.add_result("passed_test3", PASSED,   time=60.1, output_file_name=self.output_file_name)
+        report.add_result("passed_test4", PASSED,  time=615.1, output_file_name=self.output_file_name)
+        report.add_result("passed_test5", PASSED, time=3780.1, output_file_name=self.output_file_name)
+        report.set_expected_num_tests(6)
         return report
 
     def _new_report(self):

--- a/tests/unit/test_test_report.py
+++ b/tests/unit/test_test_report.py
@@ -46,13 +46,13 @@ class TestTestReport(TestCase):
             self.report_to_str(report),
             """\
 ==== Summary ========================
-{gi}pass{x} passed_test0 (1.0 seconds)
-{gi}pass{x} passed_test1 (2.0 seconds)
+{gi}pass{x} passed_test0 (1.0 s)
+{gi}pass{x} passed_test1 (2.0 s)
 =====================================
 {gi}pass{x} 2 of 2
 =====================================
-Total time was 3.0 seconds
-Elapsed time was 1.0 seconds
+Total time was 3.0 s
+Elapsed time was 1.0 s
 =====================================
 {gi}All passed!{x}
 """,
@@ -69,13 +69,13 @@ Elapsed time was 1.0 seconds
             self.report_to_str(report),
             """\
 ==== Summary ========================
-{gi}pass{x} passed_test0 (1.0 seconds)
-{gi}pass{x} passed_test1 (2.0 seconds)
+{gi}pass{x} passed_test0 (1.0 s)
+{gi}pass{x} passed_test1 (2.0 s)
 =====================================
 {gi}pass{x} 2 of 2
 =====================================
-Total time was 3.0 seconds
-Elapsed time was 1.0 seconds
+Total time was 3.0 s
+Elapsed time was 1.0 s
 =====================================
 {gi}All passed!{x}
 {rgi}WARNING: Test execution aborted after running 2 out of 3 tests{x}
@@ -93,15 +93,15 @@ Elapsed time was 1.0 seconds
             self.report_to_str(report),
             """\
 ==== Summary ========================
-{gi}pass{x} passed_test  (2.0 seconds)
-{ri}fail{x} failed_test0 (11.1 seconds)
-{ri}fail{x} failed_test1 (3.0 seconds)
+{gi}pass{x} passed_test  (2.0 s)
+{ri}fail{x} failed_test0 (11.1 s)
+{ri}fail{x} failed_test1 (3.0 s)
 =====================================
 {gi}pass{x} 1 of 3
 {ri}fail{x} 2 of 3
 =====================================
-Total time was 16.1 seconds
-Elapsed time was 12.0 seconds
+Total time was 16.1 s
+Elapsed time was 12.0 s
 =====================================
 {ri}Some failed!{x}
 """,
@@ -118,16 +118,16 @@ Elapsed time was 12.0 seconds
             self.report_to_str(report),
             """\
 ==== Summary ========================
-{gi}pass{x} passed_test  (1.0 seconds)
-{rgi}skip{x} skipped_test (0.0 seconds)
-{ri}fail{x} failed_test  (3.0 seconds)
+{gi}pass{x} passed_test  (1.0 s)
+{rgi}skip{x} skipped_test (0.0 s)
+{ri}fail{x} failed_test  (3.0 s)
 =====================================
 {gi}pass{x} 1 of 3
 {rgi}skip{x} 1 of 3
 {ri}fail{x} 1 of 3
 =====================================
-Total time was 4.0 seconds
-Elapsed time was 3.0 seconds
+Total time was 4.0 s
+Elapsed time was 3.0 s
 =====================================
 {ri}Some failed!{x}
 """,

--- a/vunit/test/report.py
+++ b/vunit/test/report.py
@@ -27,22 +27,21 @@ def get_parsed_time(time_in, max_time=0):
       max_time : Longest test time among tests. Optional parameter
     """
     time_str = ""
-    time_max = time_in if max_time == 0 else max_time
 
     (minutes, seconds) = divmod(time_in, 60)
     (hours, minutes) = divmod(minutes, 60)
-    if time_max >= 3600:
+    if max_time >= 3600 or time_in >= 3600:
         # If the longest test took 10 hours or more, pad the string to take this
         # into account.
-        padding = 5 if (time_max / 3600) % 60 >= 10 else 4
+        padding = 5 if (max_time / 3600) % 60 >= 10 else 4
         if hours > 0:
             time_str += f"{int(hours)} h ".rjust(padding)
         else:
             time_str += " " * padding
-    if time_max >= 60:
+    if max_time >= 60 or time_in >= 60:
         # If the longest test took an hour (or more), or the longest test took
         # 10 minutes or more, pad the string to take this into account.
-        padding = 7 if (time_max >= 3600) or ((time_max / 60) % 60 >= 10) else 6
+        padding = 7 if (max_time >= 3600) or ((max_time / 60) % 60 >= 10) else 6
         if minutes > 0:
             time_str += f"{int(minutes)} min ".rjust(padding)
         else:
@@ -50,7 +49,7 @@ def get_parsed_time(time_in, max_time=0):
 
     # If the longest test took a minute (or more), or the longest test
     # took 10 seconds or more, pad the string to take this into account.
-    padding = 6 if (time_max >= 60) or (time_max % 60 >= 10) else 5
+    padding = 6 if (max_time >= 60) or (max_time % 60 >= 10) else 5
     time_str += f"{seconds:2.1f} s".rjust(padding)
 
     return time_str

--- a/vunit/test/report.py
+++ b/vunit/test/report.py
@@ -30,10 +30,11 @@ def get_parsed_time(time_in, max_time=0):
 
     (minutes, seconds) = divmod(time_in, 60)
     (hours, minutes) = divmod(minutes, 60)
+
     if max(time_in, max_time) >= 3600:
         # If the longest test took 10 hours or more, pad the string to take this
         # into account.
-        padding = 5 if (max_time / 3600) % 60 >= 10 else 4
+        padding = len(f"{int(max_time // 3600)} h ")
         if hours > 0:
             time_str += f"{int(hours)} h ".rjust(padding)
         else:
@@ -41,7 +42,7 @@ def get_parsed_time(time_in, max_time=0):
     if max(time_in, max_time) >= 60:
         # If the longest test took an hour (or more), or the longest test took
         # 10 minutes or more, pad the string to take this into account.
-        padding = 7 if (max_time >= 3600) or ((max_time / 60) % 60 >= 10) else 6
+        padding = 7 if (max_time / 60 >= 10) else 6
         if minutes > 0:
             time_str += f"{int(minutes)} min ".rjust(padding)
         else:
@@ -49,7 +50,7 @@ def get_parsed_time(time_in, max_time=0):
 
     # If the longest test took a minute (or more), or the longest test
     # took 10 seconds or more, pad the string to take this into account.
-    padding = 6 if (max_time >= 60) or (max_time % 60 >= 10) else 5
+    padding = 6 if (max_time >= 10) else 5
     time_str += f"{seconds:2.1f} s".rjust(padding)
 
     return time_str

--- a/vunit/test/report.py
+++ b/vunit/test/report.py
@@ -18,6 +18,24 @@ from vunit.color_printer import COLOR_PRINTER
 from vunit.ostools import read_file
 
 
+def get_parsed_time(time_in):
+    """
+    Return string representation of input value
+    in hours, minutes and seconds.
+    """
+    time_str = ""
+    (minutes, seconds) = divmod(time_in, 60)
+    (hours, minutes) = divmod(minutes, 60)
+    if hours > 0:
+        time_str += f"{hours} hours, "
+    if minutes > 0:
+        time_str += f"{minutes} minutes, "
+
+    time_str += f"{seconds:.1f} seconds"
+
+    return time_str
+
+
 class TestReport(object):
     """
     Collect reports from running testcases
@@ -91,7 +109,7 @@ class TestReport(object):
         args.append(f"F={len(failed):d}")
         args.append(f"T={total_tests:d}")
 
-        self._printer.write(f" ({' '.join(args)!s}) {result.name!s} ({result.time:.1f} seconds)\n")
+        self._printer.write(f" ({' '.join(args)!s}) {result.name!s} ({get_parsed_time(result.time)})\n")
 
     def all_ok(self):
         """
@@ -143,8 +161,8 @@ class TestReport(object):
         self._printer.write(("=" * (max(max_len + 25, 0))) + "\n")
 
         total_time = sum((result.time for result in self._test_results.values()))
-        self._printer.write(f"Total time was {total_time:.1f} seconds\n")
-        self._printer.write(f"Elapsed time was {self._real_total_time:.1f} seconds\n")
+        self._printer.write(f"Total time was {get_parsed_time(total_time)}\n")
+        self._printer.write(f"Elapsed time was {get_parsed_time(self._real_total_time)}\n")
 
         self._printer.write(("=" * (max(max_len + 25, 0))) + "\n")
 
@@ -279,7 +297,7 @@ class TestResult(object):
 
         my_padding = max(padding - len(self.name), 0)
 
-        printer.write(f"{self.name + (' ' * my_padding)} ({self.time:.1f} seconds)\n")
+        printer.write(f"{self.name + (' ' * my_padding)} ({get_parsed_time(self.time)})\n")
 
     def to_xml(self, xunit_xml_format):
         """

--- a/vunit/test/report.py
+++ b/vunit/test/report.py
@@ -22,24 +22,36 @@ def get_parsed_time(time_in, max_time=0):
     """
     Return string representation of input value
     in hours, minutes and seconds.
+    Inputs:
+      time_in  : Time to convert to string
+      max_time : Longest test time among tests. Optional parameter
     """
     time_str = ""
     time_max = time_in if max_time == 0 else max_time
 
     (minutes, seconds) = divmod(time_in, 60)
     (hours, minutes) = divmod(minutes, 60)
-    if time_max > 3600:
+    if time_max >= 3600:
+        # If the longest test took 10 hours or more, pad the string to take this
+        # into account.
+        padding = 5 if (time_max / 3600) % 60 >= 10 else 4
         if hours > 0:
-            time_str += f"{hours} h "
+            time_str += f"{int(hours)} h ".rjust(padding)
         else:
-            time_str += "    "
-    if time_max > 60:
+            time_str += " " * padding
+    if time_max >= 60:
+        # If the longest test took an hour (or more), or the longest test took
+        # 10 minutes or more, pad the string to take this into account.
+        padding = 7 if (time_max >= 3600) or ((time_max / 60) % 60 >= 10) else 6
         if minutes > 0:
-            time_str += f"{minutes:2} min "
+            time_str += f"{int(minutes)} min ".rjust(padding)
         else:
-            time_str += "       "
+            time_str += " " * padding
 
-    time_str += f"{seconds:2.1f} s"
+    # If the longest test took a minute (or more), or the longest test
+    # took 10 seconds or more, pad the string to take this into account.
+    padding = 6 if (time_max >= 60) or (time_max % 60 >= 10) else 5
+    time_str += f"{seconds:2.1f} s".rjust(padding)
 
     return time_str
 

--- a/vunit/test/report.py
+++ b/vunit/test/report.py
@@ -157,7 +157,7 @@ class TestReport(object):
             return
 
         prefix = "==== Summary "
-        max_len = max(len(test.name)for test in all_tests)
+        max_len = max(len(test.name) for test in all_tests)
         max_time = max(test.time for test in all_tests)
         self._printer.write(f"{prefix!s}{'=' * (max(max_len - len(prefix) + 25, 0))}\n")
         for test_result in all_tests:

--- a/vunit/test/report.py
+++ b/vunit/test/report.py
@@ -30,7 +30,7 @@ def get_parsed_time(time_in, max_time=0):
 
     (minutes, seconds) = divmod(time_in, 60)
     (hours, minutes) = divmod(minutes, 60)
-    if max_time >= 3600 or time_in >= 3600:
+    if max(time_in, max_time) >= 3600:
         # If the longest test took 10 hours or more, pad the string to take this
         # into account.
         padding = 5 if (max_time / 3600) % 60 >= 10 else 4
@@ -38,7 +38,7 @@ def get_parsed_time(time_in, max_time=0):
             time_str += f"{int(hours)} h ".rjust(padding)
         else:
             time_str += " " * padding
-    if max_time >= 60 or time_in >= 60:
+    if max(time_in, max_time) >= 60:
         # If the longest test took an hour (or more), or the longest test took
         # 10 minutes or more, pad the string to take this into account.
         padding = 7 if (max_time >= 3600) or ((max_time / 60) % 60 >= 10) else 6

--- a/vunit/test/report.py
+++ b/vunit/test/report.py
@@ -18,20 +18,28 @@ from vunit.color_printer import COLOR_PRINTER
 from vunit.ostools import read_file
 
 
-def get_parsed_time(time_in):
+def get_parsed_time(time_in, max_time=0):
     """
     Return string representation of input value
     in hours, minutes and seconds.
     """
     time_str = ""
+    time_max = time_in if max_time == 0 else max_time
+
     (minutes, seconds) = divmod(time_in, 60)
     (hours, minutes) = divmod(minutes, 60)
-    if hours > 0:
-        time_str += f"{hours} hours, "
-    if minutes > 0:
-        time_str += f"{minutes} minutes, "
+    if time_max > 3600:
+        if hours > 0:
+            time_str += f"{hours} h "
+        else:
+            time_str += "    "
+    if time_max > 60:
+        if minutes > 0:
+            time_str += f"{minutes:2} min "
+        else:
+            time_str += "       "
 
-    time_str += f"{seconds:.1f} seconds"
+    time_str += f"{seconds:2.1f} s"
 
     return time_str
 
@@ -137,10 +145,11 @@ class TestReport(object):
             return
 
         prefix = "==== Summary "
-        max_len = max(len(test.name) for test in all_tests)
+        max_len = max(len(test.name)for test in all_tests)
+        max_time = max(test.time for test in all_tests)
         self._printer.write(f"{prefix!s}{'=' * (max(max_len - len(prefix) + 25, 0))}\n")
         for test_result in all_tests:
-            test_result.print_status(self._printer, padding=max_len)
+            test_result.print_status(self._printer, padding=max_len, max_time=max_time)
 
         self._printer.write(("=" * (max(max_len + 25, 0))) + "\n")
         n_failed = len(failures)
@@ -281,7 +290,7 @@ class TestResult(object):
     def failed(self):
         return self._status == FAILED
 
-    def print_status(self, printer, padding=0):
+    def print_status(self, printer, padding=0, max_time=0):
         """
         Print the status and runtime of this test result
         """
@@ -297,7 +306,7 @@ class TestResult(object):
 
         my_padding = max(padding - len(self.name), 0)
 
-        printer.write(f"{self.name + (' ' * my_padding)} ({get_parsed_time(self.time)})\n")
+        printer.write(f"{self.name + (' ' * my_padding)} ({get_parsed_time(self.time, max_time)})\n")
 
     def to_xml(self, xunit_xml_format):
         """

--- a/vunit/test/runner.py
+++ b/vunit/test/runner.py
@@ -88,7 +88,7 @@ class TestRunner(object):  # pylint: disable=too-many-instance-attributes
             for test_name in test_suite.test_names:
                 num_tests += 1
                 if self._is_verbose:
-                    now = datetime.now().time().strftime("%H:%M:%S")
+                    now = datetime.now().strftime("%H:%M:%S")
                     print(f"({now}) " + "Running test: " + test_name)
 
         if self._is_verbose:

--- a/vunit/test/runner.py
+++ b/vunit/test/runner.py
@@ -88,8 +88,7 @@ class TestRunner(object):  # pylint: disable=too-many-instance-attributes
             for test_name in test_suite.test_names:
                 num_tests += 1
                 if self._is_verbose:
-                    now = datetime.now().strftime("%H:%M:%S")
-                    print(f"({now}) " + "Running test: " + test_name)
+                    print("Running test: " + test_name)
 
         if self._is_verbose:
             print(f"Running {num_tests:d} tests")
@@ -151,7 +150,8 @@ class TestRunner(object):  # pylint: disable=too-many-instance-attributes
 
                 with self._stdout_lock():
                     for test_name in test_suite.test_names:
-                        print(f"Starting {test_name!s}")
+                        now = datetime.now().strftime("%H:%M:%S")
+                        print(f"({now}) Starting {test_name!s}")
                     print(f"Output file: {output_file_name!s}")
 
                 self._run_test_suite(test_suite, write_stdout, num_tests, output_path, output_file_name)

--- a/vunit/test/runner.py
+++ b/vunit/test/runner.py
@@ -16,6 +16,7 @@ import sys
 import time
 import logging
 import string
+from datetime import datetime
 from contextlib import contextmanager
 from .. import ostools
 from ..hashing import hash_string
@@ -87,7 +88,8 @@ class TestRunner(object):  # pylint: disable=too-many-instance-attributes
             for test_name in test_suite.test_names:
                 num_tests += 1
                 if self._is_verbose:
-                    print("Running test: " + test_name)
+                    now = datetime.now().time().strftime("%H:%M:%S")
+                    print(f"({now}) " + "Running test: " + test_name)
 
         if self._is_verbose:
             print(f"Running {num_tests:d} tests")


### PR DESCRIPTION
This pull request includes the following updates/suggestions:

* Add timestamp at the start of new tests
* Parse time so that time is printed as hours, minutes and seconds instead of only seconds.
  (The breakpoint is at 60 seconds/60 minutes even though it might suffice to allow some slack to the number of seconds/minutes before incrementing them. I.e. 70 seconds could as well be printed as 70 seconds as 1 minute 10 seconds.)