### PR TITLE
Add --waves argument to generate waveforms for GHDL and NVC

### DIFF
--- a/docs/news.d/1101.feature.rst
+++ b/docs/news.d/1101.feature.rst
@@ -1,0 +1,5 @@
+[GHDL/NVC] It is now possible to pass ``--wave`` to generate waveform files without
+opening the GUI. The earlier GHDL-only approach of passing ``--viewer-fmt``
+(or ``--gtkwave-fmt``) is deprecated and will be removed in a later version.
+There is also a new alias for providing the waveform format, ``--wave-fmt``,
+to make it consistent with the new flag.

--- a/vunit/sim_if/ghdl.py
+++ b/vunit/sim_if/ghdl.py
@@ -59,6 +59,7 @@ class GHDLInterface(SimulatorInterface, ViewerMixin):  # pylint: disable=too-man
         group = parser.add_argument_group("ghdl/nvc", description="GHDL/NVC specific flags")
         group.add_argument(
             "--viewer-fmt",
+            "--wave-fmt",
             "--gtkwave-fmt",
             choices=["vcd", "fst", "ghw"],
             default=None,
@@ -66,6 +67,7 @@ class GHDLInterface(SimulatorInterface, ViewerMixin):  # pylint: disable=too-man
         )
         group.add_argument("--viewer-args", "--gtkwave-args", default="", help="Arguments to pass to waveform viewer")
         group.add_argument("--viewer", default=None, help="Waveform viewer to use")
+        group.add_argument("--wave", action='store_true', help="Generate waveform file")
 
     @classmethod
     def from_args(cls, args, output_path, **kwargs):
@@ -82,6 +84,7 @@ class GHDLInterface(SimulatorInterface, ViewerMixin):  # pylint: disable=too-man
             viewer_fmt=args.viewer_fmt,
             viewer_args=args.viewer_args,
             viewer=args.viewer,
+            wave=args.wave,
             backend=cls.determine_backend(prefix),
         )
 
@@ -101,6 +104,7 @@ class GHDLInterface(SimulatorInterface, ViewerMixin):  # pylint: disable=too-man
         viewer_fmt=None,
         viewer_args="",
         viewer=None,
+        wave=False,
         backend="llvm",
     ):
         SimulatorInterface.__init__(self, output_path, gui)
@@ -114,6 +118,7 @@ class GHDLInterface(SimulatorInterface, ViewerMixin):  # pylint: disable=too-man
 
         self._prefix = prefix
         self._project = None
+        self._wave = wave
 
         self._backend = backend
         self._vhdl_standard = None
@@ -382,6 +387,10 @@ class GHDLInterface(SimulatorInterface, ViewerMixin):  # pylint: disable=too-man
         ghdl_e = elaborate_only and config.sim_options.get("ghdl.elab_e", False)
 
         if self._viewer_fmt is not None:
+            if not self._wave and not self._gui:
+                LOGGER.warning("Passing --viewer-fmt, or any alias of that, without either "
+                               "--gui or --wave is deprecated and will be removed in a future version.")
+
             data_file_name = str(Path(script_path) / f"wave.{self._viewer_fmt!s}")
             if Path(data_file_name).exists():
                 remove(data_file_name)

--- a/vunit/sim_if/nvc.py
+++ b/vunit/sim_if/nvc.py
@@ -66,6 +66,7 @@ class NVCInterface(SimulatorInterface, ViewerMixin):  # pylint: disable=too-many
             viewer_fmt=args.viewer_fmt,
             viewer_args=args.viewer_args,
             viewer=args.viewer,
+            wave=args.wave,
         )
 
     @classmethod
@@ -76,7 +77,7 @@ class NVCInterface(SimulatorInterface, ViewerMixin):  # pylint: disable=too-many
         return cls.find_toolchain([cls.executable])
 
     def __init__(  # pylint: disable=too-many-arguments
-        self, output_path, prefix, *, num_threads, gui=False, viewer_fmt=None, viewer_args="", viewer=None
+        self, output_path, prefix, *, num_threads, gui=False, viewer_fmt=None, viewer_args="", viewer=None, wave=False
     ):
         SimulatorInterface.__init__(self, output_path, gui)
         if viewer_fmt == "ghw":
@@ -86,6 +87,7 @@ class NVCInterface(SimulatorInterface, ViewerMixin):  # pylint: disable=too-many
 
         self._prefix = prefix
         self._project = None
+        self._wave = wave
 
         self._vhdl_standard = None
         self._coverage_files = set()
@@ -260,7 +262,7 @@ class NVCInterface(SimulatorInterface, ViewerMixin):  # pylint: disable=too-many
         libdir = self._project.get_library(config.library_name).directory
         cmd = self._get_command(self._vhdl_standard, config.library_name, libdir)
 
-        if self._gui:
+        if self._gui or self._wave:
             wave_file = script_path / (f"{config.entity_name}.{self._viewer_fmt or 'fst'}")
             if wave_file.exists():
                 remove(wave_file)


### PR DESCRIPTION
Closes #1099 
Closes #1042 

The approach here is to pass `--waves` if a waveform file should be generated. That is clearer than the "passing `--gtkwave-fmt` "-approach earlier used.

There is a deprecation warning when passing only `--viewer-fmt`/`--gtkwave-fmt` for GHDL, but it still generates the file.

I also added a new alias `--waves-fmt` for consistency.

(I guess that one can also support other simulators generating waveform files. At least for ModelSim/Questa it is possible to generate VCD-files with a few .do-file commands and I guess the same holds for many other simulators.)