### PR TITLE
Restrict setuptools to pre-82.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 requires = [
-    "setuptools >= 35.0.2",
+    "setuptools >= 35.0.2, <82.0.0",
     "setuptools_scm >= 2.0.0, <3"
 ]
 build-backend = "setuptools.build_meta"


### PR DESCRIPTION
Restrict setup tools to pre-82, as the deprecated pkg_resources is still used.

Issue: #1158 