### PR TITLE
stop packaging tests folder

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -39,17 +39,15 @@ def find_all_files(directory, endings=None):
 DATA_FILES = []
 DATA_FILES += find_all_files("vunit", endings=[".tcl"])
 DATA_FILES += find_all_files(str(Path("vunit") / "vhdl"))
-DATA_FILES += find_all_files(str(Path("vunit") / "verilog"), endings=[".v", ".sv", ".svh"])
+DATA_FILES += find_all_files(
+    str(Path("vunit") / "verilog"), endings=[".v", ".sv", ".svh"]
+)
 DATA_FILES = [os.path.relpath(file_name, "vunit") for file_name in DATA_FILES]
 
 setup(
     name="vunit_hdl",
     version=version(),
     packages=[
-        "tests",
-        "tests.lint",
-        "tests.unit",
-        "tests.acceptance",
         "vunit",
         "vunit.com",
         "vunit.parsing",


### PR DESCRIPTION
Packaging the tests folder occupied a very common
namespace for all clients that would install
vunit.