### PR TITLE
Fix syntax error in id_pkg

### DIFF
--- a/vunit/vhdl/data_types/src/id_pkg.vhd
+++ b/vunit/vhdl/data_types/src/id_pkg.vhd
@@ -22,7 +22,7 @@ package id_pkg is
   end record;
   constant null_id : id_t := (p_data => null_ptr);
   type id_vec_t is array (integer range <>) of id_t;
-  constant null_id_vec : id_vec_t := (1 to 0 => null_id);
+  constant null_id_vec : id_vec_t := (0 to 1 => null_id);
 
   -- root_id is a nameless and predefined ID that is the parent to
   -- all user created top-level IDs (no parent was specified at creation)


### PR DESCRIPTION
This PR fixes a bug that resulted in failure during elaboration using riviera pro. I am not sure if the range (0 to 1) is desired or if (1 downto 0) would be more correct. It works like this now though.