### PR TITLE
Added support for timeout in the wait_until_idle call.

### DIFF
--- a/vunit/vhdl/com/src/com.vhd
+++ b/vunit/vhdl/com/src/com.vhd
@@ -447,6 +447,11 @@ package body com_pkg is
 
     check(position /= -1, null_message_error);
 
+    -- For testing purposes when logger is mocked and the check procedure returns
+    if position = -1 then
+      return;
+    end if;
+
     get_message(net, source_actor, position, mailbox_id, reply_msg);
   end;
 

--- a/vunit/vhdl/verification_components/src/sync_pkg-body.vhd
+++ b/vunit/vhdl/verification_components/src/sync_pkg-body.vhd
@@ -6,11 +6,12 @@
 
 package body sync_pkg is
   procedure wait_until_idle(signal net : inout network_t;
-                            handle     :       sync_handle_t) is
+                            handle     :       sync_handle_t;
+                            timeout    :       delay_length := max_timeout) is
     variable msg, reply_msg : msg_t;
   begin
     msg := new_msg(wait_until_idle_msg);
-    request(net, handle, msg, reply_msg);
+    request(net, handle, msg, reply_msg, timeout);
     delete(reply_msg);
   end;
 

--- a/vunit/vhdl/verification_components/src/sync_pkg.vhd
+++ b/vunit/vhdl/verification_components/src/sync_pkg.vhd
@@ -16,9 +16,11 @@ package sync_pkg is
   -- Handle to talk to a VC implementing the sync VCI
   alias sync_handle_t is actor_t;
 
-  -- Blocking: Wait until all operations requested from the VC have been finished
+  -- Blocking: Wait until all operations requested from the VC have been
+  -- finished or timeout has been reached. A timeout results in an error.
   procedure wait_until_idle(signal net : inout network_t;
-                            handle     :       sync_handle_t);
+                            handle     :       sync_handle_t;
+                            timeout    :       delay_length := max_timeout);
 
   -- Non-blocking: Make VC wait for a delay before starting the next operation
   procedure wait_for_time(signal net : inout network_t;

--- a/vunit/vhdl/verification_components/test/tb_sync_pkg.vhd
+++ b/vunit/vhdl/verification_components/test/tb_sync_pkg.vhd
@@ -33,6 +33,14 @@ begin
     wait_until_idle(net, actor);
     check_equal(now - start, 37 ms, "wait for time mismatch");
 
+    mock(com_logger, failure);
+    start := now;
+    wait_for_time(net, actor, 37 ms);
+    wait_until_idle(net, actor, 10 ms);
+    check_log(com_logger, "TIMEOUT.", failure, start + 10 ms);
+    check_only_log(get_logger("vunit_lib:com"), "NULL MESSAGE ERROR.", failure, start + 10 ms);
+    unmock(com_logger);
+
     test_runner_cleanup(runner);
   end process;
 


### PR DESCRIPTION
The support is currently limited in terms of logger, message, and log level which can not be changed. The error message will always be from the com_logger and it will always be a failure.