### PR TITLE
Use hashes for GitHub Action versions

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -12,11 +12,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
       with:
         submodules: recursive
 
-    - uses: actions/setup-python@v5
+    - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
       with:
         python-version: '3.13'
 
@@ -28,7 +28,7 @@ jobs:
     - name: Report coverage
       run: ./.github/run.sh coverage report -m --skip-covered
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
       with:
         name: VUnit_coverage
         path: htmlcov

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -15,12 +15,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
       with:
         submodules: recursive
         fetch-depth: 0
 
-    - uses: actions/setup-python@v5
+    - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
       with:
         python-version: '3.13'
 
@@ -32,7 +32,7 @@ jobs:
     - name: Build docs
       run: tox -e py313-docs -- --color
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
       with:
         name: VUnit-site
         path: .tox/py313-docs/tmp/docsbuild/

--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -27,7 +27,7 @@ jobs:
     steps:
 
     - name: 🧰 Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
 
     - name: '🛳️ Build container image'
       run: >-
@@ -52,7 +52,7 @@ jobs:
     steps:
 
     - name: 🧰 Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
 
     - name: '🛳️ Build container image'
       run: |

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -23,10 +23,10 @@ jobs:
     steps:
 
     - name: '🧰 Checkout'
-      uses: actions/checkout@v4
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
 
     - name: '🐍 Setup Python'
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
       with:
         python-version: '3.13'
 
@@ -55,10 +55,10 @@ jobs:
     steps:
 
     - name: '🧰 Checkout'
-      uses: actions/checkout@v4
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
 
     - name: '🐍 Setup Python'
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
       with:
         python-version: ${{ matrix.py }}
 
@@ -87,7 +87,7 @@ jobs:
     steps:
 
     - name: '🧰 Checkout'
-      uses: actions/checkout@v4
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
       with:
         submodules: recursive
 
@@ -111,7 +111,7 @@ jobs:
     steps:
 
     - name: '🧰 Checkout'
-      uses: actions/checkout@v4
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
       with:
         submodules: recursive
 
@@ -142,19 +142,19 @@ jobs:
     steps:
 
     - name: '🟦 Setup MSYS2'
-      uses: msys2/setup-msys2@v2
+      uses: msys2/setup-msys2@61f9e5e925871ba6c9e3e8da24ede83ea27fa91f  # v2.27.0
       with:
         msystem: mingw64
         update: true
-        install: mingw-w64-x86_64-python-pip	
+        install: mingw-w64-x86_64-python-pip
 
     - name: '🧰 Checkout'
-      uses: actions/checkout@v4
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
       with:
         submodules: recursive
 
     - name: '⚙️ Setup GHDL'
-      uses: ghdl/setup-ghdl@main
+      uses: ghdl/setup-ghdl@09e61b6db92fe2766a0b0a4b82505a47d67570be  # v1.2.1
       with:
         backend: mcode
         runtime: mingw64
@@ -182,12 +182,12 @@ jobs:
     steps:
 
     - name: '🧰 Checkout'
-      uses: actions/checkout@v4
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
       with:
         submodules: recursive
 
     - name: '🐍 Setup Python'
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
       with:
         python-version: '3.13'
 

--- a/docs/ci/script.rst
+++ b/docs/ci/script.rst
@@ -61,7 +61,7 @@ of your repository. The YAML file should contain, at least, the following piece 
        runs-on: ubuntu-latest
        steps:
 
-         - uses: actions/checkout@v2
+         - uses: actions/checkout@v4
 
          - uses: VUnit/vunit_action@v0.1.0
 


### PR DESCRIPTION
See https://blog.rafaelgss.dev/why-you-should-pin-actions-by-commit-hash for motivation why this is the safer way to handle action versions.

Also updated the doc to a recent version of the checkout action.

One may consider activating the dependabot action, see https://github.com/apytypes/apytypes/blob/main/.github/dependabot.yml for an example (although one may consider checking weekly rather than monthly).  This will create a PR to update the versions/hashes to the latest version when a new one is available.