### PR TITLE
Support Visualizer in Questa 2024.2.

### DIFF
--- a/vunit/sim_if/modelsim.py
+++ b/vunit/sim_if/modelsim.py
@@ -685,6 +685,14 @@ proc vunit_load {{vsim_extra_args ""}} {"""
 
         return vsim_flags
 
+    def _get_gui_option(self):
+        """
+        Return the option used to start in GUI mode.
+
+        This is required to support Questa Visualizer.
+        """
+        return "-visualizer" if self._debugger == "visualizer" else "-gui"
+
     def _get_load_flags(self, config, output_path, optimize_design):
         """
         Return extra flags needed for the first vsim call in GUI mode when early load is enabled.
@@ -712,7 +720,6 @@ proc vunit_load {{vsim_extra_args ""}} {"""
             "-wlf",
             f"{fix_path(str(Path(output_path) / 'vsim.wlf'))}",
             pli_str,
-            "-visualizer",
             "-f",
             f"{fix_path(str(generics_file_name))}",
         ]

--- a/vunit/sim_if/vsim_simulator_mixin.py
+++ b/vunit/sim_if/vsim_simulator_mixin.py
@@ -314,7 +314,7 @@ proc vunit_run {} {
 
         return tcl
 
-    def _run_batch_file(self, batch_file_name, gui=False, extra_args=None):
+    def _run_batch_file(self, batch_file_name, gui=False, gui_option="-gui", extra_args=None):
         """
         Run a test bench in batch by invoking a new vsim process from the command line
         """
@@ -322,7 +322,7 @@ proc vunit_run {} {
         try:
             args = [
                 str(Path(self._prefix) / "vsim"),
-                "-gui" if gui else "-c",
+                gui_option if gui else "-c",
                 "-l",
                 str(Path(batch_file_name).parent / "transcript"),
                 "-do",
@@ -386,6 +386,14 @@ proc vunit_run {} {
         """
         return []
 
+    def _get_gui_option(self):
+        """
+        Return the option used to start in GUI mode.
+
+        This is required to support Questa Visualizer.
+        """
+        return "-gui"
+
     def simulate(self, output_path, test_suite_name, config, elaborate_only):
         """
         Run a test bench
@@ -422,6 +430,7 @@ proc vunit_run {} {
             return self._run_batch_file(
                 str(gui_file_name),
                 gui=True,
+                gui_option=self._get_gui_option(),
                 extra_args=self._get_load_flags(config, output_path, optimize_design) if early_load else None,
             )
 


### PR DESCRIPTION
This PR addresses the issue in Questa 2024.2 where `-gui` must not be passed to `vsim` when the visualizer debugger is selected. In that case `-visualizer` implies GUI mode. Solves #1096.