### PR TITLE
Add support for .svp extensions (protected SystemVerilog)

### DIFF
--- a/tests/unit/test_project.py
+++ b/tests/unit/test_project.py
@@ -1599,6 +1599,7 @@ end architecture;
         self.assertEqual(file_type_of("file.vhd"), "vhdl")
         self.assertEqual(file_type_of("file.vhdl"), "vhdl")
         self.assertEqual(file_type_of("file.sv"), "systemverilog")
+        self.assertEqual(file_type_of("file.svp"), "systemverilog")
         self.assertEqual(file_type_of("file.v"), "verilog")
         self.assertEqual(file_type_of("file.vams"), "verilog")
         self.assertRaises(RuntimeError, file_type_of, "file.foo")

--- a/vunit/source_file.py
+++ b/vunit/source_file.py
@@ -348,7 +348,7 @@ class VHDLSourceFile(SourceFile):
 # lower case representation of supported extensions
 VHDL_EXTENSIONS = (".vhd", ".vhdl", ".vho")
 VERILOG_EXTENSIONS = (".v", ".vp", ".vams", ".vo")
-SYSTEM_VERILOG_EXTENSIONS = (".sv",)
+SYSTEM_VERILOG_EXTENSIONS = (".sv", ".svp")
 VERILOG_FILE_TYPES = ("verilog", "systemverilog")
 FILE_TYPES = ("vhdl",) + VERILOG_FILE_TYPES
 


### PR DESCRIPTION
I'm working on a project that includes encrypted .svp files, this PR adds file-type recognition for that extension.