### PR TITLE
Fix: added compile_builtins=False to examples run.py files

### DIFF
--- a/examples/verilog/uart/run.py
+++ b/examples/verilog/uart/run.py
@@ -19,7 +19,7 @@ from vunit import VUnit
 
 SRC_PATH = Path(__file__).parent / "src"
 
-VU = VUnit.from_argv()
+VU = VUnit.from_argv(compile_builtins=False)
 VU.add_verilog_builtins()
 
 VU.add_library("uart_lib").add_source_files(SRC_PATH / "*.sv")

--- a/examples/verilog/user_guide/run.py
+++ b/examples/verilog/user_guide/run.py
@@ -19,7 +19,7 @@ from vunit import VUnit
 
 ROOT = Path(__file__).parent
 
-VU = VUnit.from_argv()
+VU = VUnit.from_argv(compile_builtins=False)
 VU.add_verilog_builtins()
 
 VU.add_library("lib").add_source_files(ROOT / "*.sv")

--- a/examples/verilog/verilog_ams/run.py
+++ b/examples/verilog/verilog_ams/run.py
@@ -11,7 +11,7 @@ from vunit import VUnit
 
 ROOT = Path(__file__).parent
 
-VU = VUnit.from_argv()
+VU = VUnit.from_argv(compile_builtins=False)
 VU.add_verilog_builtins()
 
 LIB = VU.add_library("lib")

--- a/examples/vhdl/array/run.py
+++ b/examples/vhdl/array/run.py
@@ -18,7 +18,7 @@ loading it from csv and raw files.
 from pathlib import Path
 from vunit import VUnit
 
-VU = VUnit.from_argv()
+VU = VUnit.from_argv(compile_builtins=False)
 VU.add_vhdl_builtins()
 VU.add_osvvm()
 

--- a/examples/vhdl/array_axis_vcs/run.py
+++ b/examples/vhdl/array_axis_vcs/run.py
@@ -21,7 +21,7 @@ in subsection :ref:`Stream <stream_vci>` and in
 from pathlib import Path
 from vunit import VUnit
 
-VU = VUnit.from_argv()
+VU = VUnit.from_argv(compile_builtins=False)
 VU.add_vhdl_builtins()
 VU.add_verification_components()
 

--- a/examples/vhdl/axi_dma/run.py
+++ b/examples/vhdl/axi_dma/run.py
@@ -20,7 +20,7 @@ via AXI-lite.
 from pathlib import Path
 from vunit import VUnit
 
-VU = VUnit.from_argv()
+VU = VUnit.from_argv(compile_builtins=False)
 VU.add_vhdl_builtins()
 VU.add_osvvm()
 VU.add_verification_components()

--- a/examples/vhdl/check/run.py
+++ b/examples/vhdl/check/run.py
@@ -16,7 +16,7 @@ Demonstrates the VUnit check library.
 from pathlib import Path
 from vunit import VUnit
 
-VU = VUnit.from_argv()
+VU = VUnit.from_argv(compile_builtins=False)
 VU.add_vhdl_builtins()
 
 # Enable location preprocessing but exclude all but check_false to make the example less bloated

--- a/examples/vhdl/com/run.py
+++ b/examples/vhdl/com/run.py
@@ -18,7 +18,7 @@ can be found in the :ref:`com user guide <com_user_guide>`.
 from pathlib import Path
 from vunit import VUnit
 
-VU = VUnit.from_argv()
+VU = VUnit.from_argv(compile_builtins=False)
 VU.add_vhdl_builtins()
 VU.add_com()
 VU.add_verification_components()

--- a/examples/vhdl/composite_generics/run.py
+++ b/examples/vhdl/composite_generics/run.py
@@ -21,7 +21,7 @@ def encode(tb_cfg):
     return ", ".join(["%s:%s" % (key, str(tb_cfg[key])) for key in tb_cfg])
 
 
-VU = VUnit.from_argv()
+VU = VUnit.from_argv(compile_builtins=False)
 VU.add_vhdl_builtins()
 
 TB_LIB = VU.add_library("tb_lib")

--- a/examples/vhdl/coverage/run.py
+++ b/examples/vhdl/coverage/run.py
@@ -20,7 +20,7 @@ def post_run(results):
             call(["gcovr", "-a", "coverage_data/gcovr.json"])
 
 
-VU = VUnit.from_argv()
+VU = VUnit.from_argv(compile_builtins=False)
 VU.add_vhdl_builtins()
 
 LIB = VU.add_library("lib")

--- a/examples/vhdl/generate_tests/run.py
+++ b/examples/vhdl/generate_tests/run.py
@@ -62,7 +62,7 @@ def generate_tests(obj, signs, data_widths):
         )
 
 
-VU = VUnit.from_argv()
+VU = VUnit.from_argv(compile_builtins=False)
 VU.add_vhdl_builtins()
 
 LIB = VU.add_library("lib")

--- a/examples/vhdl/json4vhdl/run.py
+++ b/examples/vhdl/json4vhdl/run.py
@@ -21,7 +21,7 @@ from vunit.json4vhdl import read_json, encode_json, b16encode
 
 TEST_PATH = Path(__file__).parent / "src" / "test"
 
-VU = VUnit.from_argv()
+VU = VUnit.from_argv(compile_builtins=False)
 VU.add_vhdl_builtins()
 VU.add_json4vhdl()
 

--- a/examples/vhdl/logging/run.py
+++ b/examples/vhdl/logging/run.py
@@ -16,7 +16,7 @@ Demonstrates VUnit's support for logging.
 from pathlib import Path
 from vunit import VUnit
 
-VU = VUnit.from_argv()
+VU = VUnit.from_argv(compile_builtins=False)
 VU.add_vhdl_builtins()
 
 VU.add_library("lib").add_source_files(Path(__file__).parent / "*.vhd")

--- a/examples/vhdl/osvvm_log_integration/run.py
+++ b/examples/vhdl/osvvm_log_integration/run.py
@@ -27,7 +27,7 @@ args = cli.parse_args()
 if args.use_osvvm_log and args.use_vunit_log:
     raise RuntimeError("Only one of --use-osvvm-log and --use-vunit-log can be used at any time.")
 args.clean = True
-prj = VUnit.from_args(args=args)
+prj = VUnit.from_args(args=args, compile_builtins=False)
 root = Path(__file__).parent
 if args.use_osvvm_log:
     prj.add_vhdl_builtins(use_external_log=Path(root / "osvvm_integration" / "vunit_to_osvvm_common_log_pkg-body.vhd"))

--- a/examples/vhdl/run/run.py
+++ b/examples/vhdl/run/run.py
@@ -18,7 +18,7 @@ from vunit import VUnit
 
 root = Path(__file__).parent
 
-vu = VUnit.from_argv()
+vu = VUnit.from_argv(compile_builtins=False)
 vu.add_vhdl_builtins()
 
 lib = vu.add_library("lib")

--- a/examples/vhdl/third_party_integration/run.py
+++ b/examples/vhdl/third_party_integration/run.py
@@ -9,7 +9,7 @@
 from pathlib import Path
 from vunit import VUnit
 
-VU = VUnit.from_argv()
+VU = VUnit.from_argv(compile_builtins=False)
 VU.add_vhdl_builtins()
 
 VU.add_library("lib").add_source_files(Path(__file__).parent / "test" / "*.vhd")

--- a/examples/vhdl/uart/run.py
+++ b/examples/vhdl/uart/run.py
@@ -17,7 +17,7 @@ typical module.
 from pathlib import Path
 from vunit import VUnit
 
-VU = VUnit.from_argv()
+VU = VUnit.from_argv(compile_builtins=False)
 VU.add_vhdl_builtins()
 VU.add_osvvm()
 VU.add_verification_components()

--- a/examples/vhdl/user_guide/run.py
+++ b/examples/vhdl/user_guide/run.py
@@ -17,7 +17,7 @@ The most minimal VUnit VHDL project covering the basics of the
 from pathlib import Path
 from vunit import VUnit
 
-VU = VUnit.from_argv()
+VU = VUnit.from_argv(compile_builtins=False)
 VU.add_vhdl_builtins()
 
 VU.add_library("lib").add_source_files(Path(__file__).parent / "*.vhd")

--- a/examples/vhdl/user_guide/vhdl1993/run.py
+++ b/examples/vhdl/user_guide/vhdl1993/run.py
@@ -17,7 +17,7 @@ adapted to be used with simulators that don't support VHDL 2008.
 from pathlib import Path
 from vunit import VUnit
 
-VU = VUnit.from_argv(vhdl_standard="93")
+VU = VUnit.from_argv(vhdl_standard="93", compile_builtins=False)
 VU.add_vhdl_builtins()
 
 VU.add_library("lib").add_source_files(Path(__file__).parent / "*.vhd")

--- a/examples/vhdl/vhdl_configuration/run.py
+++ b/examples/vhdl/vhdl_configuration/run.py
@@ -9,7 +9,7 @@
 from pathlib import Path
 from vunit import VUnit
 
-vu = VUnit.from_argv()
+vu = VUnit.from_argv(compile_builtins=False)
 vu.add_vhdl_builtins()
 lib = vu.add_library("lib")
 root = Path(__file__).parent

--- a/examples/vhdl/vivado/run.py
+++ b/examples/vhdl/vivado/run.py
@@ -19,7 +19,7 @@ from vivado_util import add_vivado_ip
 ROOT = Path(__file__).parent
 SRC_PATH = ROOT / "src"
 
-VU = VUnit.from_argv()
+VU = VUnit.from_argv(compile_builtins=False)
 VU.add_vhdl_builtins()
 
 VU.add_library("lib").add_source_files(SRC_PATH / "*.vhd")


### PR DESCRIPTION
**What the change does**
- Adding compile_builtins=False to examples run.py files
- Because it now gives a warning and will be deprecated later according to #777

**Why it's needed**
- Examples are now giving the error
```
WARNING - Option 'compile_builtins' of methods 'from_args' and 'from_argv' is deprecated.
In future releases, it will be removed and builtins will need to be added explicitly.
To prepare for upcoming changes, it is recommended to apply the following modifications in the run script now:

* Use `from_argv(compile_builtins=False)` or `from_args(compile_builtins=False)`.
* Add an explicit call to 'add_vhdl_builtins'.
See https://github.com/VUnit/vunit/issues/777.
```
**How you tested it**
- I have ran the examples with Questasim 2025.3 it ran as expected except for 
  - `examples/vhdl/json4vhdl/run.py`
```
==== Summary =================================================================
pass test.tb_json_gens.b16encoded stringified JSON generic (19.8 seconds)
pass test.tb_json_gens.JSON file path generic              (2.7 seconds)
pass test.tb_json_gens.b16encoded JSON file path generic   (2.8 seconds)
fail test.tb_json_gens.stringified JSON generic            (1.3 seconds)
==============================================================================
pass 3 of 4
fail 1 of 4

Traceback (most recent call last):
  File "./vunit_testing/.venv/lib/python3.13/site-packages/vunit/test/runner.py", line 244, in _run_test_suite
    results = test_suite.run(output_path=output_path, read_output=read_output)
  File "./vunit_testing/.venv/lib/python3.13/site-packages/vunit/test/list.py", line 105, in run
    test_ok = self._test_case.run(*args, **kwargs)
  File "./vunit_testing/.venv/lib/python3.13/site-packages/vunit/test/suites.py", line 72, in run
    results = self._run.run(*args, **kwargs)
  File "./vunit_testing/.venv/lib/python3.13/site-packages/vunit/test/suites.py", line 178, in run
    sim_ok = self._simulate(output_path)
  File "./vunit_testing/.venv/lib/python3.13/site-packages/vunit/test/suites.py", line 237, in _simulate
    return self._simulator_if.simulate(
           ~~~~~~~~~~~~~~~~~~~~~~~~~~~^
        output_path=output_path,
        ^^^^^^^^^^^^^^^^^^^^^^^^
    ...<2 lines>...
        elaborate_only=self._elaborate_only,
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    )
    ^
  File "./vunit_testing/.venv/lib/python3.13/site-packages/vunit/sim_if/vsim_simulator_mixin.py", line 330, in simulate
    return self._run_persistent(str(common_file_name), load_only=elaborate_only)
           ~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "./vunit_testing/.venv/lib/python3.13/site-packages/vunit/sim_if/vsim_simulator_mixin.py", line 294, in _run_persistent
    if self._persistent_shell.read_bool("failed"):
       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^
  File "./vunit_testing/.venv/lib/python3.13/site-packages/vunit/persistent_tcl_shell.py", line 77, in read_bool
    assert result in ("true", "false")
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
AssertionError
fail (P=0 S=0 F=1 T=4) test.tb_json_gens.stringified JSON generic (1.3 second)
```
