### PR TITLE
Do not run scheduled jobs on forks

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -9,6 +9,7 @@ on:
 jobs:
 
   coverage:
+    if: github.repository == 'VUnit/vunit'
     runs-on: ubuntu-latest
     steps:
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -38,7 +38,7 @@ jobs:
         path: .tox/py313-docs/tmp/docsbuild/
 
     - name: '🚀 Publish site'
-      if: github.event_name != 'pull_request' && github.ref_name == 'master'
+      if: github.repository == 'VUnit/vunit' && github.event_name != 'pull_request' && github.ref_name == 'master'
       run: >-
         GH_DEPKEY='${{ secrets.VUNIT_GITHUB_IO_DEPLOY_KEY }}'
         ./.github/publish_site.sh

--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -16,6 +16,7 @@ jobs:
 
 
   GHDL:
+    if: github.repository == 'VUnit/vunit' || github.event_name != 'schedule'
     strategy:
       fail-fast: false
       matrix:
@@ -48,6 +49,7 @@ jobs:
 
 
   NVC:
+    if: github.repository == 'VUnit/vunit' || github.event_name != 'schedule'
     runs-on: ubuntu-latest
     steps:
 

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -18,6 +18,7 @@ jobs:
 #
 
   fmt:
+    if: github.repository == 'VUnit/vunit' || github.event_name != 'schedule'
     runs-on: ubuntu-latest
     name: '🐍 black'
     steps:
@@ -43,6 +44,7 @@ jobs:
 #
 
   lin:
+    if: github.repository == 'VUnit/vunit' || github.event_name != 'schedule'
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -75,6 +77,7 @@ jobs:
 #
 
   ghdl:
+    if: github.repository == 'VUnit/vunit' || github.event_name != 'schedule'
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -99,6 +102,7 @@ jobs:
 #
 
   nvc:
+    if: github.repository == 'VUnit/vunit' || github.event_name != 'schedule'
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -125,6 +129,7 @@ jobs:
 #
 
   win:
+    if: github.repository == 'VUnit/vunit' || github.event_name != 'schedule'
     runs-on: windows-latest
     strategy:
       fail-fast: false
@@ -146,7 +151,7 @@ jobs:
       with:
         msystem: mingw64
         update: true
-        install: mingw-w64-x86_64-python-pip	
+        install: mingw-w64-x86_64-python-pip
 
     - name: '🧰 Checkout'
       uses: actions/checkout@v4
@@ -177,7 +182,7 @@ jobs:
       - ghdl
       - nvc
       - win
-    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+    if: github.repository == 'VUnit/vunit' && github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
     name: '🚀 Deploy'
     steps:
 


### PR DESCRIPTION
I've realized that many projects have scheduled jobs and that those are also executed on forks. This can be annoying when there are errors, producing emails, but also it is a waste of compute resources that every fork runs this.

Also added some additional skips for not even trying to deploy web pages on forks etc.