### PR TITLE
Feature/non aligned tlast and tvalid during stalls

### DIFF
--- a/docs/news.d/1195.breaking.rst
+++ b/docs/news.d/1195.breaking.rst
@@ -1,0 +1,8 @@
+Improved user control over what values are driven on the AXI stream bus when ``tvalid`` is low and the bus is inactive.
+The inactive value configuration is controlled by a new parameter ``inactive_policy`` to the ``new_axi_stream_master``
+function and it can also be updated dynamically with the ``set_inactive_axi_stream_policy`` command.
+This is a breaking change from the generic-based configuration used before. However, if will only affect the behavior
+of the AXI stream master VC if the generics are set to non-default values.
+
+``set_stall_config`` has also been added for dynamic control of the stall configuration. This is not a breaking
+change.

--- a/vunit/vhdl/verification_components/run.py
+++ b/vunit/vhdl/verification_components/run.py
@@ -164,16 +164,4 @@ TEST_FAILING_MAX_WAITS = TB_AXI_STREAM_PROTOCOL_CHECKER.test(
 for max_waits in [0, 8]:
     TEST_FAILING_MAX_WAITS.add_config(name="max_waits=%d" % max_waits, generics=dict(max_waits=max_waits))
 
-TB_AXI_STREAM.test("test random stall on master").add_config(
-    name="stall_master", generics=dict(g_stall_percentage_master=30)
-)
-
-TB_AXI_STREAM.test("test random pop stall on slave").add_config(
-    name="stall_slave", generics=dict(g_stall_percentage_slave=30)
-)
-
-TB_AXI_STREAM.test("test random check stall on slave").add_config(
-    name="stall_slave", generics=dict(g_stall_percentage_slave=40)
-)
-
 UI.main()

--- a/vunit/vhdl/verification_components/src/axi_lite_master_pkg.vhd
+++ b/vunit/vhdl/verification_components/src/axi_lite_master_pkg.vhd
@@ -21,35 +21,43 @@ package axi_lite_master_pkg is
   constant axi_lite_write_msg : msg_type_t := new_msg_type("write axi lite");
 
   -- Blocking: Write the bus
-  procedure write_axi_lite(signal net : inout network_t;
-                           constant bus_handle : bus_master_t;
-                           constant address : std_logic_vector;
-                           constant data : std_logic_vector;
-                           constant expected_bresp : axi_resp_t := axi_resp_okay;
-                           -- default byte enable is all bytes
-                           constant byte_enable : std_logic_vector := "");
+  procedure write_axi_lite(
+    signal net : inout network_t;
+    constant bus_handle : bus_master_t;
+    constant address : std_logic_vector;
+    constant data : std_logic_vector;
+    constant expected_bresp : axi_resp_t := axi_resp_okay;
+    -- default byte enable is all bytes
+    constant byte_enable : std_logic_vector := ""
+  );
 
   -- Non blocking: Read the bus returning a reference to the future reply
-  procedure read_axi_lite(signal net : inout network_t;
-                          constant bus_handle : bus_master_t;
-                          constant address : std_logic_vector;
-                          constant expected_rresp : axi_resp_t := axi_resp_okay;
-                          variable reference : inout bus_reference_t);
+  procedure read_axi_lite(
+    signal net : inout network_t;
+    constant bus_handle : bus_master_t;
+    constant address : std_logic_vector;
+    constant expected_rresp : axi_resp_t := axi_resp_okay;
+    variable reference : inout bus_reference_t
+  );
 
   -- Blocking: read bus with immediate reply
-  procedure read_axi_lite(signal net : inout network_t;
-                          constant bus_handle : bus_master_t;
-                          constant address : std_logic_vector;
-                          constant expected_rresp : axi_resp_t := axi_resp_okay;
-                          variable data : inout std_logic_vector);
+  procedure read_axi_lite(
+    signal net : inout network_t;
+    constant bus_handle : bus_master_t;
+    constant address : std_logic_vector;
+    constant expected_rresp : axi_resp_t := axi_resp_okay;
+    variable data : inout std_logic_vector
+  );
 
   -- Blocking: Read bus and check result against expected data
-  procedure check_axi_lite(signal net : inout network_t;
-                           constant bus_handle : bus_master_t;
-                           constant address : std_logic_vector;
-                           constant expected_rresp : axi_resp_t := axi_resp_okay;
-                           constant expected : std_logic_vector;
-                           constant msg : string := "");
+  procedure check_axi_lite(
+    signal net : inout network_t;
+    constant bus_handle : bus_master_t;
+    constant address : std_logic_vector;
+    constant expected_rresp : axi_resp_t := axi_resp_okay;
+    constant expected : std_logic_vector;
+    constant msg : string := ""
+  );
 
   function is_read(msg_type : msg_type_t) return boolean;
   function is_write(msg_type : msg_type_t) return boolean;
@@ -59,13 +67,15 @@ end package;
 
 package body axi_lite_master_pkg is
 
-  procedure write_axi_lite(signal net : inout network_t;
-                           constant bus_handle : bus_master_t;
-                           constant address : std_logic_vector;
-                           constant data : std_logic_vector;
-                           constant expected_bresp : axi_resp_t := axi_resp_okay;
-                           -- default byte enable is all bytes
-                           constant byte_enable : std_logic_vector := "") is
+  procedure write_axi_lite(
+    signal net : inout network_t;
+    constant bus_handle : bus_master_t;
+    constant address : std_logic_vector;
+    constant data : std_logic_vector;
+    constant expected_bresp : axi_resp_t := axi_resp_okay;
+    -- default byte enable is all bytes
+    constant byte_enable : std_logic_vector := ""
+  ) is
     variable request_msg : msg_t := new_msg(axi_lite_write_msg);
     variable full_data : std_logic_vector(bus_handle.p_data_length - 1 downto 0) := (others => '0');
     variable full_address : std_logic_vector(bus_handle.p_address_length - 1 downto 0) := (others => '0');
@@ -89,11 +99,13 @@ package body axi_lite_master_pkg is
     send(net, bus_handle.p_actor, request_msg);
   end procedure;
 
-  procedure read_axi_lite(signal net : inout network_t;
-                          constant bus_handle : bus_master_t;
-                          constant address : std_logic_vector;
-                          constant expected_rresp : axi_resp_t := axi_resp_okay;
-                          variable reference : inout bus_reference_t) is
+  procedure read_axi_lite(
+    signal net : inout network_t;
+    constant bus_handle : bus_master_t;
+    constant address : std_logic_vector;
+    constant expected_rresp : axi_resp_t := axi_resp_okay;
+    variable reference : inout bus_reference_t
+  ) is
     variable full_address : std_logic_vector(bus_handle.p_address_length - 1 downto 0) := (others => '0');
     alias request_msg : msg_t is reference;
   begin
@@ -104,25 +116,29 @@ package body axi_lite_master_pkg is
     send(net, bus_handle.p_actor, request_msg);
   end procedure;
 
-  procedure read_axi_lite(signal net : inout network_t;
-                          constant bus_handle : bus_master_t;
-                          constant address : std_logic_vector;
-                          constant expected_rresp : axi_resp_t := axi_resp_okay;
-                          variable data : inout std_logic_vector) is
+  procedure read_axi_lite(
+    signal net : inout network_t;
+    constant bus_handle : bus_master_t;
+    constant address : std_logic_vector;
+    constant expected_rresp : axi_resp_t := axi_resp_okay;
+    variable data : inout std_logic_vector
+  ) is
     variable reference : bus_reference_t;
   begin
     read_axi_lite(net, bus_handle, address, expected_rresp, reference);
     await_read_bus_reply(net, reference, data);
   end procedure;
 
-  procedure check_axi_lite(signal net : inout network_t;
-                           constant bus_handle : bus_master_t;
-                           constant address : std_logic_vector;
-                           constant expected_rresp : axi_resp_t := axi_resp_okay;
-                           constant expected : std_logic_vector;
-                           constant msg : string := "") is
+  procedure check_axi_lite(
+    signal net : inout network_t;
+    constant bus_handle : bus_master_t;
+    constant address : std_logic_vector;
+    constant expected_rresp : axi_resp_t := axi_resp_okay;
+    constant expected : std_logic_vector;
+    constant msg : string := ""
+  ) is
     variable data : std_logic_vector(bus_handle.p_data_length - 1 downto 0);
-    variable edata : std_logic_vector(data'range) := (others => '0');
+    variable expected_data : std_logic_vector(data'range) := (others => '0');
 
     impure function error_prefix return string is
     begin
@@ -135,14 +151,14 @@ package body axi_lite_master_pkg is
 
     impure function base_error return string is
     begin
-      return error_prefix & " - Got x""" & to_hstring(data) & """ expected x""" & to_hstring(edata) & """";
+      return error_prefix & " - Got x""" & to_hstring(data) & """ expected x""" & to_hstring(expected_data) & """";
     end;
   begin
 
-    edata(expected'length - 1 downto 0) := expected;
+    expected_data(expected'length - 1 downto 0) := expected;
 
     read_axi_lite(net, bus_handle, address, expected_rresp, data);
-    if not std_match(data, edata) then
+    if not std_match(data, expected_data) then
       failure(bus_handle.p_logger, base_error);
     end if;
   end procedure;

--- a/vunit/vhdl/verification_components/src/axi_pkg.vhd
+++ b/vunit/vhdl/verification_components/src/axi_pkg.vhd
@@ -23,5 +23,12 @@ package axi_pkg is
   constant max_axi4_burst_length : natural := 2**axi4_len_t'length;
   subtype axi4_size_t is std_logic_vector(2 downto 0);
 
+  -- This policy controls what value the bus signals are assigned when not driving valid
+  -- data. All zeros, all ones, all unknown values, or holding last valid value.
+
+  -- 'X' violates the all lower case naming rule but is kept to match the corresponding
+  -- std_logic value it represents.
+  -- vsg_off type_500
   type inactive_bus_policy_t is ('0', '1', 'X', hold);
+  -- vsg_on
 end package;

--- a/vunit/vhdl/verification_components/src/axi_pkg.vhd
+++ b/vunit/vhdl/verification_components/src/axi_pkg.vhd
@@ -24,11 +24,12 @@ package axi_pkg is
   subtype axi4_size_t is std_logic_vector(2 downto 0);
 
   -- This policy controls what value the bus signals are assigned when not driving valid
-  -- data. All zeros, all ones, all unknown values, or holding last valid value.
+  -- data. All zeros, all ones, all unknown values, holding last valid value, or
+  -- random zeros and ones.
 
   -- 'X' violates the all lower case naming rule but is kept to match the corresponding
   -- std_logic value it represents.
   -- vsg_off type_500
-  type inactive_bus_policy_t is ('0', '1', 'X', hold);
+  type inactive_bus_policy_t is ('0', '1', 'X', hold, rand01);
   -- vsg_on
 end package;

--- a/vunit/vhdl/verification_components/src/axi_pkg.vhd
+++ b/vunit/vhdl/verification_components/src/axi_pkg.vhd
@@ -22,4 +22,6 @@ package axi_pkg is
   subtype axi4_len_t is std_logic_vector(7 downto 0);
   constant max_axi4_burst_length : natural := 2**axi4_len_t'length;
   subtype axi4_size_t is std_logic_vector(2 downto 0);
+
+  type inactive_bus_policy_t is ('0', '1', 'X', hold);
 end package;

--- a/vunit/vhdl/verification_components/src/axi_read_slave.vhd
+++ b/vunit/vhdl/verification_components/src/axi_read_slave.vhd
@@ -163,7 +163,10 @@ begin
         num_beats := num_beats_now;
 
         if self.should_check_well_behaved and size /= self.data_size and len /= 0 then
-          self.fail("Burst not well behaved, axi size = " & to_string(size) & " but bus data width allows " & to_string(self.data_size));
+          self.fail(
+            "Burst not well behaved, axi size = " & to_string(size) & " but bus data width allows " &
+            to_string(self.data_size)
+          );
         end if;
       end if;
 

--- a/vunit/vhdl/verification_components/src/axi_slave_pkg.vhd
+++ b/vunit/vhdl/verification_components/src/axi_slave_pkg.vhd
@@ -34,82 +34,104 @@ package axi_slave_pkg is
   end record;
 
   constant axi_slave_logger : logger_t := get_logger("vunit_lib:axi_slave_pkg");
-  impure function new_axi_slave(memory : memory_t;
-                                actor : actor_t := null_actor;
-                                address_fifo_depth : positive := 1;
-                                write_response_fifo_depth : positive := 1;
-                                check_4kbyte_boundary : boolean := true;
-                                address_stall_probability : probability_t := 0.0;
-                                data_stall_probability : probability_t := 0.0;
-                                write_response_stall_probability : probability_t := 0.0;
-                                min_response_latency : delay_length := 0 ns;
-                                max_response_latency : delay_length := 0 ns;
-                                logger : logger_t := axi_slave_logger) return axi_slave_t;
+  impure function new_axi_slave(
+    memory : memory_t;
+    actor : actor_t := null_actor;
+    address_fifo_depth : positive := 1;
+    write_response_fifo_depth : positive := 1;
+    check_4kbyte_boundary : boolean := true;
+    address_stall_probability : probability_t := 0.0;
+    data_stall_probability : probability_t := 0.0;
+    write_response_stall_probability : probability_t := 0.0;
+    min_response_latency : delay_length := 0 ns;
+    max_response_latency : delay_length := 0 ns;
+    logger : logger_t := axi_slave_logger
+  ) return axi_slave_t;
 
   -- Get the logger used by the axi_slave
   function get_logger(axi_slave : axi_slave_t) return logger_t;
 
   -- Set the maximum number address channel tokens that can be queued
-  procedure set_address_fifo_depth(signal net : inout network_t;
-                                   axi_slave : axi_slave_t;
-                                   depth : positive);
+  procedure set_address_fifo_depth(
+    signal net : inout network_t;
+    axi_slave : axi_slave_t;
+    depth : positive
+  );
 
   -- Set the maximum number write responses that can be queued
-  procedure set_write_response_fifo_depth(signal net : inout network_t;
-                                          axi_slave : axi_slave_t;
-                                          depth : positive);
+  procedure set_write_response_fifo_depth(
+    signal net : inout network_t;
+    axi_slave : axi_slave_t;
+    depth : positive
+  );
 
   -- Set the address channel stall probability
-  procedure set_address_stall_probability(signal net : inout network_t;
-                                          axi_slave : axi_slave_t;
-                                          probability : probability_t);
+  procedure set_address_stall_probability(
+    signal net : inout network_t;
+    axi_slave : axi_slave_t;
+    probability : probability_t
+  );
 
   -- Set the data channel stall probability
-  procedure set_data_stall_probability(signal net : inout network_t;
-                                       axi_slave : axi_slave_t;
-                                       probability : probability_t);
+  procedure set_data_stall_probability(
+    signal net : inout network_t;
+    axi_slave : axi_slave_t;
+    probability : probability_t
+  );
 
   -- Set the write response stall probability
-  procedure set_write_response_stall_probability(signal net : inout network_t;
-                                                 axi_slave : axi_slave_t;
-                                                 probability : probability_t);
+  procedure set_write_response_stall_probability(
+    signal net : inout network_t;
+    axi_slave : axi_slave_t;
+    probability : probability_t
+  );
 
   -- Set the response latency
   --
   -- For a write slave this is the time between the last write data
-  -- and providing the write reponse. All write data is written to the
+  -- and providing the write response. All write data is written to the
   -- memory model right before providing write response.
-  -- Data address and expected value is still checked as soons as it arrives to
+  -- Data address and expected value is still checked as soon as it arrives to
   -- the axi slave and is not delayed until the write response time.
   --
   -- For a read slave this is the time between the read burst arrival and the
   -- first provided read data
   --
-  -- The response latency is randomly choosen in the uniform interval:
+  -- The response latency is randomly chosen in the uniform interval:
   -- [min_latency, max_latency]
-  procedure set_response_latency(signal net : inout network_t;
-                                 axi_slave : axi_slave_t;
-                                 min_latency, max_latency : delay_length);
+  procedure set_response_latency(
+    signal net : inout network_t;
+    axi_slave : axi_slave_t;
+    min_latency, max_latency : delay_length
+  );
 
   -- Short hand for set_response_latency when min and max are the same
-  procedure set_response_latency(signal net : inout network_t;
-                                 axi_slave : axi_slave_t;
-                                 latency : delay_length);
+  procedure set_response_latency(
+    signal net : inout network_t;
+    axi_slave : axi_slave_t;
+    latency : delay_length
+  );
 
-  procedure enable_4kbyte_boundary_check(signal net : inout network_t;
-                                         axi_slave : axi_slave_t);
-  procedure disable_4kbyte_boundary_check(signal net : inout network_t;
-                                          axi_slave : axi_slave_t);
+  procedure enable_4kbyte_boundary_check(
+    signal net : inout network_t;
+    axi_slave : axi_slave_t
+  );
+  procedure disable_4kbyte_boundary_check(
+    signal net : inout network_t;
+    axi_slave : axi_slave_t
+  );
 
   -- Get statistics object from axi slave
   -- Dynamically allocates new statistics object which must he deallocated when
   -- used
   -- This procedure will automatically deallocate the input statistics object
   -- if it is not null
-  procedure get_statistics(signal net : inout network_t;
-                           axi_slave : axi_slave_t;
-                           variable stat  : inout axi_statistics_t;
-                           clear : boolean := false);
+  procedure get_statistics(
+    signal net : inout network_t;
+    axi_slave : axi_slave_t;
+    variable stat  : inout axi_statistics_t;
+    clear : boolean := false
+  );
 
   -- Check that bursts are well behaved, that is that data channel traffic is
   -- as compact as possible
@@ -126,30 +148,37 @@ package axi_slave_pkg is
   procedure enable_well_behaved_check(signal net : inout network_t; axi_slave : axi_slave_t);
 
   -- Private constants
-  constant axi_slave_set_address_fifo_depth_msg : msg_type_t := new_msg_type("axi slave set address channel fifo depth");
+  constant axi_slave_set_address_fifo_depth_msg : msg_type_t :=
+    new_msg_type("axi slave set address channel fifo depth");
   constant axi_slave_set_write_response_fifo_depth_msg : msg_type_t := new_msg_type("set write response fifo depth");
-  constant axi_slave_set_address_stall_probability_msg : msg_type_t := new_msg_type("axi slave set address channel stall probability");
-  constant axi_slave_set_data_stall_probability_msg : msg_type_t := new_msg_type("axi slave set data stall probability");
-  constant axi_slave_set_write_response_stall_probability_msg : msg_type_t := new_msg_type("axi slave set write response stall probability");
+  constant axi_slave_set_address_stall_probability_msg : msg_type_t :=
+    new_msg_type("axi slave set address channel stall probability");
+  constant axi_slave_set_data_stall_probability_msg : msg_type_t :=
+    new_msg_type("axi slave set data stall probability");
+  constant axi_slave_set_write_response_stall_probability_msg : msg_type_t :=
+    new_msg_type("axi slave set write response stall probability");
   constant axi_slave_set_response_latency_msg : msg_type_t := new_msg_type("axi slave response latency probability");
-  constant axi_slave_configure_4kbyte_boundary_check_msg : msg_type_t := new_msg_type("axi slave configure 4kbyte boundary check");
+  constant axi_slave_configure_4kbyte_boundary_check_msg : msg_type_t :=
+    new_msg_type("axi slave configure 4kbyte boundary check");
   constant axi_slave_get_statistics_msg : msg_type_t := new_msg_type("axi slave get statistics");
   constant axi_slave_enable_well_behaved_check_msg : msg_type_t := new_msg_type("axi slave enable well behaved check");
 
 end package;
 
 package body axi_slave_pkg is
-  impure function new_axi_slave(memory : memory_t;
-                                actor : actor_t := null_actor;
-                                address_fifo_depth : positive := 1;
-                                write_response_fifo_depth : positive := 1;
-                                check_4kbyte_boundary : boolean := true;
-                                address_stall_probability : probability_t := 0.0;
-                                data_stall_probability : probability_t := 0.0;
-                                write_response_stall_probability : probability_t := 0.0;
-                                min_response_latency : delay_length := 0 ns;
-                                max_response_latency : delay_length := 0 ns;
-                                logger : logger_t := axi_slave_logger) return axi_slave_t is
+  impure function new_axi_slave(
+    memory : memory_t;
+    actor : actor_t := null_actor;
+    address_fifo_depth : positive := 1;
+    write_response_fifo_depth : positive := 1;
+    check_4kbyte_boundary : boolean := true;
+    address_stall_probability : probability_t := 0.0;
+    data_stall_probability : probability_t := 0.0;
+    write_response_stall_probability : probability_t := 0.0;
+    min_response_latency : delay_length := 0 ns;
+    max_response_latency : delay_length := 0 ns;
+    logger : logger_t := axi_slave_logger
+  ) return axi_slave_t is
     variable actor_tmp : actor_t := null_actor;
   begin
     if actor = null_actor then
@@ -175,9 +204,11 @@ package body axi_slave_pkg is
     return axi_slave.p_logger;
   end;
 
-  procedure set_address_fifo_depth(signal net : inout network_t;
-                                   axi_slave : axi_slave_t;
-                                   depth : positive) is
+  procedure set_address_fifo_depth(
+    signal net : inout network_t;
+    axi_slave : axi_slave_t;
+    depth : positive
+  ) is
     variable request_msg : msg_t;
     variable ack : boolean;
   begin
@@ -187,9 +218,11 @@ package body axi_slave_pkg is
     assert ack report "Failed on set_address_fifo_depth command";
   end;
 
-  procedure set_write_response_fifo_depth(signal net : inout network_t;
-                                          axi_slave : axi_slave_t;
-                                          depth : positive) is
+  procedure set_write_response_fifo_depth(
+    signal net : inout network_t;
+    axi_slave : axi_slave_t;
+    depth : positive
+  ) is
     variable request_msg : msg_t;
     variable ack : boolean;
   begin
@@ -199,9 +232,11 @@ package body axi_slave_pkg is
     assert ack report "Failed on set_write_response_fifo_depth command";
   end;
 
-  procedure set_address_stall_probability(signal net : inout network_t;
-                                          axi_slave : axi_slave_t;
-                                          probability : probability_t) is
+  procedure set_address_stall_probability(
+    signal net : inout network_t;
+    axi_slave : axi_slave_t;
+    probability : probability_t
+  ) is
     variable request_msg : msg_t;
     variable ack : boolean;
   begin
@@ -211,9 +246,11 @@ package body axi_slave_pkg is
     assert ack report "Failed on set_address_stall_probability command";
   end;
 
-  procedure set_data_stall_probability(signal net : inout network_t;
-                                       axi_slave : axi_slave_t;
-                                       probability : probability_t) is
+  procedure set_data_stall_probability(
+    signal net : inout network_t;
+    axi_slave : axi_slave_t;
+    probability : probability_t
+  ) is
     variable request_msg : msg_t;
     variable ack : boolean;
   begin
@@ -223,8 +260,10 @@ package body axi_slave_pkg is
     assert ack report "Failed on set_data_stall_probability command";
   end;
 
-  procedure set_write_response_stall_probability(signal net : inout network_t; axi_slave : axi_slave_t;
-                                                 probability : probability_t) is
+  procedure set_write_response_stall_probability(
+    signal net : inout network_t; axi_slave : axi_slave_t;
+    probability : probability_t
+  ) is
     variable request_msg : msg_t;
     variable ack : boolean;
   begin
@@ -234,9 +273,11 @@ package body axi_slave_pkg is
     assert ack report "Failed on set_write_response_stall_probability command";
   end;
 
-  procedure configure_4kbyte_boundary_check(signal net : inout network_t;
-                                            axi_slave : axi_slave_t;
-                                            value : boolean) is
+  procedure configure_4kbyte_boundary_check(
+    signal net : inout network_t;
+    axi_slave : axi_slave_t;
+    value : boolean
+  ) is
     variable request_msg : msg_t;
     variable ack : boolean;
   begin
@@ -246,9 +287,11 @@ package body axi_slave_pkg is
     assert ack report "Failed on configure_4kbyte_boundary_check command";
   end;
 
-  procedure set_response_latency(signal net : inout network_t;
-                                 axi_slave : axi_slave_t;
-                                 min_latency, max_latency : delay_length) is
+  procedure set_response_latency(
+    signal net : inout network_t;
+    axi_slave : axi_slave_t;
+    min_latency, max_latency : delay_length
+  ) is
     variable request_msg : msg_t;
     variable ack : boolean;
   begin
@@ -260,30 +303,38 @@ package body axi_slave_pkg is
   end;
 
   -- Short hand for set_response_latency when min and max are the same
-  procedure set_response_latency(signal net : inout network_t;
-                                 axi_slave : axi_slave_t;
-                                 latency : delay_length) is
+  procedure set_response_latency(
+    signal net : inout network_t;
+    axi_slave : axi_slave_t;
+    latency : delay_length
+  ) is
   begin
     set_response_latency(net, axi_slave, latency, latency);
   end;
 
-  procedure enable_4kbyte_boundary_check(signal net : inout network_t;
-                                         axi_slave : axi_slave_t) is
+  procedure enable_4kbyte_boundary_check(
+    signal net : inout network_t;
+    axi_slave : axi_slave_t
+  ) is
   begin
     configure_4kbyte_boundary_check(net, axi_slave, true);
   end;
 
-  procedure disable_4kbyte_boundary_check(signal net : inout network_t;
-                                          axi_slave : axi_slave_t) is
+  procedure disable_4kbyte_boundary_check(
+    signal net : inout network_t;
+    axi_slave : axi_slave_t
+  ) is
   begin
     configure_4kbyte_boundary_check(net, axi_slave, false);
   end;
 
 
-  procedure get_statistics(signal net : inout network_t;
-                           axi_slave : axi_slave_t;
-                           variable stat  : inout axi_statistics_t;
-                           clear : boolean := false) is
+  procedure get_statistics(
+    signal net : inout network_t;
+    axi_slave : axi_slave_t;
+    variable stat  : inout axi_statistics_t;
+    clear : boolean := false
+  ) is
     variable request_msg, reply_msg : msg_t;
   begin
     deallocate(stat);
@@ -296,8 +347,10 @@ package body axi_slave_pkg is
     delete(reply_msg);
   end;
 
-  procedure enable_well_behaved_check(signal net : inout network_t;
-                                      axi_slave : axi_slave_t) is
+  procedure enable_well_behaved_check(
+    signal net : inout network_t;
+    axi_slave : axi_slave_t
+  ) is
     variable request_msg : msg_t;
     variable ack : boolean;
   begin

--- a/vunit/vhdl/verification_components/src/axi_slave_private_pkg.vhd
+++ b/vunit/vhdl/verification_components/src/axi_slave_private_pkg.vhd
@@ -44,14 +44,15 @@ package axi_slave_private_pkg is
 
   impure function describe_burst(burst : axi_burst_t) return string;
 
-  type axi_slave_type_t is (write_slave,
-                            read_slave);
+  type axi_slave_type_t is (write_slave, read_slave);
 
   type axi_slave_private_t is protected
-    procedure init(axi_slave : axi_slave_t;
-                   axi_slave_type : axi_slave_type_t;
-                   max_id : natural;
-                   data : std_logic_vector);
+    procedure init(
+      axi_slave : axi_slave_t;
+      axi_slave_type : axi_slave_type_t;
+      max_id : natural;
+      data : std_logic_vector
+    );
     impure function get_actor return actor_t;
 
     procedure set_address_fifo_depth(depth : positive);
@@ -68,11 +69,13 @@ package axi_slave_private_pkg is
     impure function should_stall_data return boolean;
     impure function should_stall_write_response return boolean;
 
-    impure function create_burst(axid : std_logic_vector;
-                                 axaddr : std_logic_vector;
-                                 axlen : std_logic_vector;
-                                 axsize : std_logic_vector;
-                                 axburst : axi_burst_type_t) return axi_burst_t;
+    impure function create_burst(
+      axid : std_logic_vector;
+      axaddr : std_logic_vector;
+      axlen : std_logic_vector;
+      axsize : std_logic_vector;
+      axburst : axi_burst_type_t
+    ) return axi_burst_t;
 
     procedure push_burst(burst : axi_burst_t);
     impure function pop_burst return axi_burst_t;
@@ -99,8 +102,7 @@ package axi_slave_private_pkg is
     procedure clear_statistics;
   end protected;
 
-  procedure main_loop(variable self : inout axi_slave_private_t;
-                      signal net : inout network_t);
+  procedure main_loop(variable self : inout axi_slave_private_t; signal net : inout network_t);
 
   procedure check_axi_resp(bus_handle : bus_master_t; got, expected : axi_resp_t; msg : string);
 end package;
@@ -139,10 +141,12 @@ package body axi_slave_private_pkg is
     variable p_check_well_behaved : boolean;
     variable p_statistics : axi_statistics_t;
 
-    procedure init(axi_slave : axi_slave_t;
-                   axi_slave_type : axi_slave_type_t;
-                   max_id : natural;
-                   data : std_logic_vector) is
+    procedure init(
+      axi_slave : axi_slave_t;
+      axi_slave_type : axi_slave_type_t;
+      max_id : natural;
+      data : std_logic_vector
+    ) is
     begin
       p_axi_slave := axi_slave;
       p_axi_slave_type := axi_slave_type;
@@ -252,11 +256,13 @@ package body axi_slave_private_pkg is
       return should_stall(p_wresp_stall_prob);
     end;
 
-    impure function create_burst(axid : std_logic_vector;
-                                 axaddr : std_logic_vector;
-                                 axlen : std_logic_vector;
-                                 axsize : std_logic_vector;
-                                 axburst : axi_burst_type_t) return axi_burst_t is
+    impure function create_burst(
+      axid : std_logic_vector;
+      axaddr : std_logic_vector;
+      axlen : std_logic_vector;
+      axsize : std_logic_vector;
+      axburst : axi_burst_type_t
+    ) return axi_burst_t is
 
       -- Return the correct prefix ar/aw depending on slave type
       impure function ax return string is
@@ -497,8 +503,10 @@ package body axi_slave_private_pkg is
     return burst;
   end;
 
-  procedure main_loop(variable self : inout axi_slave_private_t;
-                      signal net : inout network_t) is
+  procedure main_loop(
+    variable self : inout axi_slave_private_t;
+    signal net : inout network_t
+  ) is
     variable reply_msg, request_msg : msg_t;
     variable msg_type : msg_type_t;
 

--- a/vunit/vhdl/verification_components/src/axi_statistics_pkg.vhd
+++ b/vunit/vhdl/verification_components/src/axi_statistics_pkg.vhd
@@ -15,15 +15,14 @@ package axi_statistics_pkg is
   end record;
   constant null_axi_statistics : axi_statistics_t := (p_count_by_burst_length => null_ptr);
 
-  -- Get the maximum burst length that occured
+  -- Get the maximum burst length that occurred
   impure function max_burst_length(stat : axi_statistics_t) return natural;
 
-  -- Get the minimum burst length that occured
+  -- Get the minimum burst length that occurred
   impure function min_burst_length(stat : axi_statistics_t) return natural;
 
-  -- Get the number of bursts that occured with specific length
-  impure function get_num_burst_with_length(stat : axi_statistics_t;
-                                            burst_length : natural) return natural;
+  -- Get the number of bursts that occurred with specific length
+  impure function get_num_burst_with_length(stat : axi_statistics_t; burst_length : natural) return natural;
 
   -- Get the number of bursts
   impure function num_bursts(stat : axi_statistics_t) return natural;
@@ -33,8 +32,7 @@ package axi_statistics_pkg is
 
   -- Private
   impure function new_axi_statistics return axi_statistics_t;
-  procedure add_burst_length(stat : axi_statistics_t;
-                             burst_length : natural);
+  procedure add_burst_length(stat : axi_statistics_t; burst_length : natural);
   impure function copy(stat : axi_statistics_t) return axi_statistics_t;
   procedure clear(stat : axi_statistics_t);
 end package;
@@ -60,8 +58,7 @@ package body axi_statistics_pkg is
     end loop;
   end;
 
-  procedure add_burst_length(stat : axi_statistics_t;
-                             burst_length : natural) is
+  procedure add_burst_length(stat : axi_statistics_t; burst_length : natural) is
 
   begin
     set(stat.p_count_by_burst_length, burst_length,
@@ -90,8 +87,7 @@ package body axi_statistics_pkg is
     return 0;
   end;
 
-  impure function get_num_burst_with_length(stat : axi_statistics_t;
-                                            burst_length : natural) return natural is
+  impure function get_num_burst_with_length(stat : axi_statistics_t; burst_length : natural) return natural is
   begin
     if burst_length >= length(stat.p_count_by_burst_length) then
       return 0;

--- a/vunit/vhdl/verification_components/src/axi_stream_master.vhd
+++ b/vunit/vhdl/verification_components/src/axi_stream_master.vhd
@@ -53,7 +53,10 @@ architecture a of axi_stream_master is
   constant notify_request_msg      : msg_type_t := new_msg_type("notify request");
   constant message_queue           : queue_t    := new_queue;
   constant bus_process_done_base_id : id_t       := get_id("vunit_lib:axi_stream_master:bus_process_done");
-  constant bus_process_done_id      : id_t       := get_id(to_string(num_children(bus_process_done_base_id)), parent => bus_process_done_base_id);
+  constant bus_process_done_id      : id_t       := get_id(
+      to_string(num_children(bus_process_done_base_id)),
+      parent => bus_process_done_base_id
+    );
   signal bus_process_done           : event_t    := new_event(bus_process_done_id);
 begin
 
@@ -111,24 +114,30 @@ begin
 
       procedure drive_policy(signal s : out std_logic_vector; policy : inactive_bus_policy_t) is
       begin
-        if policy = 'X' then
-          s <= (s'range => 'X');
-        elsif policy = '0' then
-          s <= (s'range => '0');
-        elsif policy = '1' then
-          s <= (s'range => '1');
-        end if;
+        case policy is
+          when 'X' =>
+            s <= (s'range => 'X');
+          when '0' =>
+            s <= (s'range => '0');
+          when '1' =>
+            s <= (s'range => '1');
+          when hold =>
+            null;
+        end case;
       end;
 
       procedure drive_policy(signal s : out std_logic; policy : inactive_bus_policy_t) is
       begin
-        if policy = 'X' then
-          s <= 'X';
-        elsif policy = '0' then
-          s <= '0';
-        elsif policy = '1' then
-          s <= '1';
-        end if;
+        case policy is
+          when 'X' =>
+            s <= 'X';
+          when '0' =>
+            s <= '0';
+          when '1' =>
+            s <= '1';
+          when hold =>
+            null;
+        end case;
       end;
 
     begin
@@ -162,10 +171,10 @@ begin
             handle_sync_message(net, msg_type, msg);
             -- Re-align with the clock when a wait for time message was handled, because this breaks edge alignment.
             wait until rising_edge(aclk);
-          
+
           elsif msg_type = notify_request_msg then
             -- Ignore this message, but expect it
-          
+
           elsif msg_type = stream_push_msg or msg_type = push_axi_stream_msg then
             -- stall according to probability configuration
             probability_stall_axi_stream(aclk, master, rnd);
@@ -194,17 +203,17 @@ begin
             wait until ((tvalid and tready) = '1' or areset_n = '0') and rising_edge(aclk);
             tvalid <= '0';
             drive_inactive(tdata, tlast, tkeep, tstrb, tid, tdest, tuser);
-          
+
           elsif msg_type = set_inactive_axi_stream_policy_msg then
             inactive_bus_policy := inactive_bus_policy_t'val(pop_integer(msg));
             axi_stream_signal := axi_stream_signal_t'val(pop_integer(msg));
             set_inactive_axi_stream_policy(master, inactive_bus_policy, axi_stream_signal);
             inactive_axi_stream_policy := get_inactive_axi_stream_policy(master);
-          
+
           elsif msg_type = set_stall_config_msg then
             deallocate(to_integer_vector_ptr(get(master.p_config, p_stall_config_idx)));
             set(master.p_config, p_stall_config_idx, to_integer(pop_integer_vector_ptr_ref(msg)));
-          
+
           else
             unexpected_msg_type(msg_type);
           end if;
@@ -258,8 +267,8 @@ begin
   deprecation_message : process is
   begin
     warning_if(
-      master.p_logger, 
-      drive_invalid, 
+      master.p_logger,
+      drive_invalid,
       "The drive_invalid generics have been deprecated. Bus inactivity is now controlled " &
       "by the inactive_bus_policy parameter to the new_axi_stream_master function."
     );

--- a/vunit/vhdl/verification_components/src/axi_stream_master.vhd
+++ b/vunit/vhdl/verification_components/src/axi_stream_master.vhd
@@ -14,6 +14,7 @@ use work.axi_stream_pkg.all;
 use work.axi_stream_private_pkg.all;
 use work.com_pkg.net;
 use work.com_pkg.receive;
+use work.com_pkg.reply;
 use work.com_types_pkg.all;
 use work.id_pkg.all;
 use work.integer_vector_ptr_pkg.all;
@@ -72,7 +73,9 @@ begin
       msg_type = push_axi_stream_msg or
       msg_type = wait_for_time_msg or
       msg_type = set_inactive_axi_stream_policy_msg or
-      msg_type = set_stall_config_msg then
+      msg_type = get_inactive_axi_stream_policy_msg or
+      msg_type = set_stall_config_msg or
+      msg_type = get_stall_config_msg then
 
       push(message_queue, request_msg);
 
@@ -88,11 +91,13 @@ begin
 
   bus_process : process
     variable msg : msg_t;
+    variable reply_msg : msg_t;
     variable msg_type : msg_type_t;
     variable rnd : RandomPType;
     variable inactive_axi_stream_policy : inactive_axi_stream_policy_t := get_inactive_axi_stream_policy(master);
     variable inactive_bus_policy : inactive_bus_policy_t;
     variable axi_stream_signal : axi_stream_signal_t;
+    variable stall_config : integer_vector_ptr_t;
 
     procedure probability_stall_axi_stream(
       signal aclk : in std_logic;
@@ -210,9 +215,22 @@ begin
             set_inactive_axi_stream_policy(master, inactive_bus_policy, axi_stream_signal);
             inactive_axi_stream_policy := get_inactive_axi_stream_policy(master);
 
+          elsif msg_type = get_inactive_axi_stream_policy_msg then
+            reply_msg := new_msg(get_inactive_axi_stream_policy_reply_msg);
+            axi_stream_signal := axi_stream_signal_t'val(pop_integer(msg));
+            inactive_bus_policy := inactive_axi_stream_policy(axi_stream_signal);
+            push(reply_msg, inactive_bus_policy_t'pos(inactive_bus_policy));
+            reply(net, msg, reply_msg);
+
           elsif msg_type = set_stall_config_msg then
             deallocate(to_integer_vector_ptr(get(master.p_config, p_stall_config_idx)));
             set(master.p_config, p_stall_config_idx, to_integer(pop_integer_vector_ptr_ref(msg)));
+
+          elsif msg_type = get_stall_config_msg then
+            reply_msg := new_msg(get_stall_config_reply_msg);
+            stall_config := to_integer_vector_ptr(get(master.p_config, p_stall_config_idx));
+            push(reply_msg, stall_config);
+            reply(net, msg, reply_msg);
 
           else
             unexpected_msg_type(msg_type);

--- a/vunit/vhdl/verification_components/src/axi_stream_master.vhd
+++ b/vunit/vhdl/verification_components/src/axi_stream_master.vhd
@@ -11,17 +11,20 @@ library osvvm;
 use osvvm.RandomPkg.RandomPType;
 
 use work.axi_stream_pkg.all;
-use work.axi_stream_private_pkg.probability_stall_axi_stream;
+use work.axi_stream_private_pkg.all;
 use work.com_pkg.net;
 use work.com_pkg.receive;
 use work.com_types_pkg.all;
 use work.id_pkg.all;
+use work.integer_vector_ptr_pkg.all;
 use work.queue_pkg.all;
 use work.stream_master_pkg.stream_push_msg;
 use work.sync_pkg.all;
 use work.event_common_pkg.is_active;
 use work.event_common_pkg.notify;
 use work.event_pkg.all;
+use work.logger_pkg.all;
+use work.axi_pkg.all;
 
 entity axi_stream_master is
   generic (
@@ -52,24 +55,6 @@ architecture a of axi_stream_master is
   constant bus_process_done_base_id : id_t       := get_id("vunit_lib:axi_stream_master:bus_process_done");
   constant bus_process_done_id      : id_t       := get_id(to_string(num_children(bus_process_done_base_id)), parent => bus_process_done_base_id);
   signal bus_process_done           : event_t    := new_event(bus_process_done_id);
-
-
-  procedure drive_invalid_output(signal l_tdata : out std_logic_vector(data_length(master)-1 downto 0);
-                                 signal l_tkeep : out std_logic_vector(data_length(master)/8-1 downto 0);
-                                 signal l_tstrb : out std_logic_vector(data_length(master)/8-1 downto 0);
-                                 signal l_tid   : out std_logic_vector(id_length(master)-1 downto 0);
-                                 signal l_tdest : out std_logic_vector(dest_length(master)-1 downto 0);
-                                 signal l_tuser : out std_logic_vector(user_length(master)-1 downto 0))
-  is
-  begin
-    l_tdata <= (others => drive_invalid_val);
-    l_tkeep <= (others => drive_invalid_val);
-    l_tstrb <= (others => drive_invalid_val);
-    l_tid   <= (others => drive_invalid_val);
-    l_tdest <= (others => drive_invalid_val);
-    l_tuser <= (others => drive_invalid_val_user);
-  end procedure;
-
 begin
 
   main : process
@@ -80,10 +65,14 @@ begin
     receive(net, master.p_actor, request_msg);
     msg_type := message_type(request_msg);
 
-    if msg_type = stream_push_msg or msg_type = push_axi_stream_msg then
+    if msg_type = stream_push_msg or
+      msg_type = push_axi_stream_msg or
+      msg_type = wait_for_time_msg or
+      msg_type = set_inactive_axi_stream_policy_msg or
+      msg_type = set_stall_config_msg then
+
       push(message_queue, request_msg);
-    elsif msg_type = wait_for_time_msg then
-      push(message_queue, request_msg);
+
     elsif msg_type = wait_until_idle_msg then
       notify_msg := new_msg(notify_request_msg);
       push(message_queue, notify_msg);
@@ -98,13 +87,64 @@ begin
     variable msg : msg_t;
     variable msg_type : msg_type_t;
     variable rnd : RandomPType;
+    variable inactive_axi_stream_policy : inactive_axi_stream_policy_t := get_inactive_axi_stream_policy(master);
+    variable inactive_bus_policy : inactive_bus_policy_t;
+    variable axi_stream_signal : axi_stream_signal_t;
+
+    procedure probability_stall_axi_stream(
+      signal aclk : in std_logic;
+      axi_stream  : in axi_stream_master_t;
+      rnd         : inout RandomPType) is
+    begin
+      probability_stall_axi_stream(aclk, get_stall_config(axi_stream), rnd);
+    end procedure;
+
+    procedure drive_inactive(
+      signal l_tdata : out std_logic_vector(data_length(master)-1 downto 0);
+      signal l_tlast : out std_logic;
+      signal l_tkeep : out std_logic_vector(data_length(master)/8-1 downto 0);
+      signal l_tstrb : out std_logic_vector(data_length(master)/8-1 downto 0);
+      signal l_tid   : out std_logic_vector(id_length(master)-1 downto 0);
+      signal l_tdest : out std_logic_vector(dest_length(master)-1 downto 0);
+      signal l_tuser : out std_logic_vector(user_length(master)-1 downto 0)
+    ) is
+
+      procedure drive_policy(signal s : out std_logic_vector; policy : inactive_bus_policy_t) is
+      begin
+        if policy = 'X' then
+          s <= (s'range => 'X');
+        elsif policy = '0' then
+          s <= (s'range => '0');
+        elsif policy = '1' then
+          s <= (s'range => '1');
+        end if;
+      end;
+
+      procedure drive_policy(signal s : out std_logic; policy : inactive_bus_policy_t) is
+      begin
+        if policy = 'X' then
+          s <= 'X';
+        elsif policy = '0' then
+          s <= '0';
+        elsif policy = '1' then
+          s <= '1';
+        end if;
+      end;
+
+    begin
+      drive_policy(l_tdata, inactive_axi_stream_policy(work.axi_stream_pkg.tdata));
+      drive_policy(l_tlast, inactive_axi_stream_policy(work.axi_stream_pkg.tlast));
+      drive_policy(l_tkeep, inactive_axi_stream_policy(work.axi_stream_pkg.tkeep));
+      drive_policy(l_tstrb, inactive_axi_stream_policy(work.axi_stream_pkg.tstrb));
+      drive_policy(l_tid, inactive_axi_stream_policy(work.axi_stream_pkg.tid));
+      drive_policy(l_tdest, inactive_axi_stream_policy(work.axi_stream_pkg.tdest));
+      drive_policy(l_tuser, inactive_axi_stream_policy(work.axi_stream_pkg.tuser));
+    end procedure;
+
   begin
     rnd.InitSeed(rnd'instance_name);
     loop
-      if drive_invalid then
-        drive_invalid_output(tdata, tkeep, tstrb, tid, tdest, tuser);
-      end if;
-
+      drive_inactive(tdata, tlast, tkeep, tstrb, tid, tdest, tuser);
       if (areset_n = '0') then
         tvalid <= '0';
         wait until areset_n = '1' and rising_edge(aclk);
@@ -122,10 +162,11 @@ begin
             handle_sync_message(net, msg_type, msg);
             -- Re-align with the clock when a wait for time message was handled, because this breaks edge alignment.
             wait until rising_edge(aclk);
+          
           elsif msg_type = notify_request_msg then
             -- Ignore this message, but expect it
+          
           elsif msg_type = stream_push_msg or msg_type = push_axi_stream_msg then
-            drive_invalid_output(tdata, tkeep, tstrb, tid, tdest, tuser);
             -- stall according to probability configuration
             probability_stall_axi_stream(aclk, master, rnd);
 
@@ -152,7 +193,18 @@ begin
             end if;
             wait until ((tvalid and tready) = '1' or areset_n = '0') and rising_edge(aclk);
             tvalid <= '0';
-            tlast <= '0';
+            drive_inactive(tdata, tlast, tkeep, tstrb, tid, tdest, tuser);
+          
+          elsif msg_type = set_inactive_axi_stream_policy_msg then
+            inactive_bus_policy := inactive_bus_policy_t'val(pop_integer(msg));
+            axi_stream_signal := axi_stream_signal_t'val(pop_integer(msg));
+            set_inactive_axi_stream_policy(master, inactive_bus_policy, axi_stream_signal);
+            inactive_axi_stream_policy := get_inactive_axi_stream_policy(master);
+          
+          elsif msg_type = set_stall_config_msg then
+            deallocate(to_integer_vector_ptr(get(master.p_config, p_stall_config_idx)));
+            set(master.p_config, p_stall_config_idx, to_integer(pop_integer_vector_ptr_ref(msg)));
+          
           else
             unexpected_msg_type(msg_type);
           end if;
@@ -202,5 +254,17 @@ begin
         tuser    => tuser
       );
   end generate axi_stream_protocol_checker_generate;
+
+  deprecation_message : process is
+  begin
+    warning_if(
+      master.p_logger, 
+      drive_invalid, 
+      "The drive_invalid generics have been deprecated. Bus inactivity is now controlled " &
+      "by the inactive_bus_policy parameter to the new_axi_stream_master function."
+    );
+
+    wait;
+  end process;
 
 end architecture;

--- a/vunit/vhdl/verification_components/src/axi_stream_master.vhd
+++ b/vunit/vhdl/verification_components/src/axi_stream_master.vhd
@@ -324,8 +324,8 @@ begin
       master.p_logger,
       not default_generics,
       "The drive_invalid generics have been deprecated. Bus inactivity is now controlled " & LF &
-      "by the inactive_bus_policy parameter to the new_axi_stream_master function. Remove generics " & LF &
-      "assignments and use the inactive_bus_policy parameter to avoid this error."
+      "by the inactive_policy parameter to the new_axi_stream_master function. Remove generics " & LF &
+      "assignments and use the inactive_policy parameter to avoid this error."
     );
 
     wait;

--- a/vunit/vhdl/verification_components/src/axi_stream_master.vhd
+++ b/vunit/vhdl/verification_components/src/axi_stream_master.vhd
@@ -161,6 +161,8 @@ begin
             s <= (s'range => '1');
           when hold =>
             null;
+          when rand01 =>
+            s <= rnd.RandSlv(s'length);
         end case;
       end;
 
@@ -175,6 +177,8 @@ begin
             s <= '1';
           when hold =>
             null;
+          when rand01 =>
+            s <= to_stdulogic(rnd.RandBit);
         end case;
       end;
 

--- a/vunit/vhdl/verification_components/src/axi_stream_master.vhd
+++ b/vunit/vhdl/verification_components/src/axi_stream_master.vhd
@@ -94,18 +94,51 @@ begin
     variable reply_msg : msg_t;
     variable msg_type : msg_type_t;
     variable rnd : RandomPType;
-    variable inactive_axi_stream_policy : inactive_axi_stream_policy_t := get_inactive_axi_stream_policy(master);
     variable inactive_bus_policy : inactive_bus_policy_t;
     variable axi_stream_signal : axi_stream_signal_t;
     variable stall_config : integer_vector_ptr_t;
 
-    procedure probability_stall_axi_stream(
-      signal aclk : in std_logic;
-      axi_stream  : in axi_stream_master_t;
-      rnd         : inout RandomPType) is
+    impure function get_inactive_axi_stream_policy(master : axi_stream_master_t) return inactive_axi_stream_policy_t is
+      impure function to_inactive_axi_stream_policy(vec : integer_vector_ptr_t) return inactive_axi_stream_policy_t is
+        variable inactive_policy : inactive_axi_stream_policy_t;
+      begin
+        for sig in inactive_policy'range loop
+          inactive_policy(sig) := inactive_bus_policy_t'val(get(vec, axi_stream_signal_t'pos(sig)));
+        end loop;
+
+        return inactive_policy;
+      end;
     begin
-      probability_stall_axi_stream(aclk, get_stall_config(axi_stream), rnd);
-    end procedure;
+      return to_inactive_axi_stream_policy(to_integer_vector_ptr(get(master.p_config, p_inactive_policy_idx)));
+    end;
+
+    variable inactive_axi_stream_policy : inactive_axi_stream_policy_t := get_inactive_axi_stream_policy(master);
+
+    procedure set_inactive_axi_stream_policy(
+      master : axi_stream_master_t;
+      inactive_policy : inactive_bus_policy_t;
+      axi_stream_signal : axi_stream_signal_t
+    ) is
+      variable start, stop : axi_stream_signal_t := axi_stream_signal;
+    begin
+      if axi_stream_signal = all_signals then
+        start := work.axi_stream_pkg.tdata;
+        stop := work.axi_stream_pkg.tuser;
+      end if;
+
+      for sig in start to stop loop
+        set(
+          to_integer_vector_ptr(get(master.p_config, p_inactive_policy_idx)),
+          axi_stream_signal_t'pos(sig),
+          inactive_bus_policy_t'pos(inactive_policy)
+        );
+      end loop;
+    end;
+
+    impure function get_stall_config(master : axi_stream_master_t) return stall_config_t is
+    begin
+      return p_to_stall_config(to_integer_vector_ptr(get(master.p_config, p_stall_config_idx)));
+    end;
 
     procedure drive_inactive(
       signal l_tdata : out std_logic_vector(data_length(master)-1 downto 0);
@@ -159,7 +192,7 @@ begin
     rnd.InitSeed(rnd'instance_name);
     loop
       drive_inactive(tdata, tlast, tkeep, tstrb, tid, tdest, tuser);
-      if (areset_n = '0') then
+      if areset_n = '0' then
         tvalid <= '0';
         wait until areset_n = '1' and rising_edge(aclk);
       else
@@ -182,7 +215,7 @@ begin
 
           elsif msg_type = stream_push_msg or msg_type = push_axi_stream_msg then
             -- stall according to probability configuration
-            probability_stall_axi_stream(aclk, master, rnd);
+            probability_stall_axi_stream(aclk, get_stall_config(master), rnd);
 
             tvalid <= '1';
             tdata <= pop_std_ulogic_vector(msg);
@@ -194,11 +227,7 @@ begin
               tdest <= pop_std_ulogic_vector(msg);
               tuser <= pop_std_ulogic_vector(msg);
             else
-              if pop_boolean(msg) then
-                tlast <= '1';
-              else
-                tlast <= '0';
-              end if;
+              tlast <= '1' when pop_boolean(msg) else '0';
               tkeep <= (others => '1');
               tstrb <= (others => '1');
               tid   <= (others => '0');
@@ -207,7 +236,6 @@ begin
             end if;
             wait until ((tvalid and tready) = '1' or areset_n = '0') and rising_edge(aclk);
             tvalid <= '0';
-            drive_inactive(tdata, tlast, tkeep, tstrb, tid, tdest, tuser);
 
           elsif msg_type = set_inactive_axi_stream_policy_msg then
             inactive_bus_policy := inactive_bus_policy_t'val(pop_integer(msg));
@@ -283,12 +311,17 @@ begin
   end generate axi_stream_protocol_checker_generate;
 
   deprecation_message : process is
+    impure function default_generics return boolean is
+    begin
+      return drive_invalid and (drive_invalid_val = 'X') and (drive_invalid_val_user = '0');
+    end;
   begin
-    warning_if(
+    error_if(
       master.p_logger,
-      drive_invalid,
-      "The drive_invalid generics have been deprecated. Bus inactivity is now controlled " &
-      "by the inactive_bus_policy parameter to the new_axi_stream_master function."
+      not default_generics,
+      "The drive_invalid generics have been deprecated. Bus inactivity is now controlled " & LF &
+      "by the inactive_bus_policy parameter to the new_axi_stream_master function. Remove generics " & LF &
+      "assignments and use the inactive_bus_policy parameter to avoid this error."
     );
 
     wait;

--- a/vunit/vhdl/verification_components/src/axi_stream_monitor.vhd
+++ b/vunit/vhdl/verification_components/src/axi_stream_monitor.vhd
@@ -8,6 +8,7 @@ library ieee;
 use ieee.std_logic_1164.all;
 
 use work.axi_stream_pkg.all;
+use work.axi_stream_private_pkg.all;
 use work.com_pkg.net;
 use work.com_pkg.publish;
 use work.com_types_pkg.msg_t;
@@ -55,7 +56,7 @@ begin
       );
     end if;
 
-    tstrb_resolved := tkeep when is_u(tstrb) else tstrb;
+    tstrb_resolved := resolve_tstrb(tkeep, tstrb);
     axi_stream_transaction := (
       tdata => tdata,
       tlast => tlast = '1',

--- a/vunit/vhdl/verification_components/src/axi_stream_monitor.vhd
+++ b/vunit/vhdl/verification_components/src/axi_stream_monitor.vhd
@@ -49,7 +49,10 @@ begin
     wait until (tvalid and tready) = '1' and rising_edge(aclk);
 
     if is_visible(monitor.p_logger, debug) then
-      debug(monitor.p_logger, "tdata: " & to_nibble_string(tdata) & " (" & to_integer_string(tdata) & ")" & ", tlast: " & to_string(tlast));
+      debug(
+        monitor.p_logger,
+        "tdata: " & to_nibble_string(tdata) & " (" & to_integer_string(tdata) & ")" & ", tlast: " & to_string(tlast)
+      );
     end if;
 
     tstrb_resolved := tkeep when is_u(tstrb) else tstrb;

--- a/vunit/vhdl/verification_components/src/axi_stream_pkg.vhd
+++ b/vunit/vhdl/verification_components/src/axi_stream_pkg.vhd
@@ -12,9 +12,11 @@ use work.checker_pkg.all;
 use work.check_pkg.all;
 use work.stream_master_pkg.stream_master_t;
 use work.stream_slave_pkg.stream_slave_t;
+use work.integer_vector_ptr_pkg.all;
 use work.sync_pkg.all;
 use work.com_pkg.all;
 use work.com_types_pkg.all;
+use work.axi_pkg.all;
 
 package axi_stream_pkg is
 
@@ -30,7 +32,17 @@ package axi_stream_pkg is
     max_stall_cycles  => 0
     );
 
+  -- Only signals relevant to inactivity policy are present.
+  type axi_stream_signal_t is (tdata, tlast, tkeep, tstrb, tid, tdest, tuser, all_signals);
+  type inactive_axi_stream_policy_t is array (tdata to tuser) of inactive_bus_policy_t;
+
+  constant default_axi_stream_policy : inactive_axi_stream_policy_t := (tuser => '0', others => 'X');
+  constant all_0_policy : inactive_axi_stream_policy_t := (others => '0');
+  constant all_1_policy : inactive_axi_stream_policy_t := (others => '1');
+  constant all_hold_policy : inactive_axi_stream_policy_t := (others => hold);
+  
   type axi_stream_component_type_t is (null_component, default_component, custom_component);
+  
 
   type axi_stream_protocol_checker_t is record
     p_type                      : axi_stream_component_type_t;
@@ -113,10 +125,10 @@ package axi_stream_pkg is
     p_id_length        : natural;
     p_dest_length      : natural;
     p_user_length      : natural;
-    p_stall_config     : stall_config_t;
     p_logger           : logger_t;
     p_monitor          : axi_stream_monitor_t;
     p_protocol_checker : axi_stream_protocol_checker_t;
+    p_config : integer_vector_ptr_t;
   end record;
 
   constant null_axi_stream_master : axi_stream_master_t := (
@@ -125,10 +137,10 @@ package axi_stream_pkg is
     p_id_length        => 0,
     p_dest_length      => 0,
     p_user_length      => 0,
-    p_stall_config     => null_stall_config,
     p_logger           => null_logger,
     p_monitor          => null_axi_stream_monitor,
-    p_protocol_checker => null_axi_stream_protocol_checker
+    p_protocol_checker => null_axi_stream_protocol_checker,
+    p_config           => null_integer_vector_ptr
     );
 
   type axi_stream_slave_t is record
@@ -137,10 +149,10 @@ package axi_stream_pkg is
     p_id_length        : natural;
     p_dest_length      : natural;
     p_user_length      : natural;
-    p_stall_config     : stall_config_t;
     p_logger           : logger_t;
     p_monitor          : axi_stream_monitor_t;
     p_protocol_checker : axi_stream_protocol_checker_t;
+    p_config : integer_vector_ptr_t;
   end record;
 
   constant null_axi_stream_slave : axi_stream_slave_t := (
@@ -149,10 +161,10 @@ package axi_stream_pkg is
     p_id_length        => 0,
     p_dest_length      => 0,
     p_user_length      => 0,
-    p_stall_config     => null_stall_config,
     p_logger           => null_logger,
     p_monitor          => null_axi_stream_monitor,
-    p_protocol_checker => null_axi_stream_protocol_checker
+    p_protocol_checker => null_axi_stream_protocol_checker,
+    p_config           => null_integer_vector_ptr
     );
 
   constant axi_stream_logger  : logger_t  := get_logger("vunit_lib:axi_stream_pkg");
@@ -167,7 +179,8 @@ package axi_stream_pkg is
     logger           : logger_t                      := axi_stream_logger;
     actor            : actor_t                       := null_actor;
     monitor          : axi_stream_monitor_t          := null_axi_stream_monitor;
-    protocol_checker : axi_stream_protocol_checker_t := null_axi_stream_protocol_checker
+    protocol_checker : axi_stream_protocol_checker_t := null_axi_stream_protocol_checker;
+    inactive_policy : inactive_axi_stream_policy_t  := default_axi_stream_policy
   ) return axi_stream_master_t;
 
   impure function new_axi_stream_slave(
@@ -224,10 +237,30 @@ package axi_stream_pkg is
   impure function as_sync(master : axi_stream_master_t) return sync_handle_t;
   impure function as_sync(slave : axi_stream_slave_t) return sync_handle_t;
 
+  procedure set_stall_config(
+    signal net : inout network_t;
+    master : axi_stream_master_t;
+    stall_config : stall_config_t
+  );
+  procedure set_stall_config(
+    signal net : inout network_t;
+    slave : axi_stream_slave_t;
+    stall_config : stall_config_t
+  );
+
+  procedure set_inactive_axi_stream_policy(
+    signal net : inout network_t;
+    master : axi_stream_master_t;
+    inactive_policy : inactive_bus_policy_t;
+    axi_stream_signal : axi_stream_signal_t := all_signals
+  );
+  
   constant push_axi_stream_msg : msg_type_t := new_msg_type("push axi stream");
   constant pop_axi_stream_msg : msg_type_t := new_msg_type("pop axi stream");
   constant check_axi_stream_msg : msg_type_t := new_msg_type("check axi stream");
   constant axi_stream_transaction_msg : msg_type_t := new_msg_type("axi stream transaction");
+  constant set_inactive_axi_stream_policy_msg : msg_type_t := new_msg_type("set inactive axi stream policy");
+  constant set_stall_config_msg : msg_type_t := new_msg_type("set stall config");
 
   alias axi_stream_reference_t is msg_t;
 
@@ -336,10 +369,13 @@ package axi_stream_pkg is
 
   function is_u(value : std_ulogic_vector) return boolean;
 
+  -- Private
+  constant p_stall_config_idx : natural := 0;
+  constant p_interactive_policy_idx : natural := 1;
+
 end package;
 
 package body axi_stream_pkg is
-
   impure function get_valid_monitor(
       data_length      : natural;
       id_length        : natural  := 0;
@@ -389,6 +425,36 @@ package body axi_stream_pkg is
     end if;
   end;
 
+  impure function to_integer_vector_ptr(stall_config : stall_config_t) return integer_vector_ptr_t is
+    variable result : integer_vector_ptr_t := new_integer_vector_ptr(3);
+  begin
+    set(result, 0, integer(stall_config.stall_probability * (2.0 ** 23)));
+    set(result, 1, stall_config.min_stall_cycles);
+    set(result, 2, stall_config.max_stall_cycles);
+
+    return result;
+  end;
+
+  procedure set_stall_config(master : axi_stream_master_t; stall_config : stall_config_t) is
+  begin
+    set(master.p_config, p_stall_config_idx, to_integer(to_integer_vector_ptr(stall_config)));
+  end;
+
+  impure function to_integer_vector_ptr(inactive_policy : inactive_axi_stream_policy_t) return integer_vector_ptr_t is
+    variable result : integer_vector_ptr_t := new_integer_vector_ptr(inactive_policy'length);
+  begin
+    for sig in inactive_policy'range loop
+      set(result, axi_stream_signal_t'pos(sig), inactive_bus_policy_t'pos(inactive_policy(sig)));
+    end loop;
+
+    return result;
+  end;
+
+  procedure set_inactive_axi_stream_policy(master : axi_stream_master_t; inactive_policy : inactive_axi_stream_policy_t) is
+  begin
+    set(master.p_config, p_interactive_policy_idx, to_integer(to_integer_vector_ptr(inactive_policy)));
+  end;
+
   impure function new_axi_stream_master(
     data_length      : natural;
     id_length        : natural                       := 0;
@@ -398,25 +464,38 @@ package body axi_stream_pkg is
     logger           : logger_t                      := axi_stream_logger;
     actor            : actor_t                       := null_actor;
     monitor          : axi_stream_monitor_t          := null_axi_stream_monitor;
-    protocol_checker : axi_stream_protocol_checker_t := null_axi_stream_protocol_checker
+    protocol_checker : axi_stream_protocol_checker_t := null_axi_stream_protocol_checker;
+    inactive_policy : inactive_axi_stream_policy_t  := default_axi_stream_policy
   ) return axi_stream_master_t is
     variable p_actor            : actor_t;
     variable p_monitor          : axi_stream_monitor_t;
     variable p_protocol_checker : axi_stream_protocol_checker_t;
+    variable handle : axi_stream_master_t;
   begin
     p_monitor          := get_valid_monitor(data_length, id_length, dest_length, user_length, logger, actor, monitor, "master");
     p_actor            := actor when actor /= null_actor else new_actor;
     p_protocol_checker := get_valid_protocol_checker(data_length, id_length, dest_length, user_length, logger, actor, protocol_checker, "master");
 
-    return (p_actor      => p_actor,
+    handle := (p_actor      => p_actor,
       p_data_length      => data_length,
       p_id_length        => id_length,
       p_dest_length      => dest_length,
       p_user_length      => user_length,
-      p_stall_config     => stall_config,
       p_logger           => logger,
       p_monitor          => p_monitor,
-      p_protocol_checker => p_protocol_checker);
+      p_protocol_checker => p_protocol_checker,
+      p_config           => new_integer_vector_ptr(p_interactive_policy_idx + 1)
+    );
+
+    set_stall_config(handle, stall_config);
+    set_inactive_axi_stream_policy(handle, inactive_policy);
+
+    return handle;
+  end;
+
+  procedure set_stall_config(slave : axi_stream_slave_t; stall_config : stall_config_t) is
+  begin
+    set(slave.p_config, p_stall_config_idx, to_integer(to_integer_vector_ptr(stall_config)));
   end;
 
   impure function new_axi_stream_slave(
@@ -433,20 +512,25 @@ package body axi_stream_pkg is
     variable p_actor            : actor_t;
     variable p_monitor          : axi_stream_monitor_t;
     variable p_protocol_checker : axi_stream_protocol_checker_t;
+    variable handle : axi_stream_slave_t;
   begin
     p_monitor          := get_valid_monitor(data_length, id_length, dest_length, user_length, logger, actor, monitor, "slave");
     p_actor            := actor when actor /= null_actor else new_actor;
     p_protocol_checker := get_valid_protocol_checker(data_length, id_length, dest_length, user_length, logger, actor, protocol_checker, "slave");
 
-    return (p_actor      => p_actor,
+    handle := (p_actor      => p_actor,
       p_data_length      => data_length,
       p_id_length        => id_length,
       p_dest_length      => dest_length,
       p_user_length      => user_length,
-      p_stall_config     => stall_config,
       p_logger           => logger,
       p_monitor          => p_monitor,
-      p_protocol_checker => p_protocol_checker);
+      p_protocol_checker => p_protocol_checker,
+      p_config => new_integer_vector_ptr(p_stall_config_idx + 1));
+
+    set_stall_config(handle, stall_config);
+
+    return handle;
   end;
 
   impure function new_axi_stream_monitor(
@@ -782,6 +866,52 @@ package body axi_stream_pkg is
       send(net, axi_stream.p_actor, check_msg);
     end if;
   end procedure;
+
+  procedure set_inactive_axi_stream_policy(
+      signal net : inout network_t;
+      master : axi_stream_master_t;
+      inactive_policy : inactive_bus_policy_t;
+      axi_stream_signal : axi_stream_signal_t := all_signals
+    ) is
+    variable msg : msg_t;
+    variable start, stop : axi_stream_signal_t := axi_stream_signal;
+  begin
+    if axi_stream_signal = all_signals then
+      start := tdata;
+      stop := tuser;
+    end if;
+
+    for sig in start to stop loop
+      msg := new_msg(set_inactive_axi_stream_policy_msg);
+      push(msg, inactive_bus_policy_t'pos(inactive_policy));
+      push(msg, axi_stream_signal_t'pos(sig));
+      send(net, master.p_actor, msg);
+    end loop;
+  end;
+
+  procedure set_stall_config(
+    signal net : inout network_t;
+    master : axi_stream_master_t;
+    stall_config : stall_config_t
+  ) is
+    variable msg : msg_t := new_msg(set_stall_config_msg);
+    variable stall_config_vec : integer_vector_ptr_t := to_integer_vector_ptr(stall_config);
+  begin
+      push(msg, stall_config_vec);
+      send(net, master.p_actor, msg);
+  end;
+
+  procedure set_stall_config(
+    signal net : inout network_t;
+    slave : axi_stream_slave_t;
+    stall_config : stall_config_t
+  ) is
+    variable msg : msg_t := new_msg(set_stall_config_msg);
+    variable stall_config_vec : integer_vector_ptr_t := to_integer_vector_ptr(stall_config);
+  begin
+      push(msg, stall_config_vec);
+      send(net, slave.p_actor, msg);
+  end;
 
   procedure push_axi_stream_transaction(msg : msg_t; axi_stream_transaction : axi_stream_transaction_t) is
   begin

--- a/vunit/vhdl/verification_components/src/axi_stream_pkg.vhd
+++ b/vunit/vhdl/verification_components/src/axi_stream_pkg.vhd
@@ -987,7 +987,8 @@ package body axi_stream_pkg is
   impure function p_to_stall_config(vec : integer_vector_ptr_t) return stall_config_t is
     variable stall_config : stall_config_t;
   begin
-    stall_config.stall_probability := real(get(vec, stall_probability_idx)) * (2.0 ** (-single_precision_mantissa_length));
+    stall_config.stall_probability := real(get(vec, stall_probability_idx)) *
+      (2.0 ** (-single_precision_mantissa_length));
     stall_config.min_stall_cycles := get(vec, min_stall_idx);
     stall_config.max_stall_cycles := get(vec, max_stall_idx);
 
@@ -1018,7 +1019,7 @@ package body axi_stream_pkg is
     send(net, slave.p_actor, msg);
   end;
 
- procedure get_stall_config(
+  procedure get_stall_config(
     signal net : inout network_t;
     slave : axi_stream_slave_t;
     stall_config : out stall_config_t

--- a/vunit/vhdl/verification_components/src/axi_stream_pkg.vhd
+++ b/vunit/vhdl/verification_components/src/axi_stream_pkg.vhd
@@ -246,10 +246,20 @@ package axi_stream_pkg is
     master : axi_stream_master_t;
     stall_config : stall_config_t
   );
+  procedure get_stall_config(
+    signal net : inout network_t;
+    master : axi_stream_master_t;
+    stall_config : out stall_config_t
+  );
   procedure set_stall_config(
     signal net : inout network_t;
     slave : axi_stream_slave_t;
     stall_config : stall_config_t
+  );
+  procedure get_stall_config(
+    signal net : inout network_t;
+    slave : axi_stream_slave_t;
+    stall_config : out stall_config_t
   );
 
   procedure set_inactive_axi_stream_policy(
@@ -259,12 +269,26 @@ package axi_stream_pkg is
     axi_stream_signal : axi_stream_signal_t := all_signals
   );
 
+  procedure get_inactive_axi_stream_policy(
+    signal net : inout network_t;
+    master : axi_stream_master_t;
+    inactive_policy : out inactive_bus_policy_t;
+    axi_stream_signal : axi_stream_signal_t range tdata to tuser
+  );
+
+
   constant push_axi_stream_msg : msg_type_t := new_msg_type("push axi stream");
   constant pop_axi_stream_msg : msg_type_t := new_msg_type("pop axi stream");
   constant check_axi_stream_msg : msg_type_t := new_msg_type("check axi stream");
   constant axi_stream_transaction_msg : msg_type_t := new_msg_type("axi stream transaction");
   constant set_inactive_axi_stream_policy_msg : msg_type_t := new_msg_type("set inactive axi stream policy");
+  constant get_inactive_axi_stream_policy_msg : msg_type_t := new_msg_type("get inactive axi stream policy");
+  constant get_inactive_axi_stream_policy_reply_msg : msg_type_t := new_msg_type(
+    "get inactive axi stream policy reply"
+  );
   constant set_stall_config_msg : msg_type_t := new_msg_type("set stall config");
+  constant get_stall_config_msg : msg_type_t := new_msg_type("get stall config");
+  constant get_stall_config_reply_msg : msg_type_t := new_msg_type("get stall config reply");
 
   alias axi_stream_reference_t is msg_t;
 
@@ -378,6 +402,7 @@ package axi_stream_pkg is
   -- Private
   constant p_stall_config_idx : natural := 0;
   constant p_interactive_policy_idx : natural := 1;
+  impure function p_to_stall_config(vec : integer_vector_ptr_t) return stall_config_t;
 
 end package;
 
@@ -944,6 +969,20 @@ package body axi_stream_pkg is
     end loop;
   end;
 
+  procedure get_inactive_axi_stream_policy(
+    signal net : inout network_t;
+    master : axi_stream_master_t;
+    inactive_policy : out inactive_bus_policy_t;
+    axi_stream_signal : axi_stream_signal_t range tdata to tuser
+  ) is
+    variable request_msg : msg_t := new_msg(get_inactive_axi_stream_policy_msg);
+    variable reply_msg : msg_t;
+  begin
+    push(request_msg, axi_stream_signal_t'pos(axi_stream_signal));
+    request(net, master.p_actor, request_msg, reply_msg);
+    inactive_policy := inactive_bus_policy_t'val(pop_integer(reply_msg));
+  end;
+
   procedure set_stall_config(
     signal net : inout network_t;
     master : axi_stream_master_t;
@@ -956,6 +995,28 @@ package body axi_stream_pkg is
     send(net, master.p_actor, msg);
   end;
 
+  impure function p_to_stall_config(vec : integer_vector_ptr_t) return stall_config_t is
+    variable stall_config : stall_config_t;
+  begin
+    stall_config.stall_probability := real(get(vec, 0)) * (2.0 ** (-23));
+    stall_config.min_stall_cycles := get(vec, 1);
+    stall_config.max_stall_cycles := get(vec, 2);
+
+    return stall_config;
+  end;
+
+  procedure get_stall_config(
+    signal net : inout network_t;
+    master : axi_stream_master_t;
+    stall_config : out stall_config_t
+  ) is
+    variable request_msg : msg_t := new_msg(get_stall_config_msg);
+    variable reply_msg : msg_t;
+  begin
+    request(net, master.p_actor, request_msg, reply_msg);
+    stall_config := p_to_stall_config(pop_integer_vector_ptr_ref(reply_msg));
+  end;
+
   procedure set_stall_config(
     signal net : inout network_t;
     slave : axi_stream_slave_t;
@@ -966,6 +1027,18 @@ package body axi_stream_pkg is
   begin
     push(msg, stall_config_vec);
     send(net, slave.p_actor, msg);
+  end;
+
+ procedure get_stall_config(
+    signal net : inout network_t;
+    slave : axi_stream_slave_t;
+    stall_config : out stall_config_t
+  ) is
+    variable request_msg : msg_t := new_msg(get_stall_config_msg);
+    variable reply_msg : msg_t;
+  begin
+    request(net, slave.p_actor, request_msg, reply_msg);
+    stall_config := p_to_stall_config(pop_integer_vector_ptr_ref(reply_msg));
   end;
 
   procedure push_axi_stream_transaction(msg : msg_t; axi_stream_transaction : axi_stream_transaction_t) is

--- a/vunit/vhdl/verification_components/src/axi_stream_pkg.vhd
+++ b/vunit/vhdl/verification_components/src/axi_stream_pkg.vhd
@@ -397,16 +397,19 @@ package axi_stream_pkg is
     max_stall_cycles  : natural
   ) return stall_config_t;
 
-  function is_u(value : std_ulogic_vector) return boolean;
-
   -- Private
   constant p_stall_config_idx : natural := 0;
-  constant p_interactive_policy_idx : natural := 1;
+  constant p_inactive_policy_idx : natural := 1;
   impure function p_to_stall_config(vec : integer_vector_ptr_t) return stall_config_t;
 
 end package;
 
 package body axi_stream_pkg is
+  constant single_precision_mantissa_length : natural := 23;
+  constant stall_probability_idx : natural := 0;
+  constant min_stall_idx : natural := 1;
+  constant max_stall_idx : natural := 2;
+
   impure function get_valid_monitor(
     data_length      : natural;
     id_length        : natural  := 0;
@@ -472,19 +475,19 @@ package body axi_stream_pkg is
         axi_stream_checker,
         protocol_checker.p_id_length,
         id_length,
-        "ID length of monitor doesn't match that of the " & parent_component
+        "ID length of protocol checker doesn't match that of the " & parent_component
       );
       check_equal(
         axi_stream_checker,
         protocol_checker.p_dest_length,
         dest_length,
-        "Dest length of monitor doesn't match that of the " & parent_component
+        "Dest length of protocol checker doesn't match that of the " & parent_component
       );
       check_equal(
         axi_stream_checker,
         protocol_checker.p_user_length,
         user_length,
-        "User length of monitor doesn't match that of the " & parent_component
+        "User length of protocol checker doesn't match that of the " & parent_component
       );
       return protocol_checker;
     end if;
@@ -495,16 +498,15 @@ package body axi_stream_pkg is
   begin
     -- Since values are in the 0 - 1 range, we can have the full resolution of the mantissa fit within
     -- an integer if reals are implemented as single-precision floats.
-    set(result, 0, integer(stall_config.stall_probability * (2.0 ** 23)));
-    set(result, 1, stall_config.min_stall_cycles);
-    set(result, 2, stall_config.max_stall_cycles);
+    set(
+      result,
+      stall_probability_idx,
+      integer(stall_config.stall_probability * (2.0 ** single_precision_mantissa_length))
+    );
+    set(result, min_stall_idx, stall_config.min_stall_cycles);
+    set(result, max_stall_idx, stall_config.max_stall_cycles);
 
     return result;
-  end;
-
-  procedure set_stall_config(master : axi_stream_master_t; stall_config : stall_config_t) is
-  begin
-    set(master.p_config, p_stall_config_idx, to_integer(to_integer_vector_ptr(stall_config)));
   end;
 
   impure function to_integer_vector_ptr(inactive_policy : inactive_axi_stream_policy_t) return integer_vector_ptr_t is
@@ -515,14 +517,6 @@ package body axi_stream_pkg is
     end loop;
 
     return result;
-  end;
-
-  procedure set_inactive_axi_stream_policy(
-    master : axi_stream_master_t;
-    inactive_policy : inactive_axi_stream_policy_t
-  ) is
-  begin
-    set(master.p_config, p_interactive_policy_idx, to_integer(to_integer_vector_ptr(inactive_policy)));
   end;
 
   impure function new_axi_stream_master(
@@ -558,18 +552,13 @@ package body axi_stream_pkg is
       p_logger           => logger,
       p_monitor          => p_monitor,
       p_protocol_checker => p_protocol_checker,
-      p_config           => new_integer_vector_ptr(p_interactive_policy_idx + 1)
+      p_config           => new_integer_vector_ptr(p_inactive_policy_idx + 1)
     );
 
-    set_stall_config(handle, stall_config);
-    set_inactive_axi_stream_policy(handle, inactive_policy);
+    set(handle.p_config, p_stall_config_idx, to_integer(to_integer_vector_ptr(stall_config)));
+    set(handle.p_config, p_inactive_policy_idx, to_integer(to_integer_vector_ptr(inactive_policy)));
 
     return handle;
-  end;
-
-  procedure set_stall_config(slave : axi_stream_slave_t; stall_config : stall_config_t) is
-  begin
-    set(slave.p_config, p_stall_config_idx, to_integer(to_integer_vector_ptr(stall_config)));
   end;
 
   impure function new_axi_stream_slave(
@@ -606,7 +595,7 @@ package body axi_stream_pkg is
       p_protocol_checker => p_protocol_checker,
       p_config => new_integer_vector_ptr(p_stall_config_idx + 1));
 
-    set_stall_config(handle, stall_config);
+    set(handle.p_config, p_stall_config_idx, to_integer(to_integer_vector_ptr(stall_config)));
 
     return handle;
   end;
@@ -998,9 +987,9 @@ package body axi_stream_pkg is
   impure function p_to_stall_config(vec : integer_vector_ptr_t) return stall_config_t is
     variable stall_config : stall_config_t;
   begin
-    stall_config.stall_probability := real(get(vec, 0)) * (2.0 ** (-23));
-    stall_config.min_stall_cycles := get(vec, 1);
-    stall_config.max_stall_cycles := get(vec, 2);
+    stall_config.stall_probability := real(get(vec, stall_probability_idx)) * (2.0 ** (-single_precision_mantissa_length));
+    stall_config.min_stall_cycles := get(vec, min_stall_idx);
+    stall_config.max_stall_cycles := get(vec, max_stall_idx);
 
     return stall_config;
   end;
@@ -1100,17 +1089,6 @@ package body axi_stream_pkg is
       min_stall_cycles  => min_stall_cycles,
       max_stall_cycles  => max_stall_cycles);
     return stall_config;
-  end;
-
-  function is_u(value : std_ulogic_vector) return boolean is
-  begin
-    for idx in value'range loop
-      if value(idx) /= 'U' then
-        return false;
-      end if;
-    end loop;
-
-    return true;
   end;
 
 end package body;

--- a/vunit/vhdl/verification_components/src/axi_stream_pkg.vhd
+++ b/vunit/vhdl/verification_components/src/axi_stream_pkg.vhd
@@ -30,19 +30,23 @@ package axi_stream_pkg is
     stall_probability => 0.0,
     min_stall_cycles  => 0,
     max_stall_cycles  => 0
-    );
+  );
 
-  -- Only signals relevant to inactivity policy are present.
+  -- These are the subsets of signals for which we can control what values to assign
+  -- when not driving valid data. tvalid and tready must always drive valid values.
+  -- all_signals is the combination of all subsets.
   type axi_stream_signal_t is (tdata, tlast, tkeep, tstrb, tid, tdest, tuser, all_signals);
   type inactive_axi_stream_policy_t is array (tdata to tuser) of inactive_bus_policy_t;
 
+  -- The standard protocol checker requires tuser to be a known value when the reset is released
   constant default_axi_stream_policy : inactive_axi_stream_policy_t := (tuser => '0', others => 'X');
   constant all_0_policy : inactive_axi_stream_policy_t := (others => '0');
   constant all_1_policy : inactive_axi_stream_policy_t := (others => '1');
+  constant all_x_policy : inactive_axi_stream_policy_t := (others => 'X');
   constant all_hold_policy : inactive_axi_stream_policy_t := (others => hold);
-  
+
   type axi_stream_component_type_t is (null_component, default_component, custom_component);
-  
+
 
   type axi_stream_protocol_checker_t is record
     p_type                      : axi_stream_component_type_t;
@@ -141,7 +145,7 @@ package axi_stream_pkg is
     p_monitor          => null_axi_stream_monitor,
     p_protocol_checker => null_axi_stream_protocol_checker,
     p_config           => null_integer_vector_ptr
-    );
+  );
 
   type axi_stream_slave_t is record
     p_actor            : actor_t;
@@ -165,7 +169,7 @@ package axi_stream_pkg is
     p_monitor          => null_axi_stream_monitor,
     p_protocol_checker => null_axi_stream_protocol_checker,
     p_config           => null_integer_vector_ptr
-    );
+  );
 
   constant axi_stream_logger  : logger_t  := get_logger("vunit_lib:axi_stream_pkg");
   constant axi_stream_checker : checker_t := new_checker(axi_stream_logger);
@@ -254,7 +258,7 @@ package axi_stream_pkg is
     inactive_policy : inactive_bus_policy_t;
     axi_stream_signal : axi_stream_signal_t := all_signals
   );
-  
+
   constant push_axi_stream_msg : msg_type_t := new_msg_type("push axi stream");
   constant pop_axi_stream_msg : msg_type_t := new_msg_type("pop axi stream");
   constant check_axi_stream_msg : msg_type_t := new_msg_type("check axi stream");
@@ -265,76 +269,78 @@ package axi_stream_pkg is
   alias axi_stream_reference_t is msg_t;
 
   procedure push_axi_stream(
-      signal net : inout network_t;
-      axi_stream : axi_stream_master_t;
-      tdata      : std_logic_vector;
-      tlast      : std_logic        := '1';
-      tkeep      : std_logic_vector := "";
-      tstrb      : std_logic_vector := "";
-      tid        : std_logic_vector := "";
-      tdest      : std_logic_vector := "";
-      tuser      : std_logic_vector := ""
-    );
+    signal net : inout network_t;
+    axi_stream : axi_stream_master_t;
+    tdata      : std_logic_vector;
+    tlast      : std_logic        := '1';
+    tkeep      : std_logic_vector := "";
+    tstrb      : std_logic_vector := "";
+    tid        : std_logic_vector := "";
+    tdest      : std_logic_vector := "";
+    tuser      : std_logic_vector := ""
+  );
 
   -- Blocking: pop a value from the axi stream
   procedure pop_axi_stream(
-      signal net : inout network_t;
-      axi_stream : axi_stream_slave_t;
-      variable tdata : out std_logic_vector;
-      variable tlast : out std_logic;
-      variable tkeep : out std_logic_vector;
-      variable tstrb : out std_logic_vector;
-      variable tid   : out std_logic_vector;
-      variable tdest : out std_logic_vector;
-      variable tuser : out std_logic_vector
-    );
+    signal net : inout network_t;
+    axi_stream : axi_stream_slave_t;
+    variable tdata : out std_logic_vector;
+    variable tlast : out std_logic;
+    variable tkeep : out std_logic_vector;
+    variable tstrb : out std_logic_vector;
+    variable tid   : out std_logic_vector;
+    variable tdest : out std_logic_vector;
+    variable tuser : out std_logic_vector
+  );
 
   procedure pop_axi_stream(
-      signal net : inout network_t;
-      axi_stream : axi_stream_slave_t;
-      variable tdata : out std_logic_vector;
-      variable tlast : out std_logic
-    );
+    signal net : inout network_t;
+    axi_stream : axi_stream_slave_t;
+    variable tdata : out std_logic_vector;
+    variable tlast : out std_logic
+  );
 
   -- Non-blocking: pop a value from the axi stream to be read in the future
-  procedure pop_axi_stream(signal net : inout network_t;
-                           axi_stream : axi_stream_slave_t;
-                           variable reference : inout axi_stream_reference_t);
+  procedure pop_axi_stream(
+    signal net : inout network_t;
+    axi_stream : axi_stream_slave_t;
+    variable reference : inout axi_stream_reference_t
+  );
 
   -- Blocking: Wait for reply to non-blocking pop
   procedure await_pop_axi_stream_reply(
-      signal net : inout network_t;
-      variable reference : inout axi_stream_reference_t;
-      variable tdata     : out std_logic_vector;
-      variable tlast     : out std_logic;
-      variable tkeep     : out std_logic_vector;
-      variable tstrb     : out std_logic_vector;
-      variable tid       : out std_logic_vector;
-      variable tdest     : out std_logic_vector;
-      variable tuser     : out std_logic_vector
-    );
+    signal net : inout network_t;
+    variable reference : inout axi_stream_reference_t;
+    variable tdata     : out std_logic_vector;
+    variable tlast     : out std_logic;
+    variable tkeep     : out std_logic_vector;
+    variable tstrb     : out std_logic_vector;
+    variable tid       : out std_logic_vector;
+    variable tdest     : out std_logic_vector;
+    variable tuser     : out std_logic_vector
+  );
 
   procedure await_pop_axi_stream_reply(
-      signal net : inout network_t;
-      variable reference : inout axi_stream_reference_t;
-      variable tdata     : out std_logic_vector;
-      variable tlast     : out std_logic
-    );
+    signal net : inout network_t;
+    variable reference : inout axi_stream_reference_t;
+    variable tdata     : out std_logic_vector;
+    variable tlast     : out std_logic
+  );
 
   -- Blocking: read axi stream and check result against expected value
   procedure check_axi_stream(
-      signal net : inout network_t;
-      axi_stream   : axi_stream_slave_t;
-      expected : std_logic_vector;
-      tlast    : std_logic        := '1';
-      tkeep    : std_logic_vector := "";
-      tstrb    : std_logic_vector := "";
-      tid      : std_logic_vector := "";
-      tdest    : std_logic_vector := "";
-      tuser    : std_logic_vector := "";
-      msg      : string           := "";
-      blocking : boolean          := true
-    );
+    signal net : inout network_t;
+    axi_stream   : axi_stream_slave_t;
+    expected : std_logic_vector;
+    tlast    : std_logic        := '1';
+    tkeep    : std_logic_vector := "";
+    tstrb    : std_logic_vector := "";
+    tid      : std_logic_vector := "";
+    tdest    : std_logic_vector := "";
+    tuser    : std_logic_vector := "";
+    msg      : string           := "";
+    blocking : boolean          := true
+  );
 
   type axi_stream_transaction_t is record
     tdata : std_logic_vector;
@@ -377,15 +383,15 @@ end package;
 
 package body axi_stream_pkg is
   impure function get_valid_monitor(
-      data_length      : natural;
-      id_length        : natural  := 0;
-      dest_length      : natural  := 0;
-      user_length      : natural  := 0;
-      logger           : logger_t := axi_stream_logger;
-      actor            : actor_t;
-      monitor          : axi_stream_monitor_t;
-      parent_component : string
-    ) return axi_stream_monitor_t is
+    data_length      : natural;
+    id_length        : natural  := 0;
+    dest_length      : natural  := 0;
+    user_length      : natural  := 0;
+    logger           : logger_t := axi_stream_logger;
+    actor            : actor_t;
+    monitor          : axi_stream_monitor_t;
+    parent_component : string
+  ) return axi_stream_monitor_t is
   begin
     if monitor = null_axi_stream_monitor then
       return monitor;
@@ -393,10 +399,24 @@ package body axi_stream_pkg is
       check(actor /= null_actor, "A valid actor is needed to create a default monitor");
       return new_axi_stream_monitor(data_length, id_length, dest_length, user_length, logger, actor);
     else
-      check_equal(axi_stream_checker, monitor.p_data_length, data_length, "Data length of monitor doesn't match that of the " & parent_component);
-      check_equal(axi_stream_checker, monitor.p_id_length, id_length, "ID length of monitor doesn't match that of the " & parent_component);
-      check_equal(axi_stream_checker, monitor.p_dest_length, dest_length, "Dest length of monitor doesn't match that of the " & parent_component);
-      check_equal(axi_stream_checker, monitor.p_user_length, user_length, "User length of monitor doesn't match that of the " & parent_component);
+      check_equal(
+        axi_stream_checker, monitor.p_data_length, data_length,
+        "Data length of monitor doesn't match that of the " & parent_component
+      );
+      check_equal(
+        axi_stream_checker, monitor.p_id_length, id_length,
+        "ID length of monitor doesn't match that of the " & parent_component
+      );
+      check_equal(
+        axi_stream_checker, monitor.p_dest_length, dest_length,
+        "Dest length of monitor doesn't match that of the " & parent_component
+      );
+      check_equal(
+        axi_stream_checker,
+        monitor.p_user_length,
+        user_length,
+        "User length of monitor doesn't match that of the " & parent_component
+      );
       return monitor;
     end if;
   end;
@@ -417,10 +437,30 @@ package body axi_stream_pkg is
     elsif protocol_checker = default_axi_stream_protocol_checker then
       return new_axi_stream_protocol_checker(data_length, id_length, dest_length, user_length, logger, actor);
     else
-      check_equal(axi_stream_checker, protocol_checker.p_data_length, data_length, "Data length of protocol checker doesn't match that of the " & parent_component);
-      check_equal(axi_stream_checker, protocol_checker.p_id_length, id_length, "ID length of monitor doesn't match that of the " & parent_component);
-      check_equal(axi_stream_checker, protocol_checker.p_dest_length, dest_length, "Dest length of monitor doesn't match that of the " & parent_component);
-      check_equal(axi_stream_checker, protocol_checker.p_user_length, user_length, "User length of monitor doesn't match that of the " & parent_component);
+      check_equal(
+        axi_stream_checker,
+        protocol_checker.p_data_length,
+        data_length,
+        "Data length of protocol checker doesn't match that of the " & parent_component
+      );
+      check_equal(
+        axi_stream_checker,
+        protocol_checker.p_id_length,
+        id_length,
+        "ID length of monitor doesn't match that of the " & parent_component
+      );
+      check_equal(
+        axi_stream_checker,
+        protocol_checker.p_dest_length,
+        dest_length,
+        "Dest length of monitor doesn't match that of the " & parent_component
+      );
+      check_equal(
+        axi_stream_checker,
+        protocol_checker.p_user_length,
+        user_length,
+        "User length of monitor doesn't match that of the " & parent_component
+      );
       return protocol_checker;
     end if;
   end;
@@ -428,6 +468,8 @@ package body axi_stream_pkg is
   impure function to_integer_vector_ptr(stall_config : stall_config_t) return integer_vector_ptr_t is
     variable result : integer_vector_ptr_t := new_integer_vector_ptr(3);
   begin
+    -- Since values are in the 0 - 1 range, we can have the full resolution of the mantissa fit within
+    -- an integer if reals are implemented as single-precision floats.
     set(result, 0, integer(stall_config.stall_probability * (2.0 ** 23)));
     set(result, 1, stall_config.min_stall_cycles);
     set(result, 2, stall_config.max_stall_cycles);
@@ -450,7 +492,10 @@ package body axi_stream_pkg is
     return result;
   end;
 
-  procedure set_inactive_axi_stream_policy(master : axi_stream_master_t; inactive_policy : inactive_axi_stream_policy_t) is
+  procedure set_inactive_axi_stream_policy(
+    master : axi_stream_master_t;
+    inactive_policy : inactive_axi_stream_policy_t
+  ) is
   begin
     set(master.p_config, p_interactive_policy_idx, to_integer(to_integer_vector_ptr(inactive_policy)));
   end;
@@ -472,9 +517,13 @@ package body axi_stream_pkg is
     variable p_protocol_checker : axi_stream_protocol_checker_t;
     variable handle : axi_stream_master_t;
   begin
-    p_monitor          := get_valid_monitor(data_length, id_length, dest_length, user_length, logger, actor, monitor, "master");
+    p_monitor          := get_valid_monitor(
+      data_length, id_length, dest_length, user_length, logger, actor, monitor, "master"
+    );
     p_actor            := actor when actor /= null_actor else new_actor;
-    p_protocol_checker := get_valid_protocol_checker(data_length, id_length, dest_length, user_length, logger, actor, protocol_checker, "master");
+    p_protocol_checker := get_valid_protocol_checker(
+      data_length, id_length, dest_length, user_length, logger, actor, protocol_checker, "master"
+    );
 
     handle := (p_actor      => p_actor,
       p_data_length      => data_length,
@@ -499,24 +548,28 @@ package body axi_stream_pkg is
   end;
 
   impure function new_axi_stream_slave(
-      data_length      : natural;
-      id_length        : natural                       := 0;
-      dest_length      : natural                       := 0;
-      user_length      : natural                       := 0;
-      stall_config     : stall_config_t                := null_stall_config;
-      logger           : logger_t                      := axi_stream_logger;
-      actor            : actor_t                       := null_actor;
-      monitor          : axi_stream_monitor_t          := null_axi_stream_monitor;
-      protocol_checker : axi_stream_protocol_checker_t := null_axi_stream_protocol_checker
-    ) return axi_stream_slave_t is
+    data_length      : natural;
+    id_length        : natural                       := 0;
+    dest_length      : natural                       := 0;
+    user_length      : natural                       := 0;
+    stall_config     : stall_config_t                := null_stall_config;
+    logger           : logger_t                      := axi_stream_logger;
+    actor            : actor_t                       := null_actor;
+    monitor          : axi_stream_monitor_t          := null_axi_stream_monitor;
+    protocol_checker : axi_stream_protocol_checker_t := null_axi_stream_protocol_checker
+  ) return axi_stream_slave_t is
     variable p_actor            : actor_t;
     variable p_monitor          : axi_stream_monitor_t;
     variable p_protocol_checker : axi_stream_protocol_checker_t;
     variable handle : axi_stream_slave_t;
   begin
-    p_monitor          := get_valid_monitor(data_length, id_length, dest_length, user_length, logger, actor, monitor, "slave");
+    p_monitor          := get_valid_monitor(
+      data_length, id_length, dest_length, user_length, logger, actor, monitor, "slave"
+    );
     p_actor            := actor when actor /= null_actor else new_actor;
-    p_protocol_checker := get_valid_protocol_checker(data_length, id_length, dest_length, user_length, logger, actor, protocol_checker, "slave");
+    p_protocol_checker := get_valid_protocol_checker(
+      data_length, id_length, dest_length, user_length, logger, actor, protocol_checker, "slave"
+    );
 
     handle := (p_actor      => p_actor,
       p_data_length      => data_length,
@@ -534,17 +587,17 @@ package body axi_stream_pkg is
   end;
 
   impure function new_axi_stream_monitor(
-      data_length      : natural;
-      id_length        : natural  := 0;
-      dest_length      : natural  := 0;
-      user_length      : natural  := 0;
-      logger           : logger_t := axi_stream_logger;
-      actor            : actor_t;
-      protocol_checker : axi_stream_protocol_checker_t := null_axi_stream_protocol_checker
-    ) return axi_stream_monitor_t is
+    data_length      : natural;
+    id_length        : natural  := 0;
+    dest_length      : natural  := 0;
+    user_length      : natural  := 0;
+    logger           : logger_t := axi_stream_logger;
+    actor            : actor_t;
+    protocol_checker : axi_stream_protocol_checker_t := null_axi_stream_protocol_checker
+  ) return axi_stream_monitor_t is
     constant p_protocol_checker : axi_stream_protocol_checker_t := get_valid_protocol_checker(
-      data_length, id_length, dest_length, user_length, logger, actor, protocol_checker, "monitor"
-    );
+        data_length, id_length, dest_length, user_length, logger, actor, protocol_checker, "monitor"
+      );
   begin
     return (
       p_type             => custom_component,
@@ -558,15 +611,15 @@ package body axi_stream_pkg is
   end;
 
   impure function new_axi_stream_protocol_checker(
-      data_length               : natural;
-      id_length                 : natural  := 0;
-      dest_length               : natural  := 0;
-      user_length               : natural  := 0;
-      logger                    : logger_t := axi_stream_logger;
-      actor                     : actor_t  := null_actor;
-      max_waits                 : natural  := 16;
-      allow_x_in_non_data_bytes : boolean  := false
-    ) return axi_stream_protocol_checker_t is
+    data_length               : natural;
+    id_length                 : natural  := 0;
+    dest_length               : natural  := 0;
+    user_length               : natural  := 0;
+    logger                    : logger_t := axi_stream_logger;
+    actor                     : actor_t  := null_actor;
+    max_waits                 : natural  := 16;
+    allow_x_in_non_data_bytes : boolean  := false
+  ) return axi_stream_protocol_checker_t is
   begin
     return (
       p_type                  => custom_component,
@@ -681,16 +734,16 @@ package body axi_stream_pkg is
   end;
 
   procedure push_axi_stream(
-      signal net : inout network_t;
-      axi_stream : axi_stream_master_t;
-      tdata      : std_logic_vector;
-      tlast      : std_logic        := '1';
-      tkeep      : std_logic_vector := "";
-      tstrb      : std_logic_vector := "";
-      tid        : std_logic_vector := "";
-      tdest      : std_logic_vector := "";
-      tuser      : std_logic_vector := ""
-    ) is
+    signal net : inout network_t;
+    axi_stream : axi_stream_master_t;
+    tdata      : std_logic_vector;
+    tlast      : std_logic        := '1';
+    tkeep      : std_logic_vector := "";
+    tstrb      : std_logic_vector := "";
+    tid        : std_logic_vector := "";
+    tdest      : std_logic_vector := "";
+    tuser      : std_logic_vector := ""
+  ) is
     variable msg             : msg_t := new_msg(push_axi_stream_msg);
     variable normalized_data : std_logic_vector(data_length(axi_stream)-1 downto 0) := (others => '0');
     variable normalized_keep : std_logic_vector(data_length(axi_stream)/8-1 downto 0) := (others => '1');
@@ -716,25 +769,27 @@ package body axi_stream_pkg is
     send(net, axi_stream.p_actor, msg);
   end;
 
-  procedure pop_axi_stream(signal net : inout network_t;
-                           axi_stream : axi_stream_slave_t;
-                           variable reference : inout axi_stream_reference_t) is
+  procedure pop_axi_stream(
+    signal net : inout network_t;
+    axi_stream : axi_stream_slave_t;
+    variable reference : inout axi_stream_reference_t
+  ) is
   begin
     reference := new_msg(pop_axi_stream_msg);
     send(net, axi_stream.p_actor, reference);
   end;
 
   procedure await_pop_axi_stream_reply(
-      signal net : inout network_t;
-      variable reference : inout axi_stream_reference_t;
-      variable tdata     : out std_logic_vector;
-      variable tlast     : out std_logic;
-      variable tkeep     : out std_logic_vector;
-      variable tstrb     : out std_logic_vector;
-      variable tid       : out std_logic_vector;
-      variable tdest     : out std_logic_vector;
-      variable tuser : out std_logic_vector
-    ) is
+    signal net : inout network_t;
+    variable reference : inout axi_stream_reference_t;
+    variable tdata     : out std_logic_vector;
+    variable tlast     : out std_logic;
+    variable tkeep     : out std_logic_vector;
+    variable tstrb     : out std_logic_vector;
+    variable tid       : out std_logic_vector;
+    variable tdest     : out std_logic_vector;
+    variable tuser : out std_logic_vector
+  ) is
     variable reply_msg : msg_t;
   begin
     receive_reply(net, reference, reply_msg);
@@ -754,11 +809,11 @@ package body axi_stream_pkg is
   end;
 
   procedure await_pop_axi_stream_reply(
-      signal net : inout network_t;
-      variable reference : inout axi_stream_reference_t;
-      variable tdata     : out std_logic_vector;
-      variable tlast     : out std_logic
-    ) is
+    signal net : inout network_t;
+    variable reference : inout axi_stream_reference_t;
+    variable tdata     : out std_logic_vector;
+    variable tlast     : out std_logic
+  ) is
     variable reply_msg : msg_t;
   begin
     receive_reply(net, reference, reply_msg);
@@ -773,16 +828,16 @@ package body axi_stream_pkg is
   end;
 
   procedure pop_axi_stream(
-      signal net : inout network_t;
-      axi_stream : axi_stream_slave_t;
-      variable tdata : out std_logic_vector;
-      variable tlast : out std_logic;
-      variable tkeep : out std_logic_vector;
-      variable tstrb : out std_logic_vector;
-      variable tid   : out std_logic_vector;
-      variable tdest : out std_logic_vector;
-      variable tuser : out std_logic_vector
-    ) is
+    signal net : inout network_t;
+    axi_stream : axi_stream_slave_t;
+    variable tdata : out std_logic_vector;
+    variable tlast : out std_logic;
+    variable tkeep : out std_logic_vector;
+    variable tstrb : out std_logic_vector;
+    variable tid   : out std_logic_vector;
+    variable tdest : out std_logic_vector;
+    variable tuser : out std_logic_vector
+  ) is
     variable reference : axi_stream_reference_t;
   begin
     pop_axi_stream(net, axi_stream, reference);
@@ -790,11 +845,11 @@ package body axi_stream_pkg is
   end;
 
   procedure pop_axi_stream(
-      signal net : inout network_t;
-      axi_stream : axi_stream_slave_t;
-      variable tdata : out std_logic_vector;
-      variable tlast : out std_logic
-    ) is
+    signal net : inout network_t;
+    axi_stream : axi_stream_slave_t;
+    variable tdata : out std_logic_vector;
+    variable tlast : out std_logic
+  ) is
     variable reference : axi_stream_reference_t;
   begin
     pop_axi_stream(net, axi_stream, reference);
@@ -802,18 +857,18 @@ package body axi_stream_pkg is
   end;
 
   procedure check_axi_stream(
-      signal net : inout network_t;
-      axi_stream   : axi_stream_slave_t;
-      expected : std_logic_vector;
-      tlast    : std_logic        := '1';
-      tkeep    : std_logic_vector := "";
-      tstrb    : std_logic_vector := "";
-      tid      : std_logic_vector := "";
-      tdest    : std_logic_vector := "";
-      tuser    : std_logic_vector := "";
-      msg      : string           := "";
-      blocking : boolean          := true
-    ) is
+    signal net : inout network_t;
+    axi_stream   : axi_stream_slave_t;
+    expected : std_logic_vector;
+    tlast    : std_logic        := '1';
+    tkeep    : std_logic_vector := "";
+    tstrb    : std_logic_vector := "";
+    tid      : std_logic_vector := "";
+    tdest    : std_logic_vector := "";
+    tuser    : std_logic_vector := "";
+    msg      : string           := "";
+    blocking : boolean          := true
+  ) is
     constant expected_normalized : std_logic_vector(expected'length - 1 downto 0) := expected;
     variable got_tdata : std_logic_vector(data_length(axi_stream)-1 downto 0);
     variable got_tlast : std_logic;
@@ -868,11 +923,11 @@ package body axi_stream_pkg is
   end procedure;
 
   procedure set_inactive_axi_stream_policy(
-      signal net : inout network_t;
-      master : axi_stream_master_t;
-      inactive_policy : inactive_bus_policy_t;
-      axi_stream_signal : axi_stream_signal_t := all_signals
-    ) is
+    signal net : inout network_t;
+    master : axi_stream_master_t;
+    inactive_policy : inactive_bus_policy_t;
+    axi_stream_signal : axi_stream_signal_t := all_signals
+  ) is
     variable msg : msg_t;
     variable start, stop : axi_stream_signal_t := axi_stream_signal;
   begin
@@ -897,8 +952,8 @@ package body axi_stream_pkg is
     variable msg : msg_t := new_msg(set_stall_config_msg);
     variable stall_config_vec : integer_vector_ptr_t := to_integer_vector_ptr(stall_config);
   begin
-      push(msg, stall_config_vec);
-      send(net, master.p_actor, msg);
+    push(msg, stall_config_vec);
+    send(net, master.p_actor, msg);
   end;
 
   procedure set_stall_config(
@@ -909,8 +964,8 @@ package body axi_stream_pkg is
     variable msg : msg_t := new_msg(set_stall_config_msg);
     variable stall_config_vec : integer_vector_ptr_t := to_integer_vector_ptr(stall_config);
   begin
-      push(msg, stall_config_vec);
-      send(net, slave.p_actor, msg);
+    push(msg, stall_config_vec);
+    send(net, slave.p_actor, msg);
   end;
 
   procedure push_axi_stream_transaction(msg : msg_t; axi_stream_transaction : axi_stream_transaction_t) is
@@ -963,8 +1018,9 @@ package body axi_stream_pkg is
   function new_stall_config(
     stall_probability : real range 0.0 to 1.0;
     min_stall_cycles  : natural;
-    max_stall_cycles  : natural) return stall_config_t is
-      variable stall_config : stall_config_t;
+    max_stall_cycles  : natural
+  ) return stall_config_t is
+    variable stall_config : stall_config_t;
   begin
     stall_config := (
       stall_probability => stall_probability,

--- a/vunit/vhdl/verification_components/src/axi_stream_private_pkg.vhd
+++ b/vunit/vhdl/verification_components/src/axi_stream_private_pkg.vhd
@@ -21,16 +21,10 @@ package axi_stream_private_pkg is
     rnd          : inout RandomPType
   );
 
-  procedure set_inactive_axi_stream_policy(
-    master : axi_stream_master_t;
-    inactive_policy : inactive_bus_policy_t;
-    axi_stream_signal : axi_stream_signal_t
-  );
-
-  impure function get_inactive_axi_stream_policy(master : axi_stream_master_t) return inactive_axi_stream_policy_t;
-
-  impure function get_stall_config(master : axi_stream_master_t) return stall_config_t;
-  impure function get_stall_config(slave : axi_stream_slave_t) return stall_config_t;
+  function resolve_tstrb(
+    tkeep : std_logic_vector;
+    tstrb : std_logic_vector
+  ) return std_logic_vector;
 end package;
 
 package body axi_stream_private_pkg is
@@ -48,49 +42,15 @@ package body axi_stream_private_pkg is
     end loop;
   end procedure;
 
-  procedure set_inactive_axi_stream_policy(
-    master : axi_stream_master_t;
-    inactive_policy : inactive_bus_policy_t;
-    axi_stream_signal : axi_stream_signal_t
-  ) is
-    variable start, stop : axi_stream_signal_t := axi_stream_signal;
+  function resolve_tstrb(
+    tkeep : std_logic_vector;
+    tstrb : std_logic_vector
+  ) return std_logic_vector is
   begin
-    if axi_stream_signal = all_signals then
-      start := tdata;
-      stop := tuser;
+    if tstrb = (tstrb'range => 'U') then
+      return tkeep;
+    else
+      return tstrb;
     end if;
-
-    for sig in start to stop loop
-      set(
-        to_integer_vector_ptr(get(master.p_config, p_interactive_policy_idx)),
-        axi_stream_signal_t'pos(sig),
-        inactive_bus_policy_t'pos(inactive_policy)
-      );
-    end loop;
-  end;
-
-  impure function to_inactive_axi_stream_policy(vec : integer_vector_ptr_t) return inactive_axi_stream_policy_t is
-    variable inactive_policy : inactive_axi_stream_policy_t;
-  begin
-    for sig in inactive_policy'range loop
-      inactive_policy(sig) := inactive_bus_policy_t'val(get(vec, axi_stream_signal_t'pos(sig)));
-    end loop;
-
-    return inactive_policy;
-  end;
-
-  impure function get_inactive_axi_stream_policy(master : axi_stream_master_t) return inactive_axi_stream_policy_t is
-  begin
-    return to_inactive_axi_stream_policy(to_integer_vector_ptr(get(master.p_config, p_interactive_policy_idx)));
-  end;
-
-  impure function get_stall_config(master : axi_stream_master_t) return stall_config_t is
-  begin
-    return p_to_stall_config(to_integer_vector_ptr(get(master.p_config, p_stall_config_idx)));
-  end;
-
-  impure function get_stall_config(slave : axi_stream_slave_t) return stall_config_t is
-  begin
-    return p_to_stall_config(to_integer_vector_ptr(get(slave.p_config, p_stall_config_idx)));
   end;
 end package body;

--- a/vunit/vhdl/verification_components/src/axi_stream_private_pkg.vhd
+++ b/vunit/vhdl/verification_components/src/axi_stream_private_pkg.vhd
@@ -16,10 +16,10 @@ use work.integer_vector_ptr_pkg.all;
 
 package axi_stream_private_pkg is
   procedure probability_stall_axi_stream(
-      signal aclk  : in std_logic;
-      stall_config : in stall_config_t;
-      rnd          : inout RandomPType
-    );
+    signal aclk  : in std_logic;
+    stall_config : in stall_config_t;
+    rnd          : inout RandomPType
+  );
 
   procedure set_inactive_axi_stream_policy(
     master : axi_stream_master_t;
@@ -44,7 +44,7 @@ package body axi_stream_private_pkg is
       num_stall_cycles := rnd.FavorSmall(stall_config.min_stall_cycles, stall_config.max_stall_cycles);
     end if;
     for stall in 0 to num_stall_cycles-1 loop
-       wait until rising_edge(aclk);
+      wait until rising_edge(aclk);
     end loop;
   end procedure;
 
@@ -61,7 +61,11 @@ package body axi_stream_private_pkg is
     end if;
 
     for sig in start to stop loop
-      set(to_integer_vector_ptr(get(master.p_config, p_interactive_policy_idx)), axi_stream_signal_t'pos(sig), inactive_bus_policy_t'pos(inactive_policy));
+      set(
+        to_integer_vector_ptr(get(master.p_config, p_interactive_policy_idx)),
+        axi_stream_signal_t'pos(sig),
+        inactive_bus_policy_t'pos(inactive_policy)
+      );
     end loop;
   end;
 

--- a/vunit/vhdl/verification_components/src/axi_stream_private_pkg.vhd
+++ b/vunit/vhdl/verification_components/src/axi_stream_private_pkg.vhd
@@ -11,46 +11,29 @@ library osvvm;
 use osvvm.RandomPkg.RandomPType;
 
 use work.axi_stream_pkg.all;
+use work.axi_pkg.all;
+use work.integer_vector_ptr_pkg.all;
 
 package axi_stream_private_pkg is
-  procedure probability_stall_axi_stream(
-      signal aclk : in std_logic;
-      axi_stream  : in axi_stream_slave_t;
-      rnd         : inout RandomPType
-    );
-
-  procedure probability_stall_axi_stream(
-      signal aclk : in std_logic;
-      axi_stream  : in axi_stream_master_t;
-      rnd         : inout RandomPType
-    );
-
   procedure probability_stall_axi_stream(
       signal aclk  : in std_logic;
       stall_config : in stall_config_t;
       rnd          : inout RandomPType
     );
 
+  procedure set_inactive_axi_stream_policy(
+    master : axi_stream_master_t;
+    inactive_policy : inactive_bus_policy_t;
+    axi_stream_signal : axi_stream_signal_t
+  );
+
+  impure function get_inactive_axi_stream_policy(master : axi_stream_master_t) return inactive_axi_stream_policy_t;
+
+  impure function get_stall_config(master : axi_stream_master_t) return stall_config_t;
+  impure function get_stall_config(slave : axi_stream_slave_t) return stall_config_t;
 end package;
 
 package body axi_stream_private_pkg is
-
-  procedure probability_stall_axi_stream(
-    signal aclk : in std_logic;
-    axi_stream  : in axi_stream_master_t;
-    rnd         : inout RandomPType) is
-  begin
-    probability_stall_axi_stream(aclk, axi_stream.p_stall_config, rnd);
-  end procedure;
-
-  procedure probability_stall_axi_stream(
-    signal aclk : in std_logic;
-    axi_stream  : in axi_stream_slave_t;
-    rnd         : inout RandomPType) is
-  begin
-    probability_stall_axi_stream(aclk, axi_stream.p_stall_config, rnd);
-  end procedure;
-
   procedure probability_stall_axi_stream(
     signal aclk  : in std_logic;
     stall_config : in stall_config_t;
@@ -65,4 +48,55 @@ package body axi_stream_private_pkg is
     end loop;
   end procedure;
 
+  procedure set_inactive_axi_stream_policy(
+    master : axi_stream_master_t;
+    inactive_policy : inactive_bus_policy_t;
+    axi_stream_signal : axi_stream_signal_t
+  ) is
+    variable start, stop : axi_stream_signal_t := axi_stream_signal;
+  begin
+    if axi_stream_signal = all_signals then
+      start := tdata;
+      stop := tuser;
+    end if;
+
+    for sig in start to stop loop
+      set(to_integer_vector_ptr(get(master.p_config, p_interactive_policy_idx)), axi_stream_signal_t'pos(sig), inactive_bus_policy_t'pos(inactive_policy));
+    end loop;
+  end;
+
+  impure function to_inactive_axi_stream_policy(vec : integer_vector_ptr_t) return inactive_axi_stream_policy_t is
+    variable inactive_policy : inactive_axi_stream_policy_t;
+  begin
+    for sig in inactive_policy'range loop
+      inactive_policy(sig) := inactive_bus_policy_t'val(get(vec, axi_stream_signal_t'pos(sig)));
+    end loop;
+
+    return inactive_policy;
+  end;
+
+  impure function get_inactive_axi_stream_policy(master : axi_stream_master_t) return inactive_axi_stream_policy_t is
+  begin
+    return to_inactive_axi_stream_policy(to_integer_vector_ptr(get(master.p_config, p_interactive_policy_idx)));
+  end;
+
+  impure function to_stall_config(vec : integer_vector_ptr_t) return stall_config_t is
+    variable stall_config : stall_config_t;
+  begin
+    stall_config.stall_probability := real(get(vec, 0)) * (2.0 ** (-23));
+    stall_config.min_stall_cycles := get(vec, 1);
+    stall_config.max_stall_cycles := get(vec, 2);
+
+    return stall_config;
+  end;
+
+  impure function get_stall_config(master : axi_stream_master_t) return stall_config_t is
+  begin
+    return to_stall_config(to_integer_vector_ptr(get(master.p_config, p_stall_config_idx)));
+  end;
+
+  impure function get_stall_config(slave : axi_stream_slave_t) return stall_config_t is
+  begin
+    return to_stall_config(to_integer_vector_ptr(get(slave.p_config, p_stall_config_idx)));
+  end;
 end package body;

--- a/vunit/vhdl/verification_components/src/axi_stream_private_pkg.vhd
+++ b/vunit/vhdl/verification_components/src/axi_stream_private_pkg.vhd
@@ -84,23 +84,13 @@ package body axi_stream_private_pkg is
     return to_inactive_axi_stream_policy(to_integer_vector_ptr(get(master.p_config, p_interactive_policy_idx)));
   end;
 
-  impure function to_stall_config(vec : integer_vector_ptr_t) return stall_config_t is
-    variable stall_config : stall_config_t;
-  begin
-    stall_config.stall_probability := real(get(vec, 0)) * (2.0 ** (-23));
-    stall_config.min_stall_cycles := get(vec, 1);
-    stall_config.max_stall_cycles := get(vec, 2);
-
-    return stall_config;
-  end;
-
   impure function get_stall_config(master : axi_stream_master_t) return stall_config_t is
   begin
-    return to_stall_config(to_integer_vector_ptr(get(master.p_config, p_stall_config_idx)));
+    return p_to_stall_config(to_integer_vector_ptr(get(master.p_config, p_stall_config_idx)));
   end;
 
   impure function get_stall_config(slave : axi_stream_slave_t) return stall_config_t is
   begin
-    return to_stall_config(to_integer_vector_ptr(get(slave.p_config, p_stall_config_idx)));
+    return p_to_stall_config(to_integer_vector_ptr(get(slave.p_config, p_stall_config_idx)));
   end;
 end package body;

--- a/vunit/vhdl/verification_components/src/axi_stream_protocol_checker.vhd
+++ b/vunit/vhdl/verification_components/src/axi_stream_protocol_checker.vhd
@@ -11,6 +11,7 @@ use ieee.numeric_std_unsigned.all;
 use std.textio.all;
 
 use work.axi_stream_pkg.all;
+use work.axi_stream_private_pkg.all;
 use work.check_pkg.all;
 use work.checker_pkg.all;
 use work.event_common_pkg.is_active;
@@ -91,7 +92,7 @@ architecture a of axi_stream_protocol_checker is
     return ret;
   end function;
 begin
-  tstrb_resolved <= tkeep when is_u(tstrb) else tstrb;
+  tstrb_resolved <= resolve_tstrb(tkeep, tstrb);
   handshake_is_not_x <= '1' when not is_x(tvalid) and not is_x(tready) else '0';
 
   -- AXI4STREAM_ERRM_TDATA_STABLE TDATA remains stable when TVALID is asserted,

--- a/vunit/vhdl/verification_components/src/axi_stream_protocol_checker.vhd
+++ b/vunit/vhdl/verification_components/src/axi_stream_protocol_checker.vhd
@@ -35,7 +35,7 @@ entity axi_stream_protocol_checker is
     tid      : in std_logic_vector(id_length(protocol_checker)-1 downto 0)     := (others => '0');
     tdest    : in std_logic_vector(dest_length(protocol_checker)-1 downto 0)   := (others => '0');
     tuser    : in std_logic_vector(user_length(protocol_checker)-1 downto 0)   := (others => '0')
-    );
+  );
 end entity;
 
 architecture a of axi_stream_protocol_checker is
@@ -134,7 +134,8 @@ begin
 
   -- AXI4STREAM_ERRM_TDATA_X A value of X on TDATA is not permitted when TVALID
   -- is HIGH
-  tdata_normalized <= normalize_tdata(tdata, tstrb_resolved, tkeep) when protocol_checker.p_allow_x_in_non_data_bytes else tdata;
+  tdata_normalized <= normalize_tdata(tdata, tstrb_resolved, tkeep) when protocol_checker.p_allow_x_in_non_data_bytes
+    else tdata;
   check_not_unknown(rule5_checker, aclk, tvalid, tdata_normalized, result("for tdata when tvalid is high"));
 
   -- AXI4STREAM_ERRM_TLAST_X A value of X on TLAST is not permitted when TVALID
@@ -255,16 +256,19 @@ begin
   check_not_unknown(rule19_checker, aclk, tvalid, tkeep, result("for tkeep when tvalid is high"));
 
   -- AXI4STREAM_ERRM_TKEEP_TSTRB If TKEEP is de-asserted, then TSTRB must also be de-asserted
-  -- eschmidscs: Binding this to tvalid. ARM does not include that, but makes more sense this way?
+  -- Binding this to tvalid. ARM does not include that, but makes more sense this way?
   rule20_check_value <= not(or(((not tkeep) and tstrb_resolved)));
   check_true(rule20_checker, aclk, tvalid, rule20_check_value, result("for tstrb de-asserted when tkeep de-asserted"));
 
   -- AXI4STREAM_AUXM_TID_TDTEST_WIDTH  The value of ID_WIDTH + DEST_WIDTH must not exceed 24
-  -- eschmidscs: Must wait a short while to allow testing of the rule.
+  -- Must wait a short while to allow testing of the rule.
   process
   begin
     wait for 1 ps;
-    check_true(rule21_checker, tid'length + tdest'length <= 24, result("for tid width and tdest width together must be less than 25"));
+    check_true(
+      rule21_checker, tid'length + tdest'length <= 24,
+      result("for tid width and tdest width together must be less than 25")
+    );
     wait;
   end process;
 
@@ -277,7 +281,9 @@ begin
   end process;
   areset_rose <= areset_n and not areset_n_d;
   not_tvalid   <= not tvalid;
-  check_implication(rule22_checker, aclk, areset_n, areset_rose, not_tvalid, result("for tvalid de-asserted after reset release"));
+  check_implication(
+    rule22_checker, aclk, areset_n, areset_rose, not_tvalid, result("for tvalid de-asserted after reset release")
+  );
 
   -- for * being DATA, KEEP, STRB, ID, DEST or USER
   -- AXI4STREAM_ERRM_T*_TIEOFF T* must be stable while *_WIDTH has been set to zero

--- a/vunit/vhdl/verification_components/src/axi_stream_slave.vhd
+++ b/vunit/vhdl/verification_components/src/axi_stream_slave.vhd
@@ -40,7 +40,7 @@ entity axi_stream_slave is
     tid      : in std_logic_vector(id_length(slave)-1 downto 0)     := (others => '0');
     tdest    : in std_logic_vector(dest_length(slave)-1 downto 0)   := (others => '0');
     tuser    : in std_logic_vector(user_length(slave)-1 downto 0)   := (others => '0')
- );
+  );
 end entity;
 
 architecture a of axi_stream_slave is
@@ -48,7 +48,9 @@ architecture a of axi_stream_slave is
   constant notify_request_msg       : msg_type_t := new_msg_type("notify request");
   constant message_queue            : queue_t    := new_queue;
   constant bus_process_done_base_id : id_t       := get_id("vunit_lib:axi_stream_slave:bus_process_done");
-  constant bus_process_done_id      : id_t       := get_id(to_string(num_children(bus_process_done_base_id)), parent => bus_process_done_base_id);
+  constant bus_process_done_id      : id_t       := get_id(
+      to_string(num_children(bus_process_done_base_id)), parent => bus_process_done_base_id
+    );
   signal bus_process_done           : event_t    := new_event(bus_process_done_id);
 
 begin
@@ -124,10 +126,10 @@ begin
         if msg_type = wait_for_time_msg then
           handle_sync_message(net, msg_type, msg);
           wait until rising_edge(aclk);
-        
+
         elsif msg_type = notify_request_msg then
           -- Ignore this message, but expect it
-        
+
         elsif msg_type = stream_pop_msg or msg_type = pop_axi_stream_msg or msg_type = check_axi_stream_msg then
 
           -- stall according to probability configuration
@@ -163,7 +165,7 @@ begin
               end if;
             end loop;
             if mismatch then
-                check_field(tdata, expected_tdata, "TDATA mismatch, " & to_string(report_msg));
+              check_field(tdata, expected_tdata, "TDATA mismatch, " & to_string(report_msg));
             end if;
 
             check_field(tkeep, pop_std_ulogic_vector(msg), "TKEEP mismatch, " & to_string(report_msg));
@@ -174,11 +176,11 @@ begin
             check_field(tuser, pop_std_ulogic_vector(msg), "TUSER mismatch, " & to_string(report_msg));
           end if;
 
-        
+
         elsif msg_type = set_stall_config_msg then
           deallocate(to_integer_vector_ptr(get(slave.p_config, p_stall_config_idx)));
           set(slave.p_config, p_stall_config_idx, to_integer(pop_integer_vector_ptr_ref(msg)));
-          
+
         else
           unexpected_msg_type(msg_type);
         end if;
@@ -225,7 +227,7 @@ begin
         tid      => tid,
         tdest    => tdest,
         tuser    => tuser
-        );
+      );
   end generate axi_stream_protocol_checker_generate;
 
 end architecture;

--- a/vunit/vhdl/verification_components/src/axi_stream_slave.vhd
+++ b/vunit/vhdl/verification_components/src/axi_stream_slave.vhd
@@ -66,7 +66,8 @@ begin
       msg_type = pop_axi_stream_msg or
       msg_type = check_axi_stream_msg or
       msg_type = wait_for_time_msg or
-      msg_type = set_stall_config_msg then
+      msg_type = set_stall_config_msg or
+      msg_type = get_stall_config_msg  then
 
       push(message_queue, request_msg);
 
@@ -111,6 +112,7 @@ begin
     variable expected_tdata : std_logic_vector(tdata'range);
     variable mismatch : boolean;
     variable tstrb_resolved : std_logic_vector(tstrb'range);
+    variable stall_config : integer_vector_ptr_t;
   begin
     rnd.InitSeed(rnd'instance_name);
     loop
@@ -180,6 +182,12 @@ begin
         elsif msg_type = set_stall_config_msg then
           deallocate(to_integer_vector_ptr(get(slave.p_config, p_stall_config_idx)));
           set(slave.p_config, p_stall_config_idx, to_integer(pop_integer_vector_ptr_ref(msg)));
+
+        elsif msg_type = get_stall_config_msg then
+          reply_msg := new_msg(get_stall_config_reply_msg);
+          stall_config := to_integer_vector_ptr(get(slave.p_config, p_stall_config_idx));
+          push(reply_msg, stall_config);
+          reply(net, msg, reply_msg);
 
         else
           unexpected_msg_type(msg_type);

--- a/vunit/vhdl/verification_components/src/axi_stream_slave.vhd
+++ b/vunit/vhdl/verification_components/src/axi_stream_slave.vhd
@@ -82,14 +82,6 @@ begin
   end process;
 
   bus_process : process
-    procedure probability_stall_axi_stream(
-      signal aclk : in std_logic;
-      axi_stream  : in axi_stream_slave_t;
-      rnd         : inout RandomPType) is
-    begin
-      probability_stall_axi_stream(aclk, get_stall_config(axi_stream), rnd);
-    end procedure;
-
     procedure check_field(got, exp : std_logic_vector; msg : string) is
     begin
       if got'length /= 0 and exp'length /= 0 then
@@ -135,13 +127,16 @@ begin
         elsif msg_type = stream_pop_msg or msg_type = pop_axi_stream_msg or msg_type = check_axi_stream_msg then
 
           -- stall according to probability configuration
-          probability_stall_axi_stream(aclk, slave, rnd);
+          probability_stall_axi_stream(
+            aclk,
+            p_to_stall_config(to_integer_vector_ptr(get(slave.p_config, p_stall_config_idx))),
+            rnd);
 
           tready <= '1';
           wait until (tvalid and tready) = '1' and rising_edge(aclk);
           tready <= '0';
 
-          tstrb_resolved := tkeep when is_u(tstrb) else tstrb;
+          tstrb_resolved := resolve_tstrb(tkeep, tstrb);
           if msg_type = stream_pop_msg or msg_type = pop_axi_stream_msg then
             axi_stream_transaction := (
               tdata => tdata,

--- a/vunit/vhdl/verification_components/src/axi_stream_slave.vhd
+++ b/vunit/vhdl/verification_components/src/axi_stream_slave.vhd
@@ -14,10 +14,11 @@ use work.check_pkg.all;
 use work.com_pkg.all;
 use work.com_types_pkg.all;
 use work.id_pkg.all;
+use work.integer_vector_ptr_pkg.all;
 use work.queue_pkg.all;
 use work.stream_slave_pkg.stream_pop_msg;
 use work.axi_stream_pkg.all;
-use work.axi_stream_private_pkg.probability_stall_axi_stream;
+use work.axi_stream_private_pkg.all;
 use work.sync_pkg.all;
 use work.string_ptr_pkg.all;
 use work.event_common_pkg.is_active;
@@ -59,12 +60,14 @@ begin
     receive(net, slave.p_actor, request_msg);
     msg_type := message_type(request_msg);
 
-    if msg_type = stream_pop_msg or msg_type = pop_axi_stream_msg then
+    if msg_type = stream_pop_msg or
+      msg_type = pop_axi_stream_msg or
+      msg_type = check_axi_stream_msg or
+      msg_type = wait_for_time_msg or
+      msg_type = set_stall_config_msg then
+
       push(message_queue, request_msg);
-    elsif msg_type = check_axi_stream_msg then
-      push(message_queue, request_msg);
-    elsif msg_type = wait_for_time_msg then
-      push(message_queue, request_msg);
+
     elsif msg_type = wait_until_idle_msg then
       notify_msg := new_msg(notify_request_msg);
       push(message_queue, notify_msg);
@@ -76,6 +79,13 @@ begin
   end process;
 
   bus_process : process
+    procedure probability_stall_axi_stream(
+      signal aclk : in std_logic;
+      axi_stream  : in axi_stream_slave_t;
+      rnd         : inout RandomPType) is
+    begin
+      probability_stall_axi_stream(aclk, get_stall_config(axi_stream), rnd);
+    end procedure;
 
     procedure check_field(got, exp : std_logic_vector; msg : string) is
     begin
@@ -114,8 +124,10 @@ begin
         if msg_type = wait_for_time_msg then
           handle_sync_message(net, msg_type, msg);
           wait until rising_edge(aclk);
+        
         elsif msg_type = notify_request_msg then
           -- Ignore this message, but expect it
+        
         elsif msg_type = stream_pop_msg or msg_type = pop_axi_stream_msg or msg_type = check_axi_stream_msg then
 
           -- stall according to probability configuration
@@ -162,6 +174,11 @@ begin
             check_field(tuser, pop_std_ulogic_vector(msg), "TUSER mismatch, " & to_string(report_msg));
           end if;
 
+        
+        elsif msg_type = set_stall_config_msg then
+          deallocate(to_integer_vector_ptr(get(slave.p_config, p_stall_config_idx)));
+          set(slave.p_config, p_stall_config_idx, to_integer(pop_integer_vector_ptr_ref(msg)));
+          
         else
           unexpected_msg_type(msg_type);
         end if;

--- a/vunit/vhdl/verification_components/src/axi_write_slave.vhd
+++ b/vunit/vhdl/verification_components/src/axi_write_slave.vhd
@@ -62,9 +62,9 @@ architecture a of axi_write_slave is
 
   procedure push_burst_data(queue : queue_t; variable burst_data : inout burst_data_t) is
   begin
-     push_integer(queue, burst_data.length);
-     push_integer_vector_ptr_ref(queue, burst_data.address);
-     push_integer_vector_ptr_ref(queue, burst_data.data);
+    push_integer(queue, burst_data.length);
+    push_integer_vector_ptr_ref(queue, burst_data.address);
+    push_integer_vector_ptr_ref(queue, burst_data.data);
   end;
 
   impure function pop_burst_data(queue : queue_t) return burst_data_t is
@@ -109,8 +109,7 @@ begin
       end if;
     end procedure;
 
-    procedure record_input_data(variable input_data : inout burst_data_t;
-                                address : natural; byte : natural) is
+    procedure record_input_data(variable input_data : inout burst_data_t; address : natural; byte : natural) is
       variable ignored : boolean;
     begin
       if not check_address(axi_slave.p_memory, address, reading => false, check_permissions => true) then
@@ -251,7 +250,8 @@ begin
         num_beats := num_beats_now;
 
         if self.should_check_well_behaved and size /= self.data_size and len /= 0 then
-          self.fail("Burst not well behaved, axi size = " & to_string(size) & " but bus data width allows " & to_string(self.data_size));
+          self.fail("Burst not well behaved, axi size = " & to_string(size) & " but bus data width allows " &
+          to_string(self.data_size));
         end if;
       end if;
 

--- a/vunit/vhdl/verification_components/test/tb_axi_read_slave.vhd
+++ b/vunit/vhdl/verification_components/test/tb_axi_read_slave.vhd
@@ -52,21 +52,23 @@ begin
   main : process
     variable rnd : RandomPType;
 
-    procedure write_addr(id : std_logic_vector;
-                         addr : natural;
-                         len : natural;
-                         log_size : natural;
-                         burst : axi_burst_type_t) is
+    procedure write_addr(
+      id : std_logic_vector;
+      addr : natural;
+      len : natural;
+      log_size : natural;
+      burst : axi_burst_type_t
+    ) is
     begin
-        arvalid <= '1';
-        arid <= id;
-        araddr <= std_logic_vector(to_unsigned(addr, araddr'length));
-        arlen <= std_logic_vector(to_unsigned(len-1, arlen'length));
-        arsize <= std_logic_vector(to_unsigned(log_size, arsize'length));
-        arburst <= burst;
+      arvalid <= '1';
+      arid <= id;
+      araddr <= std_logic_vector(to_unsigned(addr, araddr'length));
+      arlen <= std_logic_vector(to_unsigned(len-1, arlen'length));
+      arsize <= std_logic_vector(to_unsigned(log_size, arsize'length));
+      arburst <= burst;
 
-        wait until (arvalid and arready) = '1' and rising_edge(clk);
-        arvalid <= '0';
+      wait until (arvalid and arready) = '1' and rising_edge(clk);
+      arvalid <= '0';
     end procedure;
 
     procedure read_data(id : std_logic_vector; address : natural; size : natural; resp : axi_resp_t; last : boolean) is
@@ -84,9 +86,11 @@ begin
       check_equal(rlast, last, "rlast");
     end procedure;
 
-    procedure transfer(log_size, len : natural;
-                       id : std_logic_vector;
-                       burst : std_logic_vector) is
+    procedure transfer(
+      log_size, len : natural;
+      id : std_logic_vector;
+      burst : std_logic_vector
+    ) is
       variable buf : buffer_t;
       variable size : natural;
       variable data : integer_vector_ptr_t;
@@ -194,9 +198,11 @@ begin
       mock(axi_slave_logger, failure);
       write_addr(x"2", base_address(buf), 1, 0, axi_burst_type_fixed);
       wait until mock_queue_length > 0 and rising_edge(clk);
-      check_only_log(axi_slave_logger,
-                     "Reading from address 0 at offset 0 within anonymous buffer at range (0 to 15) without permission (no_access)",
-                     failure);
+      check_only_log(
+        axi_slave_logger,
+        "Reading from address 0 at offset 0 within anonymous buffer at range (0 to 15) without permission (no_access)",
+        failure
+      );
       unmock(axi_slave_logger);
 
     elsif run("Test error on unsupported wrap burst") then
@@ -213,7 +219,11 @@ begin
       mock(axi_slave_logger, failure);
       write_addr(x"2", base_address(buf)+4000, 256, 0, axi_burst_type_incr);
       wait until mock_queue_length > 0 and rising_edge(clk);
-      check_only_log(axi_slave_logger, "Crossing 4KByte boundary. First page = 0 (4000/4096), last page = 1 (4255/4096)", failure);
+      check_only_log(
+        axi_slave_logger,
+        "Crossing 4KByte boundary. First page = 0 (4000/4096), last page = 1 (4255/4096)",
+        failure
+      );
       unmock(axi_slave_logger);
 
     elsif run("Test no error on 4KByte boundary crossing with disabled check") then
@@ -350,7 +360,11 @@ begin
       rready <= '1';
       wait until rising_edge(clk);
       write_addr(x"0", base_address(buf), len => 2, log_size => 0, burst => axi_burst_type_incr);
-      check_only_log(axi_slave_logger, "Burst not well behaved, axi size = 1 but bus data width allows " & to_string(data_size), failure);
+      check_only_log(
+        axi_slave_logger,
+        "Burst not well behaved, axi size = 1 but bus data width allows " & to_string(data_size),
+        failure
+      );
       unmock(axi_slave_logger);
 
     elsif run("Test well behaved check fails when rready not high during active burst") then

--- a/vunit/vhdl/verification_components/test/tb_axi_stream.vhd
+++ b/vunit/vhdl/verification_components/test/tb_axi_stream.vhd
@@ -13,6 +13,7 @@ context work.vunit_context;
 context work.com_context;
 context work.data_types_context;
 use work.axi_stream_pkg.all;
+use work.axi_pkg.all;
 use work.stream_master_pkg.all;
 use work.stream_slave_pkg.all;
 use work.sync_pkg.all;
@@ -26,9 +27,7 @@ entity tb_axi_stream is
     g_data_length : positive := 8;
     g_id_length   : natural := 8;
     g_dest_length : natural := 8;
-    g_user_length : natural := 8;
-    g_stall_percentage_master : natural range 0 to 100 := 0;
-    g_stall_percentage_slave  : natural range 0 to 100 := 0
+    g_user_length : natural := 8
   );
 end entity;
 
@@ -36,12 +35,10 @@ architecture a of tb_axi_stream is
 
   constant min_stall_cycles : natural := 5;
   constant max_stall_cycles : natural := 15;
-  constant master_stall_config : stall_config_t := new_stall_config(stall_probability => real(g_stall_percentage_master)/100.0, min_stall_cycles => min_stall_cycles, max_stall_cycles => max_stall_cycles);
-  constant slave_stall_config  : stall_config_t := new_stall_config(stall_probability => real(g_stall_percentage_slave)/100.0 , min_stall_cycles => min_stall_cycles, max_stall_cycles => max_stall_cycles);
 
   constant master_axi_stream : axi_stream_master_t := new_axi_stream_master(
     data_length => g_data_length, id_length => g_id_length, dest_length => g_dest_length, user_length => g_user_length,
-    stall_config => master_stall_config, logger => get_logger("master"), actor => new_actor("master"),
+    logger => get_logger("master"), actor => new_actor("master"),
     monitor => default_axi_stream_monitor, protocol_checker => default_axi_stream_protocol_checker
   );
   constant master_stream : stream_master_t := as_stream(master_axi_stream);
@@ -49,7 +46,7 @@ architecture a of tb_axi_stream is
 
   constant slave_axi_stream : axi_stream_slave_t := new_axi_stream_slave(
     data_length => g_data_length, id_length => g_id_length, dest_length => g_dest_length, user_length => g_user_length,
-    stall_config => slave_stall_config, logger => get_logger("slave"), actor => new_actor("slave"),
+    logger => get_logger("slave"), actor => new_actor("slave"),
     monitor => default_axi_stream_monitor, protocol_checker => default_axi_stream_protocol_checker
   );
   constant slave_stream : stream_slave_t := as_stream(slave_axi_stream);
@@ -80,14 +77,6 @@ architecture a of tb_axi_stream is
   signal tid : std_logic_vector(id_length(slave_axi_stream)-1 downto 0);
   signal tdest : std_logic_vector(dest_length(slave_axi_stream)-1 downto 0);
   signal tuser : std_logic_vector(user_length(slave_axi_stream)-1 downto 0);
-
-  signal not_valid      : std_logic;
-  signal not_valid_data : std_logic;
-  signal not_valid_keep : std_logic;
-  signal not_valid_strb : std_logic;
-  signal not_valid_id   : std_logic;
-  signal not_valid_dest : std_logic;
-  signal not_valid_user : std_logic;
 
   signal connected_tkeep : boolean := true;
   signal connected_tstrb : boolean := true;
@@ -136,8 +125,24 @@ begin
     variable msg_type               : msg_type_t;
     variable timestamp              : time := 0 ns;
 
-    variable mocklogger : logger_t;
+    variable mock_logger : logger_t;
     variable rnd : RandomPtype;
+    variable stall_config : stall_config_t;
+    variable stall_probability_percent : natural;
+    variable previous_inactive_policy : inactive_bus_policy_t := 'X';
+    variable loop_count : natural := 0;
+
+    impure function select_policy(
+      modified_signal, signal_to_check : axi_stream_signal_t;
+      current_inactive_policy, previous_inactive_policy : inactive_bus_policy_t
+    ) return inactive_bus_policy_t is
+    begin
+      if signal_to_check >= modified_signal then
+        return current_inactive_policy;
+      end if;
+
+      return previous_inactive_policy;
+    end;
 
     procedure get_axi_stream_transaction(variable axi_stream_transaction : out axi_stream_transaction_t) is
     begin
@@ -146,6 +151,37 @@ begin
       handle_axi_stream_transaction(msg_type, msg, axi_stream_transaction);
       check(is_already_handled(msg_type));
     end;
+
+    procedure check(inactive_data, packet_data : std_logic_vector; inactive_policy : inactive_bus_policy_t) is
+    begin
+      if inactive_policy = '0' then
+        check_equal(inactive_data, std_logic_vector'((inactive_data'range => '0')));
+      elsif inactive_policy = '1' then
+        check_equal(inactive_data, std_logic_vector'((inactive_data'range => '1')));
+      elsif inactive_policy = 'X' then
+        check_equal(inactive_data, std_logic_vector'((inactive_data'range => 'X')));
+      elsif inactive_policy = hold then
+        check_equal(inactive_data, packet_data);
+      else
+
+        check_failed;
+      end if;
+   end;
+
+    procedure check(inactive_data, packet_data : std_logic; inactive_policy : inactive_bus_policy_t) is
+    begin
+      if inactive_policy = '0' then
+        check_equal(inactive_data, '0');
+      elsif inactive_policy = '1' then
+        check_equal(inactive_data, '1');
+      elsif inactive_policy = 'X' then
+        check_equal(inactive_data, 'X');
+      elsif inactive_policy = hold then
+        check_equal(inactive_data, packet_data);
+      else
+        check_failed;
+      end if;
+   end;
 
   begin
     test_runner_setup(runner, runner_cfg);
@@ -432,8 +468,8 @@ begin
       -- Delay mocking the logger to prevent 'invalid checks' from failing the checks below
       wait until rising_edge (aclk) and tvalid = '1';
 
-      mocklogger := get_logger("check");
-      mock(mocklogger);
+      mock_logger := get_logger("check");
+      mock(mock_logger);
 
       if id'length > 0 then
         id := x"23";
@@ -447,27 +483,27 @@ begin
       check_axi_stream(net, slave_axi_stream, not data, tlast => '0', tkeep => not keep, tstrb => not strb, tid => id, tdest => dest,
                        tuser => user, msg => "checking axi stream");
 
-      check_log(mocklogger, "TDATA mismatch, checking axi stream - Got " &
+      check_log(mock_logger, "TDATA mismatch, checking axi stream - Got " &
                 to_nibble_string(data) & " (" & to_string(to_integer(data)) & "). Expected " &
                 to_nibble_string(not data) & " (" & to_string(to_integer(not data)) & ").", error);
-      check_log(mocklogger, "TKEEP mismatch, checking axi stream - Got " &
+      check_log(mock_logger, "TKEEP mismatch, checking axi stream - Got " &
                 to_nibble_string(keep) & " (" & to_string(to_integer(keep)) & "). Expected " &
                 to_nibble_string(not keep) & " (" & to_string(to_integer(not keep)) & ").", error);
-      check_log(mocklogger, "TSTRB mismatch, checking axi stream - Got " &
+      check_log(mock_logger, "TSTRB mismatch, checking axi stream - Got " &
                 to_nibble_string(strb) & " (" & to_string(to_integer(strb)) & "). Expected " &
                 to_nibble_string(not strb) & " (" & to_string(to_integer(not strb)) & ").", error);
-      check_log(mocklogger, "TLAST mismatch, checking axi stream - Got 1. Expected 0.", error);
+      check_log(mock_logger, "TLAST mismatch, checking axi stream - Got 1. Expected 0.", error);
       if id'length > 0 then
-        check_log(mocklogger, "TID mismatch, checking axi stream - Got 0010_0010 (34). Expected 0010_0011 (35).", error);
+        check_log(mock_logger, "TID mismatch, checking axi stream - Got 0010_0010 (34). Expected 0010_0011 (35).", error);
       end if;
       if dest'length > 0 then
-        check_log(mocklogger, "TDEST mismatch, checking axi stream - Got 0011_0011 (51). Expected 0011_0100 (52).", error);
+        check_log(mock_logger, "TDEST mismatch, checking axi stream - Got 0011_0011 (51). Expected 0011_0100 (52).", error);
       end if;
       if user'length > 0 then
-        check_log(mocklogger, "TUSER mismatch, checking axi stream - Got 0100_0100 (68). Expected 0100_0101 (69).", error);
+        check_log(mock_logger, "TUSER mismatch, checking axi stream - Got 0100_0100 (68). Expected 0100_0101 (69).", error);
       end if;
 
-      unmock(mocklogger);
+      unmock(mock_logger);
 
     elsif run("test back-to-back passing check") then
       keep := (others => '1');
@@ -581,38 +617,45 @@ begin
 
       wait until rising_edge(aclk);
       wait for 1 ps;
-      mocklogger := get_logger("check");
-      mock(mocklogger);
+      mock_logger := get_logger("check");
+      mock(mock_logger);
 
       wait until rising_edge(aclk) and tvalid = '1';
       wait for 1 ps;
 
-      check_log(mocklogger, "TDATA mismatch, check non-blocking - Got " &
+      check_log(mock_logger, "TDATA mismatch, check non-blocking - Got " &
                 to_nibble_string(data) & " (" & to_string(to_integer(data)) & "). Expected " &
                 to_nibble_string(not data) & " (" & to_string(to_integer(not data)) & ").", error);
-      check_log(mocklogger, "TKEEP mismatch, check non-blocking - Got " &
+      check_log(mock_logger, "TKEEP mismatch, check non-blocking - Got " &
                 to_nibble_string(keep) & " (" & to_string(to_integer(keep)) & "). Expected " &
                 to_nibble_string(not keep) & " (" & to_string(to_integer(not keep)) & ").", error);
-      check_log(mocklogger, "TSTRB mismatch, check non-blocking - Got " &
+      check_log(mock_logger, "TSTRB mismatch, check non-blocking - Got " &
                 to_nibble_string(keep) & " (" & to_string(to_integer(keep)) & "). Expected " &
                 to_nibble_string(not keep) & " (" & to_string(to_integer(not keep)) & ").", error);
-      check_log(mocklogger, "TLAST mismatch, check non-blocking - Got 1. Expected 0.", error);
+      check_log(mock_logger, "TLAST mismatch, check non-blocking - Got 1. Expected 0.", error);
       if id'length > 0 then
-        check_log(mocklogger, "TID mismatch, check non-blocking - Got 0010_1010 (42). Expected 0010_1100 (44).", error);
+        check_log(mock_logger, "TID mismatch, check non-blocking - Got 0010_1010 (42). Expected 0010_1100 (44).", error);
       end if;
       if dest'length > 0 then
-        check_log(mocklogger, "TDEST mismatch, check non-blocking - Got 0000_0100 (4). Expected 0000_0101 (5).", error);
+        check_log(mock_logger, "TDEST mismatch, check non-blocking - Got 0000_0100 (4). Expected 0000_0101 (5).", error);
       end if;
       if user'length > 0 then
-        check_log(mocklogger, "TUSER mismatch, check non-blocking - Got 0000_0111 (7). Expected 0000_1000 (8).", error);
+        check_log(mock_logger, "TUSER mismatch, check non-blocking - Got 0000_0111 (7). Expected 0000_1000 (8).", error);
       end if;
 
-      unmock(mocklogger);
+      unmock(mock_logger);
 
       check_equal(now, timestamp + 20 ns + 1 ps, " transaction time incorrect");
 
     elsif run("test random stall on master") or run("test random pop stall on slave") then
       wait until rising_edge(aclk);
+      stall_probability_percent := 30;
+      stall_config := new_stall_config(real(stall_probability_percent) / 100.0, min_stall_cycles, max_stall_cycles);
+      if running_test_case = "test random stall on master" then
+        set_stall_config(net, master_axi_stream, stall_config);
+      else
+        set_stall_config(net, slave_axi_stream, stall_config);
+      end if;
       for i in 0 to 100 loop
         pop_stream(net, slave_stream, reference);
         push(reference_queue, reference);
@@ -633,17 +676,20 @@ begin
       info("Min stall length was " & to_string(axis_stall_stats.valid.min));
       info("Max stall length was " & to_string(axis_stall_stats.valid.max));
       if running_test_case = "test random stall on master" then
-        check((axis_stall_stats.valid.events < (g_stall_percentage_master+10)) and (axis_stall_stats.valid.events > (g_stall_percentage_master-10)), "Checking that the tvalid stall probability lies within reasonable boundaries");
-        check((axis_stall_stats.valid.min >= min_stall_cycles) and (axis_stall_stats.valid.max <= max_stall_cycles), "Checking that the minimal and maximal stall lenghts are in expected boundaries");
+        check((axis_stall_stats.valid.events < (stall_probability_percent+10)) and (axis_stall_stats.valid.events > (stall_probability_percent-10)), "Checking that the tvalid stall probability lies within reasonable boundaries");
+        check((axis_stall_stats.valid.min >= min_stall_cycles) and (axis_stall_stats.valid.max <= max_stall_cycles), "Checking that the minimal and maximal stall lengths are in expected boundaries");
         check_equal(axis_stall_stats.ready.events, 0, "Checking that there are zero tready stall events");
       else
-        check((axis_stall_stats.ready.events < (g_stall_percentage_slave+10)) and (axis_stall_stats.ready.events > (g_stall_percentage_slave-10)), "Checking that the tready stall probability lies within reasonable boundaries");
-        check((axis_stall_stats.ready.min >= min_stall_cycles) and (axis_stall_stats.ready.max <= max_stall_cycles), "Checking that the minimal and maximal stall lenghts are in expected boundaries");
+        check((axis_stall_stats.ready.events < (stall_probability_percent+10)) and (axis_stall_stats.ready.events > (stall_probability_percent-10)), "Checking that the tready stall probability lies within reasonable boundaries");
+        check((axis_stall_stats.ready.min >= min_stall_cycles) and (axis_stall_stats.ready.max <= max_stall_cycles), "Checking that the minimal and maximal stall lengths are in expected boundaries");
         check_equal(axis_stall_stats.valid.events, 0, "Checking that there are zero tvalid stall events");
       end if;
 
     elsif run("test random check stall on slave") then
       wait until rising_edge(aclk);
+      stall_probability_percent := 40;
+      stall_config := new_stall_config(real(stall_probability_percent) / 100.0, min_stall_cycles, max_stall_cycles);
+      set_stall_config(net, slave_axi_stream, stall_config);
       for i in 0 to 100 loop
         check_axi_stream(net, slave_axi_stream, std_logic_vector(to_unsigned(i + 1, data'length)), blocking => false);
       end loop;
@@ -657,12 +703,125 @@ begin
       info("There have been " & to_string(axis_stall_stats.valid.events) & " tvalid stall events");
       info("Min stall length was " & to_string(axis_stall_stats.valid.min));
       info("Max stall length was " & to_string(axis_stall_stats.valid.max));
-      check((axis_stall_stats.ready.events < (g_stall_percentage_slave+10)) and (axis_stall_stats.ready.events > (g_stall_percentage_slave-10)), "Checking that the tready stall probability lies within reasonable boundaries");
-      check((axis_stall_stats.ready.min >= min_stall_cycles) and (axis_stall_stats.ready.max <= max_stall_cycles), "Checking that the minimal and maximal stall lenghts are in expected boundaries");
+      check((axis_stall_stats.ready.events < (stall_probability_percent+10)) and (axis_stall_stats.ready.events > (stall_probability_percent-10)), "Checking that the tready stall probability lies within reasonable boundaries");
+      check((axis_stall_stats.ready.min >= min_stall_cycles) and (axis_stall_stats.ready.max <= max_stall_cycles), "Checking that the minimal and maximal stall lengths are in expected boundaries");
       check_equal(axis_stall_stats.valid.events, 0, "Checking that there are zero tvalid stall events");
 
+    elsif run("test signal inactive bus policy") then
+      -- tuser is not allowed to be X when not in reset but the capability is tested for completeness.
+      disable(get_logger("protocol_checker:rule 10"), error);
+      disable(get_logger("monitor:rule 10"), error);
+      disable(get_logger("master:rule 10"), error);
+      disable(get_logger("slave:rule 10"), error);
+      for inactive_policy in inactive_bus_policy_t'left to inactive_bus_policy_t'right loop
+        for axi_stream_signal in work.axi_stream_pkg.tuser downto work.axi_stream_pkg.tdata loop
+          set_inactive_axi_stream_policy(net, master_axi_stream, inactive_policy, axi_stream_signal);
+
+          axi_stream_transaction := (tdata => x"99", tlast => true, tkeep => "1", tstrb => "1", tid => x"11", tdest => x"22", tuser => x"33");
+          last := '1' when axi_stream_transaction.tlast else '0';
+          push_axi_stream(
+            net,
+            master_axi_stream,
+            tdata => axi_stream_transaction.tdata,
+            tlast => last,
+            tkeep => axi_stream_transaction.tkeep,
+            tstrb => axi_stream_transaction.tstrb,
+            tid => axi_stream_transaction.tid,
+            tdest => axi_stream_transaction.tdest,
+            tuser => axi_stream_transaction.tuser
+          );
+
+          pop_axi_stream(net, slave_axi_stream, data, last, keep, strb, id, dest, user);
+          wait until rising_edge(aclk);
+          for sig in work.axi_stream_pkg.tdata to  work.axi_stream_pkg.tuser loop
+            case sig is
+              when work.axi_stream_pkg.tdata =>
+                check(
+                  tdata,
+                  axi_stream_transaction.tdata, select_policy(axi_stream_signal, work.axi_stream_pkg.tdata, inactive_policy, previous_inactive_policy)
+                );
+              when work.axi_stream_pkg.tlast =>
+                check(
+                  tlast,
+                  last, select_policy(axi_stream_signal, work.axi_stream_pkg.tlast, inactive_policy, previous_inactive_policy)
+                );
+              when work.axi_stream_pkg.tkeep =>
+                check(
+                  tkeep,
+                  axi_stream_transaction.tkeep, select_policy(axi_stream_signal, work.axi_stream_pkg.tkeep, inactive_policy, previous_inactive_policy)
+                );
+              when work.axi_stream_pkg.tstrb =>
+                check(
+                  tstrb,
+                  axi_stream_transaction.tstrb, select_policy(axi_stream_signal, work.axi_stream_pkg.tstrb, inactive_policy, previous_inactive_policy)
+                );
+              when work.axi_stream_pkg.tid =>
+                check(
+                  tid,
+                  axi_stream_transaction.tid, select_policy(axi_stream_signal, work.axi_stream_pkg.tid, inactive_policy, previous_inactive_policy)
+                );
+              when work.axi_stream_pkg.tdest =>
+                check(
+                  tdest,
+                  axi_stream_transaction.tdest, select_policy(axi_stream_signal, work.axi_stream_pkg.tdest, inactive_policy, previous_inactive_policy)
+                );
+              when work.axi_stream_pkg.tuser =>
+                check(
+                  tuser,
+                  axi_stream_transaction.tuser, select_policy(axi_stream_signal, work.axi_stream_pkg.tuser, inactive_policy, previous_inactive_policy)
+                );
+            end case;
+            loop_count := loop_count + 1;
+          end loop;
+        end loop;
+        previous_inactive_policy := inactive_policy;
+      end loop;
+      check_equal(loop_count, 4 * 7 * 7);
+
+    elsif run("test global inactive bus policy") then
+      for inactive_policy in inactive_bus_policy_t'('0') to inactive_bus_policy_t'('1') loop
+
+        set_inactive_axi_stream_policy(net, master_axi_stream, inactive_policy);
+
+        axi_stream_transaction := (tdata => x"99", tlast => true, tkeep => "1", tstrb => "1", tid => x"11", tdest => x"22", tuser => x"33");
+        last := '1' when axi_stream_transaction.tlast else '0';
+        push_axi_stream(
+          net,
+          master_axi_stream,
+          tdata => axi_stream_transaction.tdata,
+          tlast => last,
+          tkeep => axi_stream_transaction.tkeep,
+          tstrb => axi_stream_transaction.tstrb,
+          tid => axi_stream_transaction.tid,
+          tdest => axi_stream_transaction.tdest,
+          tuser => axi_stream_transaction.tuser
+        );
+
+        pop_axi_stream(net, slave_axi_stream, data, last, keep, strb, id, dest, user);
+        wait until rising_edge(aclk);
+        for sig in work.axi_stream_pkg.tdata to  work.axi_stream_pkg.tuser loop
+          case sig is
+            when work.axi_stream_pkg.tdata =>
+              check(tdata, "", inactive_policy);
+            when work.axi_stream_pkg.tlast =>
+              check(tlast, '-', inactive_policy);
+            when work.axi_stream_pkg.tkeep =>
+              check(tkeep, "", inactive_policy);
+            when work.axi_stream_pkg.tstrb =>
+              check(tstrb, "", inactive_policy);
+            when work.axi_stream_pkg.tid =>
+              check(tid, "", inactive_policy);
+            when work.axi_stream_pkg.tdest =>
+              check(tdest, "", inactive_policy);
+            when work.axi_stream_pkg.tuser =>
+              check(tuser, "", inactive_policy);
+          end case;
+          loop_count := loop_count + 1;
+        end loop;
+      end loop;
+      check_equal(loop_count, 2 * 7);
     end if;
-    test_runner_cleanup(runner);
+    test_runner_cleanup(runner, allow_disabled_errors => running_test_case = "test signal inactive bus policy");
   end process;
   test_runner_watchdog(runner, 10 ms);
 
@@ -684,27 +843,6 @@ begin
 
   tkeep <= tkeep_from_master when connected_tkeep else (others => '1');
   tstrb <= tstrb_from_master when connected_tstrb else (others => 'U');
-
- not_valid <= not tvalid;
-
- not_valid_data <= '1' when is_x(tdata) else '0';
- check_true(aclk, not_valid, not_valid_data, "Invalid data not X");
- not_valid_keep <= '1' when is_x(tkeep_from_master) else '0';
- check_true(aclk, not_valid, not_valid_keep, "Invalid keep not X");
- not_valid_strb <= '1' when is_x(tstrb_from_master) else '0';
- check_true(aclk, not_valid, not_valid_strb, "Invalid strb not X");
- GEN_CHECK_INVALID_ID: if g_id_length > 0 generate
-   not_valid_id   <= '1' when is_x(tid) else '0';
-   check_true(aclk, not_valid, not_valid_id,   "Invalid id not X");
- end generate;
- GEN_CHECK_INVALID_DEST: if g_dest_length > 0 generate
-   not_valid_dest <= '1' when is_x(tdest) else '0';
-   check_true(aclk, not_valid, not_valid_dest, "Invalid dest not X");
- end generate;
- GEN_CHECK_INVALID_USER: if g_user_length > 0 generate
-   not_valid_user <= '1' when tuser = std_logic_vector'("00000000") else '0';
-   check_true(aclk, not_valid, not_valid_user, "Invalid user not 0");
- end generate;
 
   axi_stream_slave_inst : entity work.axi_stream_slave
     generic map(
@@ -771,7 +909,7 @@ begin
       end if;
 
       -------------------------------------------------------------------------
-      -- TVALID Minmal and Maximal Stall lengths
+      -- TVALID Minimal and Maximal Stall lengths
       if tvalid then
         axis_stall_stats.valid.start <= '1';
       end if;
@@ -785,7 +923,7 @@ begin
         axis_stall_stats.valid.max <= maximum(axis_stall_stats.valid.length, axis_stall_stats.valid.max);
       end if;
       -------------------------------------------------------------------------
-      -- TREADY Minmal and Maximal Stall lengths
+      -- TREADY Minimal and Maximal Stall lengths
       if tready then
         axis_stall_stats.ready.start <= '1';
       end if;

--- a/vunit/vhdl/verification_components/test/tb_axi_stream.vhd
+++ b/vunit/vhdl/verification_components/test/tb_axi_stream.vhd
@@ -906,8 +906,7 @@ begin
 
   axi_stream_master_inst : entity work.axi_stream_master
     generic map(
-      master => master_axi_stream,
-      drive_invalid => false
+      master => master_axi_stream
     )
     port map(
       aclk     => aclk,

--- a/vunit/vhdl/verification_components/test/tb_axi_stream.vhd
+++ b/vunit/vhdl/verification_components/test/tb_axi_stream.vhd
@@ -20,6 +20,7 @@ use work.sync_pkg.all;
 
 library osvvm;
 use osvvm.RandomPkg.all;
+use osvvm.CoveragePkg.all;
 
 entity tb_axi_stream is
   generic(
@@ -133,6 +134,7 @@ begin
     variable previous_inactive_policy : inactive_bus_policy_t := 'X';
     variable inactive_policy_read_back : inactive_bus_policy_t;
     variable loop_count : natural := 0;
+    variable cov : CoverageIDType;
 
     impure function select_policy(
       modified_signal, signal_to_check : axi_stream_signal_t;
@@ -154,33 +156,86 @@ begin
       check(is_already_handled(msg_type));
     end;
 
-    procedure check(inactive_data, packet_data : std_logic_vector; inactive_policy : inactive_bus_policy_t) is
+    function to_sl(policy : inactive_bus_policy_t) return std_logic is
     begin
-      if inactive_policy = '0' then
-        check_equal(inactive_data, std_logic_vector'((inactive_data'range => '0')));
-      elsif inactive_policy = '1' then
-        check_equal(inactive_data, std_logic_vector'((inactive_data'range => '1')));
-      elsif inactive_policy = 'X' then
-        check_equal(inactive_data, std_logic_vector'((inactive_data'range => 'X')));
-      elsif inactive_policy = hold then
+      if policy = '0' then
+        return '0';
+      elsif policy = '1' then
+        return '1';
+      elsif policy = 'X' then
+        return 'X';
+      end if;
+
+      check_failed("Cannot convert inactive_bus_policy " & inactive_bus_policy_t'image(policy) & " to std_logic.");
+      return 'U';
+    end;
+
+    procedure check(
+      add_to_coverage : boolean;
+      inactive_data, packet_data : std_logic;
+      inactive_policy : inactive_bus_policy_t
+    ) is
+    begin
+      if inactive_policy = hold then
         check_equal(inactive_data, packet_data);
+      elsif inactive_policy = rand01 then
+        check_not_unknown(inactive_data);
       else
-        check_failed;
+        check_equal(inactive_data, to_sl(inactive_policy));
+      end if;
+
+      if add_to_coverage then
+        if inactive_policy = rand01 then
+          -- Randomized bits should cover '0' (bin 0) and '1' (bin 1).
+          ICover(cov, to_integer(inactive_data));
+        else
+          -- Non-randomized bits are immediately covered.
+          ICover(cov, 0);
+          ICover(cov, 1);
+        end if;
       end if;
     end;
 
-    procedure check(inactive_data, packet_data : std_logic; inactive_policy : inactive_bus_policy_t) is
+    procedure check(
+      add_to_coverage : boolean;
+      inactive_data, packet_data : std_logic_vector;
+      inactive_policy : inactive_bus_policy_t
+    ) is
     begin
-      if inactive_policy = '0' then
-        check_equal(inactive_data, '0');
-      elsif inactive_policy = '1' then
-        check_equal(inactive_data, '1');
-      elsif inactive_policy = 'X' then
-        check_equal(inactive_data, 'X');
-      elsif inactive_policy = hold then
+      if inactive_data'length = 1 then
+        check(
+          add_to_coverage,
+          inactive_data(inactive_data'left),
+          packet_data(packet_data'left),
+          inactive_policy
+        );
+        return;
+      end if;
+
+      if inactive_policy = hold then
         check_equal(inactive_data, packet_data);
+      elsif inactive_policy = rand01 then
+        check_not_unknown(inactive_data);
       else
-        check_failed;
+        check_equal(inactive_data, std_logic_vector'((inactive_data'range => to_sl(inactive_policy))));
+      end if;
+
+      if add_to_coverage then
+        if inactive_policy = rand01 then
+          -- Randomized vectors should cover values whose bits are not all the same (bin 0), and
+          -- not the packet data (bin 1).
+          if inactive_data /= (inactive_data'range => '0') and inactive_data /= (inactive_data'range => '1') then
+            ICover(cov, 0);
+          end if;
+
+          if inactive_data /= packet_data then
+            ICover(cov, 1);
+          end if;
+        else
+          -- Non-randomized vectors are immediately covered.
+          ICover(cov, 0);
+          ICover(cov, 1);
+        end if;
       end if;
     end;
 
@@ -777,6 +832,7 @@ begin
       disable(get_logger("monitor:rule 10"), error);
       disable(get_logger("master:rule 10"), error);
       disable(get_logger("slave:rule 10"), error);
+
       for inactive_policy in inactive_bus_policy_t'left to inactive_bus_policy_t'right loop
         for axi_stream_signal in work.axi_stream_pkg.tuser downto work.axi_stream_pkg.tdata loop
           set_inactive_axi_stream_policy(net, master_axi_stream, inactive_policy, axi_stream_signal);
@@ -788,71 +844,76 @@ begin
             tid => x"11", tdest => x"22", tuser => x"33"
           );
           last := '1' when axi_stream_transaction.tlast else '0';
-          push_axi_stream(
-            net,
-            master_axi_stream,
-            tdata => axi_stream_transaction.tdata,
-            tlast => last,
-            tkeep => axi_stream_transaction.tkeep,
-            tstrb => axi_stream_transaction.tstrb,
-            tid => axi_stream_transaction.tid,
-            tdest => axi_stream_transaction.tdest,
-            tuser => axi_stream_transaction.tuser
-          );
 
-          pop_axi_stream(net, slave_axi_stream, data, last, keep, strb, id, dest, user);
-          wait until rising_edge(aclk);
-          for sig in work.axi_stream_pkg.tdata to  work.axi_stream_pkg.tuser loop
-            case sig is
-              when work.axi_stream_pkg.tdata =>
-                check(
-                  tdata,
-                  axi_stream_transaction.tdata,
-                  select_policy(axi_stream_signal, work.axi_stream_pkg.tdata, inactive_policy, previous_inactive_policy)
-                );
-              when work.axi_stream_pkg.tlast =>
-                check(
-                  tlast,
-                  last,
-                  select_policy(axi_stream_signal, work.axi_stream_pkg.tlast, inactive_policy, previous_inactive_policy)
-                );
-              when work.axi_stream_pkg.tkeep =>
-                check(
-                  tkeep,
-                  axi_stream_transaction.tkeep,
-                  select_policy(axi_stream_signal, work.axi_stream_pkg.tkeep, inactive_policy, previous_inactive_policy)
-                );
-              when work.axi_stream_pkg.tstrb =>
-                check(
-                  tstrb,
-                  axi_stream_transaction.tstrb,
-                  select_policy(axi_stream_signal, work.axi_stream_pkg.tstrb, inactive_policy, previous_inactive_policy)
-                );
-              when work.axi_stream_pkg.tid =>
-                check(
-                  tid,
-                  axi_stream_transaction.tid,
-                  select_policy(axi_stream_signal, work.axi_stream_pkg.tid, inactive_policy, previous_inactive_policy)
-                );
-              when work.axi_stream_pkg.tdest =>
-                check(
-                  tdest,
-                  axi_stream_transaction.tdest,
-                  select_policy(axi_stream_signal, work.axi_stream_pkg.tdest, inactive_policy, previous_inactive_policy)
-                );
-              when work.axi_stream_pkg.tuser =>
-                check(
-                  tuser,
-                  axi_stream_transaction.tuser,
-                  select_policy(axi_stream_signal, work.axi_stream_pkg.tuser, inactive_policy, previous_inactive_policy)
-                );
-            end case;
-            loop_count := loop_count + 1;
+          cov := NewID(
+            axi_stream_signal_t'image(axi_stream_signal) & "_" &
+            inactive_bus_policy_t'image(inactive_policy)
+          );
+          AddBins(cov,  GenBin(0,1));
+
+          while not IsCovered(cov) loop
+            push_axi_stream(
+              net,
+              master_axi_stream,
+              tdata => axi_stream_transaction.tdata,
+              tlast => last,
+              tkeep => axi_stream_transaction.tkeep,
+              tstrb => axi_stream_transaction.tstrb,
+              tid => axi_stream_transaction.tid,
+              tdest => axi_stream_transaction.tdest,
+              tuser => axi_stream_transaction.tuser
+            );
+            pop_axi_stream(net, slave_axi_stream, data, last, keep, strb, id, dest, user);
+            wait until rising_edge(aclk);
+
+            check(
+              axi_stream_signal = work.axi_stream_pkg.tdata,
+              tdata,
+              axi_stream_transaction.tdata,
+              select_policy(axi_stream_signal, work.axi_stream_pkg.tdata, inactive_policy, previous_inactive_policy)
+            );
+            check(
+              axi_stream_signal = work.axi_stream_pkg.tlast,
+              tlast,
+              last,
+              select_policy(axi_stream_signal, work.axi_stream_pkg.tlast, inactive_policy, previous_inactive_policy)
+            );
+            check(
+              axi_stream_signal = work.axi_stream_pkg.tkeep,
+              tkeep,
+              axi_stream_transaction.tkeep,
+              select_policy(axi_stream_signal, work.axi_stream_pkg.tkeep, inactive_policy, previous_inactive_policy)
+            );
+            check(
+              axi_stream_signal = work.axi_stream_pkg.tstrb,
+              tstrb,
+              axi_stream_transaction.tstrb,
+              select_policy(axi_stream_signal, work.axi_stream_pkg.tstrb, inactive_policy, previous_inactive_policy)
+            );
+            check(
+              axi_stream_signal = work.axi_stream_pkg.tid,
+              tid,
+              axi_stream_transaction.tid,
+              select_policy(axi_stream_signal, work.axi_stream_pkg.tid, inactive_policy, previous_inactive_policy)
+            );
+            check(
+              axi_stream_signal = work.axi_stream_pkg.tdest,
+              tdest,
+              axi_stream_transaction.tdest,
+              select_policy(axi_stream_signal, work.axi_stream_pkg.tdest, inactive_policy, previous_inactive_policy)
+            );
+            check(
+              axi_stream_signal = work.axi_stream_pkg.tuser,
+              tuser,
+              axi_stream_transaction.tuser,
+              select_policy(axi_stream_signal, work.axi_stream_pkg.tuser, inactive_policy, previous_inactive_policy)
+            );
           end loop;
+          loop_count := loop_count + 1;
         end loop;
         previous_inactive_policy := inactive_policy;
       end loop;
-      check_equal(loop_count, 4 * 7 * 7);
+      check_equal(loop_count, 5 * 7);
 
     elsif run("test global inactive bus policy") then
       for inactive_policy in inactive_bus_policy_t'('0') to inactive_bus_policy_t'('1') loop
@@ -878,27 +939,16 @@ begin
 
         pop_axi_stream(net, slave_axi_stream, data, last, keep, strb, id, dest, user);
         wait until rising_edge(aclk);
-        for sig in work.axi_stream_pkg.tdata to  work.axi_stream_pkg.tuser loop
-          case sig is
-            when work.axi_stream_pkg.tdata =>
-              check(tdata, "", inactive_policy);
-            when work.axi_stream_pkg.tlast =>
-              check(tlast, '-', inactive_policy);
-            when work.axi_stream_pkg.tkeep =>
-              check(tkeep, "", inactive_policy);
-            when work.axi_stream_pkg.tstrb =>
-              check(tstrb, "", inactive_policy);
-            when work.axi_stream_pkg.tid =>
-              check(tid, "", inactive_policy);
-            when work.axi_stream_pkg.tdest =>
-              check(tdest, "", inactive_policy);
-            when work.axi_stream_pkg.tuser =>
-              check(tuser, "", inactive_policy);
-          end case;
-          loop_count := loop_count + 1;
-        end loop;
+        check(false, tdata, "-", inactive_policy);
+        check(false, tlast, '-', inactive_policy);
+        check(false, tkeep, "-", inactive_policy);
+        check(false, tstrb, "-", inactive_policy);
+        check(false, tid, "-", inactive_policy);
+        check(false, tdest, "-", inactive_policy);
+        check(false, tuser, "-", inactive_policy);
+        loop_count := loop_count + 1;
       end loop;
-      check_equal(loop_count, 2 * 7);
+      check_equal(loop_count, 2);
     end if;
     test_runner_cleanup(runner, allow_disabled_errors => running_test_case = "test signal inactive bus policy");
   end process;

--- a/vunit/vhdl/verification_components/test/tb_axi_stream.vhd
+++ b/vunit/vhdl/verification_components/test/tb_axi_stream.vhd
@@ -163,10 +163,9 @@ begin
       elsif inactive_policy = hold then
         check_equal(inactive_data, packet_data);
       else
-
         check_failed;
       end if;
-   end;
+    end;
 
     procedure check(inactive_data, packet_data : std_logic; inactive_policy : inactive_bus_policy_t) is
     begin
@@ -181,7 +180,7 @@ begin
       else
         check_failed;
       end if;
-   end;
+    end;
 
   begin
     test_runner_setup(runner, runner_cfg);
@@ -247,7 +246,10 @@ begin
       check_equal(last, '1', result("pop stream last"));
 
     elsif run("test single axi push and axi pop") then
-      push_axi_stream(net, master_axi_stream, x"99", tlast => '1', tkeep => "1", tstrb => "1", tid => x"11", tdest => x"22", tuser => x"33" );
+      push_axi_stream(
+        net, master_axi_stream, x"99", tlast => '1', tkeep => "1",
+        tstrb => "1", tid => x"11", tdest => x"22", tuser => x"33"
+      );
       pop_axi_stream(net, slave_axi_stream, data, last, keep, strb, id, dest, user);
       check_equal(data, std_logic_vector'(x"99"), result("pop axi stream data"));
       check_equal(last, std_logic'('1'), result("pop stream last"));
@@ -272,8 +274,9 @@ begin
       for iter in 1 to 2 loop
         connected_tstrb <= false;
         connected_tkeep <= iter = 1;
-        if iter = 1 then
-          push_axi_stream(net, master_axi_stream, x"99", tlast => '1', tkeep => "1", tid => x"11", tdest => x"22", tuser => x"33" );
+        if iter = 1 then push_axi_stream(
+          net, master_axi_stream, x"99", tlast => '1', tkeep => "1", tid => x"11", tdest => x"22", tuser => x"33"
+        );
         else
           push_axi_stream(net, master_axi_stream, x"99", tlast => '1', tid => x"11", tdest => x"22", tuser => x"33" );
         end if;
@@ -288,7 +291,9 @@ begin
 
         for i in 1 to n_monitors loop
           get_axi_stream_transaction(axi_stream_transaction);
-          check_equal(axi_stream_transaction.tdata, std_logic_vector'(x"99"), result("for axi_stream_transaction.tdata"));
+          check_equal(
+            axi_stream_transaction.tdata, std_logic_vector'(x"99"), result("for axi_stream_transaction.tdata")
+          );
           check_true(axi_stream_transaction.tlast, result("for axi_stream_transaction.tlast"));
           check_equal(axi_stream_transaction.tkeep, std_logic_vector'("1"), result("pop stream keep"));
           check_equal(axi_stream_transaction.tstrb, std_logic_vector'("1"), result("pop stream strb"));
@@ -306,7 +311,8 @@ begin
       pop_stream(net, slave_stream, data, last_bool);
       check_equal(data, std_logic_vector'(x"77"), result("for pop stream data"));
       check_true(last_bool, result("for pop stream last"));
-      check_equal(now - 10 ns, timestamp + 50 ns, result("for push wait time"));  -- two extra cycles inserted by alignment
+      -- Two extra cycles inserted by alignment
+      check_equal(now - 10 ns, timestamp + 50 ns, result("for push wait time"));
       for i in 1 to n_monitors loop
         get_axi_stream_transaction(axi_stream_transaction);
         check_equal(
@@ -417,9 +423,14 @@ begin
       if user'length > 0 then
         user := x"45";
       end if;
-      push_axi_stream(net, master_axi_stream, data, tlast => '1', tkeep => keep, tstrb => strb, tid => id, tdest => dest, tuser => user);
-      check_axi_stream(net, slave_axi_stream, data, tlast => '1', tkeep => keep, tstrb => strb, tid => id, tdest => dest, tuser => user,
-                       msg => "checking axi stream");
+      push_axi_stream(
+        net, master_axi_stream, data, tlast => '1', tkeep => keep,
+        tstrb => strb, tid => id, tdest => dest, tuser => user
+      );
+      check_axi_stream(
+        net, slave_axi_stream, data, tlast => '1', tkeep => keep, tstrb => strb,
+        tid => id, tdest => dest, tuser => user, msg => "checking axi stream"
+      );
 
     elsif run("test passing reduced check") then
       data := rnd.RandSlv(data'length);
@@ -434,7 +445,10 @@ begin
       if user'length > 0 then
         user := x"45";
       end if;
-      push_axi_stream(net, master_axi_stream, data, tlast => '1', tkeep => keep, tstrb => strb, tid => id, tdest => dest, tuser => user);
+      push_axi_stream(
+        net, master_axi_stream, data, tlast => '1', tkeep => keep,
+        tstrb => strb, tid => id, tdest => dest, tuser => user
+      );
       check_axi_stream(net, slave_axi_stream, data, tlast => '1', msg => "reduced checking axi stream");
 
     elsif run("test passing with no tkeep") then
@@ -445,9 +459,14 @@ begin
         id := x"23";
         dest := x"34";
         user := x"45";
-        push_axi_stream(net, master_axi_stream, data, tlast => '1', tkeep => keep, tstrb => strb, tid => id, tdest => dest, tuser => user);
-        check_axi_stream(net, slave_axi_stream, data xor x"00ff", tlast => '1', tkeep => keep, tstrb => strb, tid => id, tdest => dest,
-                         tuser => user, msg => "checking axi stream", blocking => blocking);
+        push_axi_stream(
+          net, master_axi_stream, data, tlast => '1', tkeep => keep,
+          tstrb => strb, tid => id, tdest => dest, tuser => user
+        );
+        check_axi_stream(
+          net, slave_axi_stream, data xor x"00ff", tlast => '1', tkeep => keep, tstrb => strb,
+          tid => id, tdest => dest, tuser => user, msg => "checking axi stream", blocking => blocking
+        );
       end loop;
       wait_until_idle(net, as_sync(slave_axi_stream));
 
@@ -464,7 +483,10 @@ begin
       if user'length > 0 then
         user := x"44";
       end if;
-      push_axi_stream(net, master_axi_stream, data, tlast => '1', tkeep => keep, tstrb => strb, tid => id, tdest => dest, tuser => user);
+      push_axi_stream(
+        net, master_axi_stream, data, tlast => '1', tkeep => keep,
+        tstrb => strb, tid => id, tdest => dest, tuser => user
+      );
       -- Delay mocking the logger to prevent 'invalid checks' from failing the checks below
       wait until rising_edge (aclk) and tvalid = '1';
 
@@ -480,8 +502,9 @@ begin
       if user'length > 0 then
         user := x"45";
       end if;
-      check_axi_stream(net, slave_axi_stream, not data, tlast => '0', tkeep => not keep, tstrb => not strb, tid => id, tdest => dest,
-                       tuser => user, msg => "checking axi stream");
+      check_axi_stream(
+        net, slave_axi_stream, not data, tlast => '0', tkeep => not keep, tstrb => not strb,
+        tid => id, tdest => dest, tuser => user, msg => "checking axi stream");
 
       check_log(mock_logger, "TDATA mismatch, checking axi stream - Got " &
                 to_nibble_string(data) & " (" & to_string(to_integer(data)) & "). Expected " &
@@ -494,13 +517,19 @@ begin
                 to_nibble_string(not strb) & " (" & to_string(to_integer(not strb)) & ").", error);
       check_log(mock_logger, "TLAST mismatch, checking axi stream - Got 1. Expected 0.", error);
       if id'length > 0 then
-        check_log(mock_logger, "TID mismatch, checking axi stream - Got 0010_0010 (34). Expected 0010_0011 (35).", error);
+        check_log(
+          mock_logger, "TID mismatch, checking axi stream - Got 0010_0010 (34). Expected 0010_0011 (35).", error
+        );
       end if;
       if dest'length > 0 then
-        check_log(mock_logger, "TDEST mismatch, checking axi stream - Got 0011_0011 (51). Expected 0011_0100 (52).", error);
+        check_log(
+          mock_logger, "TDEST mismatch, checking axi stream - Got 0011_0011 (51). Expected 0011_0100 (52).", error
+        );
       end if;
       if user'length > 0 then
-        check_log(mock_logger, "TUSER mismatch, checking axi stream - Got 0100_0100 (68). Expected 0100_0101 (69).", error);
+        check_log(
+          mock_logger, "TUSER mismatch, checking axi stream - Got 0100_0100 (68). Expected 0100_0101 (69).", error
+        );
       end if;
 
       unmock(mock_logger);
@@ -634,13 +663,19 @@ begin
                 to_nibble_string(not keep) & " (" & to_string(to_integer(not keep)) & ").", error);
       check_log(mock_logger, "TLAST mismatch, check non-blocking - Got 1. Expected 0.", error);
       if id'length > 0 then
-        check_log(mock_logger, "TID mismatch, check non-blocking - Got 0010_1010 (42). Expected 0010_1100 (44).", error);
+        check_log(
+          mock_logger, "TID mismatch, check non-blocking - Got 0010_1010 (42). Expected 0010_1100 (44).", error
+        );
       end if;
       if dest'length > 0 then
-        check_log(mock_logger, "TDEST mismatch, check non-blocking - Got 0000_0100 (4). Expected 0000_0101 (5).", error);
+        check_log(
+          mock_logger, "TDEST mismatch, check non-blocking - Got 0000_0100 (4). Expected 0000_0101 (5).", error
+        );
       end if;
       if user'length > 0 then
-        check_log(mock_logger, "TUSER mismatch, check non-blocking - Got 0000_0111 (7). Expected 0000_1000 (8).", error);
+        check_log(
+          mock_logger, "TUSER mismatch, check non-blocking - Got 0000_0111 (7). Expected 0000_1000 (8).", error
+        );
       end if;
 
       unmock(mock_logger);
@@ -676,12 +711,26 @@ begin
       info("Min stall length was " & to_string(axis_stall_stats.valid.min));
       info("Max stall length was " & to_string(axis_stall_stats.valid.max));
       if running_test_case = "test random stall on master" then
-        check((axis_stall_stats.valid.events < (stall_probability_percent+10)) and (axis_stall_stats.valid.events > (stall_probability_percent-10)), "Checking that the tvalid stall probability lies within reasonable boundaries");
-        check((axis_stall_stats.valid.min >= min_stall_cycles) and (axis_stall_stats.valid.max <= max_stall_cycles), "Checking that the minimal and maximal stall lengths are in expected boundaries");
+        check(
+          (axis_stall_stats.valid.events < (stall_probability_percent+10)) and
+          (axis_stall_stats.valid.events > (stall_probability_percent-10)),
+          "Checking that the tvalid stall probability lies within reasonable boundaries"
+        );
+        check(
+          (axis_stall_stats.valid.min >= min_stall_cycles) and (axis_stall_stats.valid.max <= max_stall_cycles),
+          "Checking that the minimal and maximal stall lengths are in expected boundaries"
+        );
         check_equal(axis_stall_stats.ready.events, 0, "Checking that there are zero tready stall events");
       else
-        check((axis_stall_stats.ready.events < (stall_probability_percent+10)) and (axis_stall_stats.ready.events > (stall_probability_percent-10)), "Checking that the tready stall probability lies within reasonable boundaries");
-        check((axis_stall_stats.ready.min >= min_stall_cycles) and (axis_stall_stats.ready.max <= max_stall_cycles), "Checking that the minimal and maximal stall lengths are in expected boundaries");
+        check(
+          (axis_stall_stats.ready.events < (stall_probability_percent+10)) and
+          (axis_stall_stats.ready.events > (stall_probability_percent-10)),
+          "Checking that the tready stall probability lies within reasonable boundaries"
+        );
+        check(
+          (axis_stall_stats.ready.min >= min_stall_cycles) and (axis_stall_stats.ready.max <= max_stall_cycles),
+          "Checking that the minimal and maximal stall lengths are in expected boundaries"
+        );
         check_equal(axis_stall_stats.valid.events, 0, "Checking that there are zero tvalid stall events");
       end if;
 
@@ -703,8 +752,15 @@ begin
       info("There have been " & to_string(axis_stall_stats.valid.events) & " tvalid stall events");
       info("Min stall length was " & to_string(axis_stall_stats.valid.min));
       info("Max stall length was " & to_string(axis_stall_stats.valid.max));
-      check((axis_stall_stats.ready.events < (stall_probability_percent+10)) and (axis_stall_stats.ready.events > (stall_probability_percent-10)), "Checking that the tready stall probability lies within reasonable boundaries");
-      check((axis_stall_stats.ready.min >= min_stall_cycles) and (axis_stall_stats.ready.max <= max_stall_cycles), "Checking that the minimal and maximal stall lengths are in expected boundaries");
+      check(
+        (axis_stall_stats.ready.events < (stall_probability_percent+10)) and
+        (axis_stall_stats.ready.events > (stall_probability_percent-10)),
+        "Checking that the tready stall probability lies within reasonable boundaries"
+      );
+      check(
+        (axis_stall_stats.ready.min >= min_stall_cycles) and (axis_stall_stats.ready.max <= max_stall_cycles),
+        "Checking that the minimal and maximal stall lengths are in expected boundaries"
+      );
       check_equal(axis_stall_stats.valid.events, 0, "Checking that there are zero tvalid stall events");
 
     elsif run("test signal inactive bus policy") then
@@ -717,7 +773,10 @@ begin
         for axi_stream_signal in work.axi_stream_pkg.tuser downto work.axi_stream_pkg.tdata loop
           set_inactive_axi_stream_policy(net, master_axi_stream, inactive_policy, axi_stream_signal);
 
-          axi_stream_transaction := (tdata => x"99", tlast => true, tkeep => "1", tstrb => "1", tid => x"11", tdest => x"22", tuser => x"33");
+          axi_stream_transaction := (
+            tdata => x"99", tlast => true, tkeep => "1", tstrb => "1",
+            tid => x"11", tdest => x"22", tuser => x"33"
+          );
           last := '1' when axi_stream_transaction.tlast else '0';
           push_axi_stream(
             net,
@@ -738,37 +797,44 @@ begin
               when work.axi_stream_pkg.tdata =>
                 check(
                   tdata,
-                  axi_stream_transaction.tdata, select_policy(axi_stream_signal, work.axi_stream_pkg.tdata, inactive_policy, previous_inactive_policy)
+                  axi_stream_transaction.tdata,
+                  select_policy(axi_stream_signal, work.axi_stream_pkg.tdata, inactive_policy, previous_inactive_policy)
                 );
               when work.axi_stream_pkg.tlast =>
                 check(
                   tlast,
-                  last, select_policy(axi_stream_signal, work.axi_stream_pkg.tlast, inactive_policy, previous_inactive_policy)
+                  last,
+                  select_policy(axi_stream_signal, work.axi_stream_pkg.tlast, inactive_policy, previous_inactive_policy)
                 );
               when work.axi_stream_pkg.tkeep =>
                 check(
                   tkeep,
-                  axi_stream_transaction.tkeep, select_policy(axi_stream_signal, work.axi_stream_pkg.tkeep, inactive_policy, previous_inactive_policy)
+                  axi_stream_transaction.tkeep,
+                  select_policy(axi_stream_signal, work.axi_stream_pkg.tkeep, inactive_policy, previous_inactive_policy)
                 );
               when work.axi_stream_pkg.tstrb =>
                 check(
                   tstrb,
-                  axi_stream_transaction.tstrb, select_policy(axi_stream_signal, work.axi_stream_pkg.tstrb, inactive_policy, previous_inactive_policy)
+                  axi_stream_transaction.tstrb,
+                  select_policy(axi_stream_signal, work.axi_stream_pkg.tstrb, inactive_policy, previous_inactive_policy)
                 );
               when work.axi_stream_pkg.tid =>
                 check(
                   tid,
-                  axi_stream_transaction.tid, select_policy(axi_stream_signal, work.axi_stream_pkg.tid, inactive_policy, previous_inactive_policy)
+                  axi_stream_transaction.tid,
+                  select_policy(axi_stream_signal, work.axi_stream_pkg.tid, inactive_policy, previous_inactive_policy)
                 );
               when work.axi_stream_pkg.tdest =>
                 check(
                   tdest,
-                  axi_stream_transaction.tdest, select_policy(axi_stream_signal, work.axi_stream_pkg.tdest, inactive_policy, previous_inactive_policy)
+                  axi_stream_transaction.tdest,
+                  select_policy(axi_stream_signal, work.axi_stream_pkg.tdest, inactive_policy, previous_inactive_policy)
                 );
               when work.axi_stream_pkg.tuser =>
                 check(
                   tuser,
-                  axi_stream_transaction.tuser, select_policy(axi_stream_signal, work.axi_stream_pkg.tuser, inactive_policy, previous_inactive_policy)
+                  axi_stream_transaction.tuser,
+                  select_policy(axi_stream_signal, work.axi_stream_pkg.tuser, inactive_policy, previous_inactive_policy)
                 );
             end case;
             loop_count := loop_count + 1;
@@ -783,7 +849,10 @@ begin
 
         set_inactive_axi_stream_policy(net, master_axi_stream, inactive_policy);
 
-        axi_stream_transaction := (tdata => x"99", tlast => true, tkeep => "1", tstrb => "1", tid => x"11", tdest => x"22", tuser => x"33");
+        axi_stream_transaction := (
+          tdata => x"99", tlast => true, tkeep => "1",
+          tstrb => "1", tid => x"11", tdest => x"22", tuser => x"33"
+        );
         last := '1' when axi_stream_transaction.tlast else '0';
         push_axi_stream(
           net,

--- a/vunit/vhdl/verification_components/test/tb_axi_stream.vhd
+++ b/vunit/vhdl/verification_components/test/tb_axi_stream.vhd
@@ -128,8 +128,10 @@ begin
     variable mock_logger : logger_t;
     variable rnd : RandomPtype;
     variable stall_config : stall_config_t;
+    variable stall_config_read_back : stall_config_t;
     variable stall_probability_percent : natural;
     variable previous_inactive_policy : inactive_bus_policy_t := 'X';
+    variable inactive_policy_read_back : inactive_bus_policy_t;
     variable loop_count : natural := 0;
 
     impure function select_policy(
@@ -686,11 +688,17 @@ begin
       wait until rising_edge(aclk);
       stall_probability_percent := 30;
       stall_config := new_stall_config(real(stall_probability_percent) / 100.0, min_stall_cycles, max_stall_cycles);
+
       if running_test_case = "test random stall on master" then
         set_stall_config(net, master_axi_stream, stall_config);
+        get_stall_config(net, master_axi_stream, stall_config_read_back);
       else
         set_stall_config(net, slave_axi_stream, stall_config);
+        get_stall_config(net, slave_axi_stream, stall_config_read_back);
       end if;
+      check_equal(stall_config_read_back.stall_probability, stall_config.stall_probability, max_diff => 0.0001);
+      check_equal(stall_config_read_back.min_stall_cycles, stall_config.min_stall_cycles);
+      check_equal(stall_config_read_back.max_stall_cycles, stall_config.max_stall_cycles);
       for i in 0 to 100 loop
         pop_stream(net, slave_stream, reference);
         push(reference_queue, reference);
@@ -772,6 +780,8 @@ begin
       for inactive_policy in inactive_bus_policy_t'left to inactive_bus_policy_t'right loop
         for axi_stream_signal in work.axi_stream_pkg.tuser downto work.axi_stream_pkg.tdata loop
           set_inactive_axi_stream_policy(net, master_axi_stream, inactive_policy, axi_stream_signal);
+          get_inactive_axi_stream_policy(net, master_axi_stream, inactive_policy_read_back, axi_stream_signal);
+          check(inactive_policy_read_back = inactive_policy);
 
           axi_stream_transaction := (
             tdata => x"99", tlast => true, tkeep => "1", tstrb => "1",
@@ -896,7 +906,9 @@ begin
 
   axi_stream_master_inst : entity work.axi_stream_master
     generic map(
-      master => master_axi_stream)
+      master => master_axi_stream,
+      drive_invalid => false
+    )
     port map(
       aclk     => aclk,
       areset_n => areset_n,

--- a/vunit/vhdl/verification_components/test/tb_axi_stream_protocol_checker.vhd
+++ b/vunit/vhdl/verification_components/test/tb_axi_stream_protocol_checker.vhd
@@ -255,7 +255,8 @@ begin
 
     elsif run("Test failing check of that tlast remains stable when tvalid is asserted and tready is low") then
       fail_stable_test(
-        d(0) => tlast, rule_name => ":rule 2", signal_name => "tlast", zero_string => "1", one_string => "0", zero_value => '1', one_value => '0'
+        d(0) => tlast, rule_name => ":rule 2", signal_name => "tlast", zero_string => "1",
+        one_string => "0", zero_value => '1', one_value => '0'
       );
 
     elsif run("Test passing check of that tvalid remains asserted until tready is high") then

--- a/vunit/vhdl/verification_components/test/tb_axi_stream_protocol_checker.vhd
+++ b/vunit/vhdl/verification_components/test/tb_axi_stream_protocol_checker.vhd
@@ -81,15 +81,15 @@ begin
 
     procedure fail_stable_test (
       signal d : out std_logic_vector;
-      constant rname : string; constant sname : string;
-      constant szero : string; constant sone : string;
-      constant vzero : std_logic := '0'; constant vone : std_logic := '1'
+      constant rule_name : string; constant signal_name : string;
+      constant zero_string : string; constant one_string : string;
+      constant zero_value : std_logic := '0'; constant one_value : std_logic := '1'
     ) is
-      constant zeros : std_logic_vector(d'range) := (others => vzero);
-      constant ones : std_logic_vector(d'range) := (others => vone);
+      constant zeros : std_logic_vector(d'range) := (others => zero_value);
+      constant ones : std_logic_vector(d'range) := (others => one_value);
       variable rule_logger : logger_t;
     begin
-      rule_logger := get_logger(get_name(logger) & rname);
+      rule_logger := get_logger(get_name(logger) & rule_name);
       mock(rule_logger);
 
       wait until rising_edge(aclk);
@@ -106,8 +106,10 @@ begin
 
       check_only_log(
         rule_logger,
-        "Stability check failed for " & sname & " while waiting for tready - Got " & sone & " at 2nd active and enabled clock edge. Expected " & szero & ".",
-        error);
+        "Stability check failed for " & signal_name & " while waiting for tready - Got " & one_string &
+        " at 2nd active and enabled clock edge. Expected " & zero_string & ".",
+        error
+      );
 
       wait until rising_edge(aclk);
       tvalid <= '1';
@@ -121,8 +123,10 @@ begin
 
       check_only_log(
         rule_logger,
-        "Stability check failed for " & sname & " while waiting for tready - Got " & sone & " at 2nd active and enabled clock edge. Expected " & szero & ".",
-        error);
+        "Stability check failed for " & signal_name & " while waiting for tready - Got " & one_string &
+        " at 2nd active and enabled clock edge. Expected " & zero_string & ".",
+        error
+      );
 
       tvalid <= '1';
       wait until rising_edge(aclk);
@@ -139,12 +143,16 @@ begin
 
       check_log(
         rule_logger,
-        "Stability check passed for " & sname & " while waiting for tready - Got " & sone & " for 2 active and enabled clock edges.",
-        pass);
+        "Stability check passed for " & signal_name & " while waiting for tready - Got " & one_string &
+        " for 2 active and enabled clock edges.",
+        pass
+      );
       check_only_log(
         rule_logger,
-        "Stability check failed for " & sname & " while waiting for tready - Got " & szero & " at 2nd active and enabled clock edge. Expected " & sone & ".",
-        error);
+        "Stability check failed for " & signal_name & " while waiting for tready - Got " & zero_string &
+        " at 2nd active and enabled clock edge. Expected " & one_string & ".",
+        error
+      );
 
       unmock(rule_logger);
     end;
@@ -200,17 +208,18 @@ begin
     procedure fail_unknown_test(
       signal d: out std_logic_vector;
       signal e1, e2: out std_logic;
-      constant rname : string;
-      constant sname : string;
-      constant e1name : string;
+      constant rule_name : string;
+      constant signal_name : string;
+      constant e1_name : string;
       constant skip_meta_values : boolean_vector(meta_values'range) := (others => false)
     ) is
       variable rule_logger : logger_t;
     begin
-      rule_logger := get_logger(get_name(logger) & rname);
+      rule_logger := get_logger(get_name(logger) & rule_name);
       mock(rule_logger);
 
-      -- need to disable these signals first, because there would be a log message for the first clock edge if enabled (happens with areset_n)
+      -- Need to disable these signals first, because there would be a log message for the first clock edge
+      -- if enabled (happens with areset_n)
       e1 <= '0';
       e2 <= '0';
       wait until rising_edge(aclk);
@@ -223,8 +232,10 @@ begin
         wait for 1 ns;
         check_only_log(
           rule_logger,
-          "Not unknown check failed for " & sname & " when " & e1name & " is high - Got " & to_nibble_string(std_logic_vector'(d'range => meta_values(i))) & ".",
-          error);
+          "Not unknown check failed for " & signal_name & " when " & e1_name & " is high - Got " &
+          to_nibble_string(std_logic_vector'(d'range => meta_values(i))) & ".",
+          error
+        );
       end loop;
 
       unmock(rule_logger);
@@ -243,7 +254,9 @@ begin
       pass_stable_test(d(0) => tlast);
 
     elsif run("Test failing check of that tlast remains stable when tvalid is asserted and tready is low") then
-      fail_stable_test(d(0) => tlast, rname => ":rule 2", sname => "tlast", szero => "1", sone => "0", vzero => '1', vone => '0');
+      fail_stable_test(
+        d(0) => tlast, rule_name => ":rule 2", signal_name => "tlast", zero_string => "1", one_string => "0", zero_value => '1', one_value => '0'
+      );
 
     elsif run("Test passing check of that tvalid remains asserted until tready is high") then
       wait until rising_edge(aclk);
@@ -280,12 +293,16 @@ begin
 
       check_log(
         rule_logger,
-        "Stability check failed for tvalid while waiting for tready - Got 0 " & "at 2nd active and enabled clock edge. Expected 1.",
-        error);
+        "Stability check failed for tvalid while waiting for tready - Got 0 " &
+        "at 2nd active and enabled clock edge. Expected 1.",
+        error
+      );
       check_only_log(
         rule_logger,
-        "Stability check failed for tvalid while waiting for tready - Got 0 " & "at 3rd active and enabled clock edge. Expected 1.",
-        error);
+        "Stability check failed for tvalid while waiting for tready - Got 0 " &
+        "at 3rd active and enabled clock edge. Expected 1.",
+        error
+      );
 
       wait until rising_edge(aclk);
       tvalid <= '1';
@@ -299,8 +316,10 @@ begin
 
       check_only_log(
         rule_logger,
-        "Stability check failed for tvalid while waiting for tready - Got L " & "at 2nd active and enabled clock edge. Expected 1.",
-        error);
+        "Stability check failed for tvalid while waiting for tready - Got L " &
+        "at 2nd active and enabled clock edge. Expected 1.",
+        error
+      );
 
       unmock(rule_logger);
 
@@ -340,8 +359,10 @@ begin
 
       check_only_log(
         rule_logger,
-        "Check failed for performance - tready active " & to_string(max_waits + 1) & " clock cycles after tvalid. Expected <= " & to_string(max_waits) & " clock cycles.",
-        warning);
+        "Check failed for performance - tready active " & to_string(max_waits + 1) &
+        " clock cycles after tvalid. Expected <= " & to_string(max_waits) & " clock cycles.",
+        warning
+      );
 
       unmock(rule_logger);
 
@@ -489,7 +510,9 @@ begin
       set_phase(runner_state, test_runner_cleanup);
       entry_gate(runner);
 
-      check_only_log(rule_logger, "Unconditional check failed for packet completion for the following streams: 0.", error);
+      check_only_log(
+        rule_logger, "Unconditional check failed for packet completion for the following streams: 0.", error
+      );
 
       unmock(rule_logger);
 
@@ -547,7 +570,7 @@ begin
       tkeep <= (others => '1');
       pass_unknown_test(tstrb, tvalid, tready);
 
-      -- U is reolved to the value of tkeep and should not fail
+      -- U is resolved to the value of tkeep and should not fail
       tvalid <= '0';
       tready <= '0';
       wait until rising_edge(aclk);
@@ -560,8 +583,10 @@ begin
 
     elsif run("Test failing check of that tstrb must not be unknown when tvalid is high") then
       tkeep <= (others => '1');
-      -- U is reolved to the value of tkeep and should not fail
-      fail_unknown_test(tstrb, tvalid, tready, ":rule 18", "tstrb", "tvalid", skip_meta_values => (5 => true, others => false));
+      -- U is resolved to the value of tkeep and should not fail
+      fail_unknown_test(
+        tstrb, tvalid, tready, ":rule 18", "tstrb", "tvalid", skip_meta_values => (5 => true, others => false)
+      );
 
     elsif run("Test passing check of that tkeep must not be unknown when tvalid is high") then
       pass_unknown_test(tkeep, tvalid, tready);
@@ -671,7 +696,7 @@ begin
       tid      => tid,
       tdest    => tdest,
       tuser    => tuser
-      );
+    );
 
   aclk <= not aclk after 5 ns;
 end architecture;

--- a/vunit/vhdl/verification_components/test/tb_axi_write_slave.vhd
+++ b/vunit/vhdl/verification_components/test/tb_axi_write_slave.vhd
@@ -57,8 +57,10 @@ begin
     variable buf : buffer_t;
     variable rnd : RandomPType;
 
-    procedure read_response(id : std_logic_vector;
-                            resp : axi_resp_t := axi_resp_okay) is
+    procedure read_response(
+      id : std_logic_vector;
+      resp : axi_resp_t := axi_resp_okay
+    ) is
     begin
       bready <= '1';
       wait until (bvalid and bready) = '1' and rising_edge(clk);
@@ -68,11 +70,13 @@ begin
     end procedure;
 
 
-    procedure write_addr(id : std_logic_vector;
-                         addr : natural;
-                         len : natural;
-                         log_size : natural;
-                         burst : axi_burst_type_t) is
+    procedure write_addr(
+      id : std_logic_vector;
+      addr : natural;
+      len : natural;
+      log_size : natural;
+      burst : axi_burst_type_t
+    ) is
     begin
       awvalid <= '1';
       awid <= id;
@@ -85,10 +89,12 @@ begin
       awvalid <= '0';
     end procedure;
 
-    procedure transfer_data(id : std_logic_vector;
-                            buf : buffer_t;
-                            log_size : natural;
-                            data : integer_vector_ptr_t) is
+    procedure transfer_data(
+      id : std_logic_vector;
+      buf : buffer_t;
+      log_size : natural;
+      data : integer_vector_ptr_t
+    ) is
       variable size, len, address, idx : natural;
     begin
       size := 2**log_size;
@@ -121,10 +127,12 @@ begin
       end loop;
     end procedure;
 
-    procedure transfer(id : std_logic_vector;
-                       buf : buffer_t;
-                       log_size : natural;
-                       data : integer_vector_ptr_t) is
+    procedure transfer(
+      id : std_logic_vector;
+      buf : buffer_t;
+      log_size : natural;
+      data : integer_vector_ptr_t
+    ) is
     begin
       transfer_data(id, buf, log_size, data);
       read_response(id, axi_resp_okay);
@@ -219,9 +227,11 @@ begin
       mock(axi_slave_logger, failure);
       wait until (wvalid and wready) = '1' and rising_edge(clk);
       wait until mock_queue_length > 0 and rising_edge(clk);
-      check_only_log(axi_slave_logger,
-                     "Writing to address 0 at offset 0 within anonymous buffer at range (0 to 15) without permission (no_access)",
-                     failure);
+      check_only_log(
+        axi_slave_logger,
+        "Writing to address 0 at offset 0 within anonymous buffer at range (0 to 15) without permission (no_access)",
+        failure
+      );
       unmock(axi_slave_logger);
       wvalid <= '0';
       wlast <= '0';
@@ -412,7 +422,9 @@ begin
       mock(axi_slave_logger, failure);
       write_addr(x"2", base_address(buf)+4000, 256, 0, axi_burst_type_incr);
       wait until mock_queue_length > 0 and rising_edge(clk);
-      check_only_log(axi_slave_logger, "Crossing 4KByte boundary. First page = 0 (4000/4096), last page = 1 (4255/4096)", failure);
+      check_only_log(
+        axi_slave_logger, "Crossing 4KByte boundary. First page = 0 (4000/4096), last page = 1 (4255/4096)", failure
+      );
       unmock(axi_slave_logger);
 
     elsif run("Test no error on 4KByte boundary crossing with disabled check") then
@@ -567,7 +579,11 @@ begin
       wvalid <= '1';
       wlast  <= '0';
       write_addr(x"0", base_address(buf), len => 2, log_size => 0, burst => axi_burst_type_incr);
-      check_only_log(axi_slave_logger, "Burst not well behaved, axi size = 1 but bus data width allows " & to_string(data_size), failure);
+      check_only_log(
+        axi_slave_logger,
+        "Burst not well behaved, axi size = 1 but bus data width allows " & to_string(data_size),
+        failure
+      );
       unmock(axi_slave_logger);
 
     elsif run("Test well behaved check fails when wvalid not high during active burst") then


### PR DESCRIPTION
This PR improves the user control over what values are driven on the AXI stream bus when `tvalid` is low and the bus is inactive. The default value is still `X` for all signals but `tuser` which is assigned zero(s). The reason for the default value of `tuser` is that it often carries control information that is more sensitive to `X` values. An `X` value on `tuser` would also violate rule 10 of the `axi_stream_protocol_checker` which requires `tuser` to be a known value when the reset is inactive. Rule 10 is based on a rule in the protocol checker from ARM.

This PR also improves the granularity for assigning the inactive values as `tdata`, `tlast`, `tkeep`, `tstrb`, `tid`, `tdest`, and `tuser` can be controlled separately. All bits in these signals are assigned either `0`, `1`, `X`, random zeros and ones, or they keep the previous valid value.

The inactive value configuration is controlled by a new parameter `inactive_policy` to the `new_axi_stream_master` function. This is a breaking change from the previous generic-based configuration **if** the generics have non-default values. The generics will remain for a transition period but they serve no other purpose than providing an error if they are set at non-default values.

The configuration can also be changed dynamically with the `set_inactive_axi_stream_policy` command.

Dynamic control of the AXI stream VC stall configuration has also been added (`set_stall_config`).