### PR TITLE
Bumped required setuptools version.

### DIFF
--- a/docs/news.d/1196.misc.rst
+++ b/docs/news.d/1196.misc.rst
@@ -1,0 +1,2 @@
+Bumped required setuptools version to >=77. The higher version is required to support the license and license files
+formats in pyproject.toml.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=61"]
+requires = ["setuptools>=77"]
 build-backend = "setuptools.build_meta"
 
 [project]


### PR DESCRIPTION
The higher version is required to support the license and license files formats.