### PR TITLE
Add check for existing coverage files to merge_coverage function (modelsim)

### DIFF
--- a/vunit/sim_if/modelsim.py
+++ b/vunit/sim_if/modelsim.py
@@ -881,6 +881,11 @@ proc _vunit_sim_restart {} {
         if args is None:
             args = []
 
+        # Check if at least one valid coverage file exists.
+        if not any(file_exists(f) for f in self._coverage_files):
+            LOGGER.warning("No existing coverage files found. Skipping coverage database creation.")
+            return
+
         coverage_files = str(Path(self._output_path) / "coverage_files.txt")
         vcover_cmd = [str(Path(self._prefix) / "vcover"), "merge", "-inputs"] + [coverage_files] + args + [file_name]
         with Path(coverage_files).open("w", encoding="utf-8") as fptr:


### PR DESCRIPTION
If simulation is run with coverage enabled but no testcases were executed (because filtering), the merge_coverage procedure does end in an error. This pre-check checks, if there is anything to merge before performing the merge command.

Resolves #1208.

Result (with ModelSim):
```
$ make sim
WARNING - Found no test benches using current filter rule:

    Filters entities and modules that have a runner_cfg generic/parameter

    Gives warning when design_unit matches tb_* or *_tb without having a runner_cfg
    Gives warning when a design_unit has  a runner_cfg but the name does not match tb_* or *_tb

Re-compile not needed

No tests were run!
WARNING - No existing coverage files found. Skipping coverage database creation.
```
