### PR TITLE
Added .svp as systemverilog protected source file

### DIFF
--- a/vunit/source_file.py
+++ b/vunit/source_file.py
@@ -348,7 +348,7 @@ class VHDLSourceFile(SourceFile):
 # lower case representation of supported extensions
 VHDL_EXTENSIONS = (".vhd", ".vhdl", ".vho")
 VERILOG_EXTENSIONS = (".v", ".vp", ".vams", ".vo")
-SYSTEM_VERILOG_EXTENSIONS = (".sv",)
+SYSTEM_VERILOG_EXTENSIONS = (".sv", ".svp")
 VERILOG_FILE_TYPES = ("verilog", "systemverilog")
 FILE_TYPES = ("vhdl",) + VERILOG_FILE_TYPES
 


### PR DESCRIPTION
.SVP is used for example on QuestaSim/Modelsim to provide encrypted sources as a part of simulation. User can compile them using standard vcom, and they become part of given library.