### PR TITLE
Fix array_axis_vcs example 

### DIFF
--- a/examples/vhdl/array_axis_vcs/run.py
+++ b/examples/vhdl/array_axis_vcs/run.py
@@ -29,6 +29,6 @@ SRC_PATH = Path(__file__).parent / "src"
 
 VU.add_library("lib").add_source_files([SRC_PATH / "*.vhd", SRC_PATH / "**" / "*.vhd"])
 
-# VU.set_sim_option('modelsim.init_files.after_load',['runall_addwave.do'])
+VU.set_sim_option("modelsim.init_file.gui", "runall_addwave.do")
 
 VU.main()

--- a/examples/vhdl/array_axis_vcs/run.py
+++ b/examples/vhdl/array_axis_vcs/run.py
@@ -29,6 +29,6 @@ SRC_PATH = Path(__file__).parent / "src"
 
 VU.add_library("lib").add_source_files([SRC_PATH / "*.vhd", SRC_PATH / "**" / "*.vhd"])
 
-# vu.set_sim_option('modelsim.init_files.after_load',['runall_addwave.do'])
+# VU.set_sim_option('modelsim.init_files.after_load',['runall_addwave.do'])
 
 VU.main()

--- a/examples/vhdl/array_axis_vcs/runall_addwave.do
+++ b/examples/vhdl/array_axis_vcs/runall_addwave.do
@@ -1,5 +1,5 @@
 echo "Running DO File"
-foreach v "vunit_axism vunit_axiss uut uut/fifo" {
+foreach v "uut_vc/vunit_axism uut_vc/vunit_axiss uut_vc/uut uut_vc/uut/fifo" {
   add wave -group "$v" -position insertpoint sim:/tb_axis_loop/$v/*
 }
 run -all;


### PR DESCRIPTION
Hi there!

Yesterday, I spoke to Unai M. C., and he gave me a hint to resolve #1081 by reviewing the `array_axis_vcs` example. I’ve fixed it to achieve correct simulation with QuestaSim.

### Changes made:

- Replaced `vu` with `VU` on line 32.
- Corrected the instantiation of components in `runall_addwave.do`.

The following images illustrate the errors:

**Error 1**:

![vunit_PR_1](https://github.com/user-attachments/assets/dca18883-4444-4037-9ef1-ec695e492bb6)

**Error 2**:

![vunit_PR_2](https://github.com/user-attachments/assets/a8b7a28d-e4eb-4594-926b-7676613b278a)

**Fixed** (with -g, the Questa GUI opens; without -g and with -v, the test information (through `info()` function) is displayed correctly):

![vunit_PR_3](https://github.com/user-attachments/assets/247b0245-1d74-4bf0-ace2-9f3d3b8c0562)

![vunit_PR_4](https://github.com/user-attachments/assets/2feb7df0-4cd0-4647-88d2-908f78d6887d)

Cheers!

---

/cc @umarcor