### PR TITLE
Fix NVC coverage merge to use configured path instead of PATH

### DIFF
--- a/vunit/sim_if/nvc.py
+++ b/vunit/sim_if/nvc.py
@@ -369,7 +369,7 @@ class NVCInterface(SimulatorInterface, ViewerMixin):  # pylint: disable=too-many
                 LOGGER.warning("Missing coverage file: %s", coverage_file)
 
         nvc_coverage_merge_cmd = [
-            "nvc",
+            str(Path(self._prefix) / self.executable),
             "--cover-merge",
             "-o",
             f"{file_name}.ncdb",


### PR DESCRIPTION
Following up the PR https://github.com/VUnit/vunit/pull/1139, I would like to apply a fix on the way NVC is called.

The PR https://github.com/VUnit/vunit/pull/1139 only works if NVC is in the PATH. However, it should call NVC specified by `environ["VUNIT_NVC_PATH"]`.

