### PR TITLE
Removed Questasim compilation warning. Fixes #981. (2)

### DIFF
--- a/vunit/vhdl/string_ops/src/string_ops.vhd
+++ b/vunit/vhdl/string_ops/src/string_ops.vhd
@@ -485,7 +485,7 @@ package body string_ops is
     variable start_pos, stop_pos : natural;
     variable n, o : natural := 0;
   begin
-    if substring = "" then
+    if substring'length = 0 then
       n := s'length + 1;
     elsif s = "" then
       n := 0;


### PR DESCRIPTION
fix modelsim/questa warning on string length comparison, not include in the previous [commit](https://github.com/VUnit/vunit/commit/c68626dc2eb04d455ebe99555499e994cf6f1847).