### PR TITLE
Enabled VHDL-2019 for  GHDL >= 6.0.0.

### DIFF
--- a/docs/news.d/1177.feature.rst
+++ b/docs/news.d/1177.feature.rst
@@ -1,0 +1,3 @@
+Enabled VHDL-2019 for GHDL >= 6.0.0.
+
+Note that VUnit log location support based on call_path is deactivated as this is yet to be supported by GHDL.

--- a/tests/unit/test_ghdl_interface.py
+++ b/tests/unit/test_ghdl_interface.py
@@ -138,7 +138,31 @@ warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE."""
         self.assertRaises(AssertionError, GHDLInterface.determine_backend, "prefix")
 
     @mock.patch("vunit.sim_if.check_output", autospec=True, return_value="")  # pylint: disable=no-self-use
-    def test_compile_project_2008(self, check_output):
+    @mock.patch.object(GHDLInterface, "determine_version", return_value=6.0)
+    def test_compile_project_2019(self, determine_version, check_output):
+        simif = GHDLInterface(prefix="prefix", output_path="")
+        write_file("file.vhd", "")
+
+        project = Project()
+        project.add_library("lib", "lib_path")
+        project.add_source_file("file.vhd", "lib", file_type="vhdl", vhdl_standard=VHDL.standard("2019"))
+        simif.compile_project(project)
+        check_output.assert_called_once_with(
+            [
+                str(Path("prefix") / "ghdl"),
+                "-a",
+                "--workdir=lib_path",
+                "--work=lib",
+                "--std=19",
+                "-Plib_path",
+                "file.vhd",
+            ],
+            env=simif.get_env(),
+        )
+
+    @mock.patch("vunit.sim_if.check_output", autospec=True, return_value="")  # pylint: disable=no-self-use
+    @mock.patch.object(GHDLInterface, "determine_version", return_value=5.0)
+    def test_compile_project_2008(self, determine_version, check_output):
         simif = GHDLInterface(prefix="prefix", output_path="")
         write_file("file.vhd", "")
 
@@ -160,7 +184,8 @@ warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE."""
         )
 
     @mock.patch("vunit.sim_if.check_output", autospec=True, return_value="")  # pylint: disable=no-self-use
-    def test_compile_project_2002(self, check_output):
+    @mock.patch.object(GHDLInterface, "determine_version", return_value=5.0)
+    def test_compile_project_2002(self, determine_version, check_output):
         simif = GHDLInterface(prefix="prefix", output_path="")
         write_file("file.vhd", "")
 
@@ -182,7 +207,8 @@ warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE."""
         )
 
     @mock.patch("vunit.sim_if.check_output", autospec=True, return_value="")  # pylint: disable=no-self-use
-    def test_compile_project_93(self, check_output):
+    @mock.patch.object(GHDLInterface, "determine_version", return_value=5.0)
+    def test_compile_project_93(self, determine_version, check_output):
         simif = GHDLInterface(prefix="prefix", output_path="")
         write_file("file.vhd", "")
 
@@ -204,7 +230,8 @@ warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE."""
         )
 
     @mock.patch("vunit.sim_if.check_output", autospec=True, return_value="")  # pylint: disable=no-self-use
-    def test_compile_project_extra_flags(self, check_output):
+    @mock.patch.object(GHDLInterface, "determine_version", return_value=5.0)
+    def test_compile_project_extra_flags(self, determine_version, check_output):
         simif = GHDLInterface(prefix="prefix", output_path="")
         write_file("file.vhd", "")
 
@@ -228,7 +255,8 @@ warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE."""
             env=simif.get_env(),
         )
 
-    def test_elaborate_e_project(self):
+    @mock.patch.object(GHDLInterface, "determine_version", return_value=5.0)
+    def test_elaborate_e_project(self, determine_version):
         design_unit = Entity("tb_entity", file_name=str(Path("tempdir") / "file.vhd"))
         design_unit.original_file_name = str(Path("tempdir") / "other_path" / "original_file.vhd")
         design_unit.generic_names = ["runner_cfg", "tb_path"]
@@ -258,7 +286,8 @@ warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE."""
             ],
         )
 
-    def test_compile_project_verilog_error(self):
+    @mock.patch.object(GHDLInterface, "determine_version", return_value=5.0)
+    def test_compile_project_verilog_error(self, determine_version):
         simif = GHDLInterface(prefix="prefix", output_path="")
         write_file("file.v", "")
 

--- a/vunit/builtins.py
+++ b/vunit/builtins.py
@@ -448,11 +448,10 @@ in your VUnit Git repository? You have to do this first if installing using setu
 
             library.add_source_files(file_name, preprocessors=[])
 
-    def _add_vhdl_logging(self):
+    def _add_vhdl_logging(self, use_external_log):
         """
         Add logging functionality
         """
-
         use_call_paths = self._simulator_class.supports_vhdl_call_paths() and (
             self._vhdl_standard in VHDL.STD_2019.and_later
         )
@@ -465,6 +464,10 @@ in your VUnit Git repository? You have to do this first if installing using setu
             base_file_name = Path(file_name).name
 
             if base_file_name.startswith("location_pkg-body"):
+                continue
+
+            if (base_file_name == "common_log_pkg-body.vhd") and use_external_log:
+                self._add_files(Path(use_external_log))
                 continue
 
             standards = set()
@@ -504,7 +507,7 @@ in your VUnit Git repository? You have to do this first if installing using setu
             })
         """
         self._add_data_types(external=external)
-        self._add_vhdl_logging()
+        self._add_vhdl_logging(use_external_log)
         self._add_files(VHDL_PATH / "*.vhd")
         for path in (
             "core",
@@ -515,14 +518,6 @@ in your VUnit Git repository? You have to do this first if installing using setu
             "path",
         ):
             self._add_files(VHDL_PATH / path / "src" / "*.vhd")
-
-        logging_files = glob(str(VHDL_PATH / "logging" / "src" / "*.vhd"))
-        for logging_file in logging_files:
-            if logging_file.endswith("common_log_pkg-body.vhd") and use_external_log:
-                self._add_files(Path(use_external_log))
-                continue
-
-            self._add_files(Path(logging_file))
 
 
 def osvvm_is_installed():

--- a/vunit/sim_if/ghdl.py
+++ b/vunit/sim_if/ghdl.py
@@ -119,6 +119,7 @@ class GHDLInterface(SimulatorInterface, ViewerMixin):  # pylint: disable=too-man
         self._vhdl_standard = None
         self._coverage_test_dirs = set()  # For gcov
         self._coverage_files = set()  # For --coverage
+        self._version = self.determine_version(self.find_prefix())
 
     def has_valid_exit_code(self):  # pylint: disable=arguments-differ
         """
@@ -185,6 +186,13 @@ class GHDLInterface(SimulatorInterface, ViewerMixin):  # pylint: disable=too-man
         )
 
     @classmethod
+    def supports_vhdl_call_paths(cls):
+        """
+        Returns True when this simulator supports VHDL-2019 call paths
+        """
+        return False
+
+    @classmethod
     def supports_vhdl_package_generics(cls):
         """
         Returns True when this simulator supports VHDL package generics
@@ -246,16 +254,20 @@ class GHDLInterface(SimulatorInterface, ViewerMixin):  # pylint: disable=too-man
         LOGGER.error("Unknown file type: %s", source_file.file_type)
         raise CompileError
 
-    @staticmethod
-    def _std_str(vhdl_standard):
+    def _std_str(self, vhdl_standard):
         """
         Convert standard to format of GHDL command line flag
         """
-        if vhdl_standard == VHDL.STD_2002:
-            return "02"
+        if vhdl_standard == VHDL.STD_2019:
+            if self._version >= 6.0:
+                return "19"
+            raise ValueError("VHDL-2019 requires GHDL >=6.0.0.")
 
         if vhdl_standard == VHDL.STD_2008:
             return "08"
+
+        if vhdl_standard == VHDL.STD_2002:
+            return "02"
 
         if vhdl_standard == VHDL.STD_1993:
             return "93"


### PR DESCRIPTION
Note that VUnit log location support based on call_path is deactivated as this is yet to be supported by GHDL.