### PR TITLE
Add vunit_tb_name tcl variable and vunit_tb_path for Active-HDL

### DIFF
--- a/docs/news.d/1033.feature.rst
+++ b/docs/news.d/1033.feature.rst
@@ -1,0 +1,2 @@
+[Riviera-PRO, ModelSim/Questa, Active-HDL] Defined the TCL variable ``vunit_tb_name`` as the name of the top level design unit during the evaluation of the ``<simulator>.init_file`` scripts for Active-HDL, Riviera-PRO and ModelSim/Qusta.
+[Active-HDL] Defined the TCL variable ``vunit_tb_path`` during the evaluation of the ``activehdl.init_file.gui`` script.

--- a/docs/py/opts.rst
+++ b/docs/py/opts.rst
@@ -123,6 +123,7 @@ The following simulation options are known.
    using the ``vsim`` command.
    During script evaluation the ``vunit_tb_path`` variable is defined
    as the path of the folder containing the test bench.
+   Additionally, the ``vunit_tb_name`` variable is defined as the name of the test bench.
    Must be a list of strings.
 
 ``modelsim.init_files.before_run``
@@ -136,6 +137,7 @@ The following simulation options are known.
    For example this can be used to configure the waveform viewer.
    During script evaluation the ``vunit_tb_path`` variable is defined
    as the path of the folder containing the test bench.
+   Additionally, the ``vunit_tb_name`` variable is defined as the name of the test bench.
    Must be a string.
 
 ``rivierapro.vsim_flags``
@@ -153,6 +155,7 @@ The following simulation options are known.
    using the ``vsim`` command.
    During script evaluation the ``vunit_tb_path`` variable is defined
    as the path of the folder containing the test bench.
+   Additionally, the ``vunit_tb_name`` variable is defined as the name of the test bench.
    Must be a list of strings.
 
 ``rivierapro.init_files.before_run``
@@ -166,6 +169,7 @@ The following simulation options are known.
    For example this can be used to configure the waveform viewer.
    During script evaluation the ``vunit_tb_path`` variable is defined
    as the path of the folder containing the test bench.
+   Additionally, the ``vunit_tb_name`` variable is defined as the name of the test bench.
    Must be a string.
 
 ``activehdl.vsim_flags``
@@ -180,6 +184,9 @@ The following simulation options are known.
 ``activehdl.init_file.gui``
    A user defined TCL-file that is sourced after the design has been loaded in the GUI.
    For example this can be used to configure the waveform viewer.
+   During script evaluation the ``vunit_tb_path`` variable is defined
+   as the path of the folder containing the test bench.
+   Additionally, the ``vunit_tb_name`` variable is defined as the name of the test bench.
    Must be a string.
 
 ``ghdl.elab_flags``

--- a/vunit/sim_if/activehdl.py
+++ b/vunit/sim_if/activehdl.py
@@ -460,12 +460,15 @@ proc vunit_help {} {
     def _create_user_init_function(self, config):
         """
         Create the vunit_user_init function which sources the user defined TCL file in
-        simulator_name.init_file.gui
+        simulator_name.init_file.gui.
+        Also defines the vunit_tb_path and the vunit_tb_name variable.
         """
         opt_name = self.name + ".init_file.gui"
         init_file = config.sim_options.get(opt_name, None)
         tcl = "proc vunit_user_init {} {\n"
         if init_file is not None:
+            tcl += f'set vunit_tb_name {config.design_unit_name}\n'
+            tcl += f'set vunit_tb_path {fix_path(str(Path(config.tb_path).resolve()))}\n'
             tcl += f'source "{fix_path(str(Path(init_file).resolve()))!s}"\n'
         tcl += "    return 0\n"
         tcl += "}\n"
@@ -473,7 +476,8 @@ proc vunit_help {} {
 
     def _create_gui_script(self, common_file_name, config):
         """
-        Create the user facing script which loads common functions and prints a help message
+        Create the user facing script which loads common functions and prints a help message.
+        Also defines the vunit_tb_path and the vunit_tb_name variable.
         """
 
         tcl = ""

--- a/vunit/sim_if/activehdl.py
+++ b/vunit/sim_if/activehdl.py
@@ -467,8 +467,8 @@ proc vunit_help {} {
         init_file = config.sim_options.get(opt_name, None)
         tcl = "proc vunit_user_init {} {\n"
         if init_file is not None:
-            tcl += f'set vunit_tb_name {config.design_unit_name}\n'
-            tcl += f'set vunit_tb_path {fix_path(str(Path(config.tb_path).resolve()))}\n'
+            tcl += f"set vunit_tb_name {config.design_unit_name}\n"
+            tcl += f"set vunit_tb_path {fix_path(str(Path(config.tb_path).resolve()))}\n"
             tcl += f'source "{fix_path(str(Path(init_file).resolve()))!s}"\n'
         tcl += "    return 0\n"
         tcl += "}\n"

--- a/vunit/sim_if/vsim_simulator_mixin.py
+++ b/vunit/sim_if/vsim_simulator_mixin.py
@@ -233,9 +233,12 @@ proc vunit_run {} {
         """
         Create TCL to source a file and catch errors
         Also defines the vunit_tb_path variable as the config.tb_path
+        and the vunit_tb_name variable as the config.design_unit_name
+
         """
         template = """
     set vunit_tb_path "%s"
+    set vunit_tb_name "%s"
     set file_name "%s"
     puts "Sourcing file ${file_name} from %s"
     if {[catch {source ${file_name}} error_msg]} {
@@ -246,6 +249,7 @@ proc vunit_run {} {
 """
         tcl = template % (
             fix_path(str(Path(config.tb_path).resolve())),
+            config.design_unit_name,
             fix_path(str(Path(file_name).resolve())),
             message,
         )


### PR DESCRIPTION
The main usage of the sim options <simulator>.init_file.gui is loading the correct wave file. 
To load the correct wave file, the `vunit_tb_path` variable is defined during script evaluation. That variable points to the directory that contains the testbench.  

If a user wants to load different wave files for different test benches located in the same directory, the name of the testbench is needed. 

This PR adds the name of the test bench as a tcl variable called `vunit_tb_name` for modelsim, riviera and active-hdl.
This PR also adds the `vunit_tb_path` for active-hdl.


## Example usage for Active-HDL

tb.set_sim_option("activehdl.init_file.gui", "activehdl_gui.do")

activehdl_gui.do:
```
global wavefile
set wavefile ${vunit_tb_path}/${vunit_tb_name}_wave.do

# try to source a wave file with the name of the design unit
if { [file exists ${wavefile}] } {
    puts "loading wave from '${wavefile}'."
    do ${wavefile}
} else {
    puts "No Wave file found in the testbench directory. If you save a wave as '${vunit_tb_name}_wave.do', it will be loaded automatically next time."
}
```




