### PR TITLE
Add option to run testcase pre_config only

### DIFF
--- a/vunit/ui/__init__.py
+++ b/vunit/ui/__init__.py
@@ -756,6 +756,9 @@ other preprocessors. Lowest value first. The order between preprocessors with th
         """
         Base vunit main function without performing exit
         """
+        if self._args.pre_config_only:
+            return self._main_pre_config_only()
+
         if self._include_in_test_pattern or self._exclude_from_test_pattern:
             self._update_test_filter(self._include_in_test_pattern, self._exclude_from_test_pattern)
 
@@ -1149,6 +1152,19 @@ other preprocessors. Lowest value first. The order between preprocessors with th
         """
         simulator_if = self._create_simulator_if()
         self._compile(simulator_if)
+        return True
+
+    def _main_pre_config_only(self):
+        """
+        Main function when only running pre config
+        """
+        test_list = self._create_tests(simulator_if=None)
+
+        for test in test_list:
+            test_cfg = test._test_case._configuration
+            if test_cfg.pre_config:
+                print(f"Calling pre config of testcase: {test_cfg.name}")
+                test_cfg.call_pre_config(self._output_path, self._simulator_output_path)
         return True
 
     def _create_output_path(self, clean: bool):

--- a/vunit/vunit_cli.py
+++ b/vunit/vunit_cli.py
@@ -290,6 +290,13 @@ def _create_argument_parser(description=None, for_documentation=False):
         " generated from system time.",
     )
 
+    parser.add_argument(
+        "--pre-config-only",
+        action="store_true",
+        default=False,
+        help="Run the pre simulation hook",
+    )
+
     SIMULATOR_FACTORY.add_arguments(parser)
 
     return parser


### PR DESCRIPTION
In my development flow I sometimes need to execute the pre_config of select testcases without actually running them. One example would be regenerating a .mif/.mem file that is loaded by a BRAM without closing my Modelsim GUI. I did not find any existing solutions for this (i.e. vunit_restart will not re-run the testcase pre_config).

As an example I implemented a naive version via a new command line parameter "--pre-config-only" that works for my use case.

Is there any interest in such a feature? Or perhaps I missed a feature which already covers my use-case? 