### PR TITLE
updating OSVVM to version 2026.05

### DIFF
--- a/examples/vhdl/osvvm_log_integration/run.py
+++ b/examples/vhdl/osvvm_log_integration/run.py
@@ -47,16 +47,22 @@ osvvm_files_to_compile = [
     "TextUtilPkg.vhd",
     "OsvvmScriptSettingsPkg.vhd",
     "OsvvmScriptSettingsPkg_default.vhd",
+    "IfElsePkg.vhd",
+    "OsvvmSettingsPkg.vhd",
+    "OsvvmSettingsPkg_default.vhd",
+    "FileUtilPkg.vhd",
+    "LanguageSupport2019Pkg.vhd",
+    "AssertApiPkg.vhd",
 ]
 for osvvm_file in osvvm_files_to_compile:
-    osvvm.add_source_files(root / ".." / ".." / ".." / "vunit" / "vhdl" / "osvvm" / osvvm_file)
+    prj.add_osvvm_file_to_lib(osvvm_file, osvvm)
 
 if args.use_vunit_log:
     osvvm.add_source_files(root / "osvvm_integration" / "osvvm_to_vunit_common_log_pkg.vhd")
     osvvm.add_source_files(root / "osvvm_integration" / "osvvm_to_vunit_common_log_pkg-body.vhd")
     osvvm.add_source_files(root / "osvvm_integration" / "AlertLogPkg.vhd")
 else:
-    osvvm.add_source_files(root / ".." / ".." / ".." / "vunit" / "vhdl" / "osvvm" / "AlertLogPkg.vhd")
+    prj.add_osvvm_file_to_lib("AlertLogPkg.vhd", osvvm)
 
 
 prj.set_compile_option("rivierapro.vcom_flags", ["-dbg"])

--- a/tests/acceptance/test_artificial.py
+++ b/tests/acceptance/test_artificial.py
@@ -27,7 +27,7 @@ class TestVunitArtificial(unittest.TestCase):
     """
 
     def setUp(self):
-        if simulator_is("activehdl"):
+        if simulator_is("activehdl", "modelsim"):
             self.output_path = str(ROOT / "artificial_out")
         else:
             # Spaces in path intentional to verify that it is supported

--- a/vunit/builtins.py
+++ b/vunit/builtins.py
@@ -29,7 +29,6 @@ from vunit.vhdl_standard import VHDL, VHDLStandard
 from vunit.ui.common import get_checked_file_names_from_globs
 from vunit.about import version, VUnitVersion
 
-
 LOGGER = logging.getLogger(__name__)
 
 VHDL_PATH = (Path(__file__).parent / "vhdl").resolve()
@@ -389,64 +388,141 @@ class Builtins(object):
             return None
         return self._vunit_obj.add_library(library_name)
 
+    def _osvvm_file_map(self, file_name):
+        """
+        Mapping for a given osvvm file to the actual file that should be used. Returns empty string for no file
+        """
+        simulator_coverage_api = self._simulator_class.get_osvvm_coverage_api()
+        osvvm_file_dict = {
+            "LanguageSupport2019Pkg.vhd": ("deprecated/LanguageSupport2019Pkg_c.vhd"),
+            "FileLinePathPkg.vhd": (
+                "FileLinePathPkg.vhd"
+                if self._simulator_class.supports_2019_impure_functions()
+                else "deprecated/FileLinePathPkg_c.vhd"
+            ),
+            "AssertApiPkg.vhd": (
+                "AssertApiPkg.vhd"
+                if self._simulator_class.supports_2019_assert_api()
+                else "deprecated/AssertApiPkg_c.vhd"
+            ),
+            "DynamicVectorGenericPkg.vhd": (
+                "DynamicVectorGenericPkg.vhd"
+                if self._simulator_class.supports_2019_generics()
+                else "deprecated/DynamicVectorPkg_IntV_c.vhd"
+            ),
+            "DynamicVectorPkg_instances.vhd": (
+                "DynamicVectorPkg_instances.vhd"
+                if self._simulator_class.supports_2019_generics()
+                else "deprecated/DynamicVectorPkg_slv_c.vhd"
+            ),
+            "RandomPkg2019.vhd": (
+                "RandomPkg2019.vhd"
+                if self._simulator_class.supports_2019_impure_functions()
+                else "deprecated/RandomPkg2019_c.vhd"
+            ),
+            "ScoreboardPkg_IntV.vhd": "deprecated/ScoreboardPkg_IntV_c.vhd",
+            "ScoreboardPkg_slv.vhd": "deprecated/ScoreboardPkg_slv_c.vhd",
+            "ScoreboardPkg_int.vhd": "deprecated/ScoreboardPkg_int_c.vhd",
+            "ScoreboardPkg_signed.vhd": "deprecated/ScoreboardPkg_signed_c.vhd",
+            "ScoreboardPkg_unsigned.vhd": "deprecated/ScoreboardPkg_unsigned_c.vhd",
+            "MemoryGenericPkg.vhd": "deprecated/MemoryPkg_orig_c.vhd",
+            "MemoryPkg.vhd": (
+                "MemoryPkg.vhd"
+                if self._simulator_class.supports_vhdl_package_generics()
+                else "deprecated/MemoryPkg_c.vhd"
+            ),
+            "ScoreboardGenericPkg.vhd": "",
+            "CoverageVendorApiPkg_Aldec.vhd": (
+                "CoverageVendorApiPkg_Aldec.vhd" if simulator_coverage_api == "rivierapro" else ""
+            ),
+            "CoverageVendorApiPkg_default.vhd": (
+                "CoverageVendorApiPkg_default.vhd" if simulator_coverage_api not in ["nvc", "rivierapro"] else ""
+            ),
+            "CoverageVendorApiPkg_NVC.vhd": ("CoverageVendorApiPkg_NVC.vhd" if simulator_coverage_api == "nvc" else ""),
+        }
+        return osvvm_file_dict.get(file_name)
+
+    def _osvvm_file_select(self, file_name):
+        """
+        pass osvvm file_name and it returns either file_name or empty string (for no file)
+        should be used with an interator over all files in the main osvvm directory.
+        will select correct file from depreciated folder if require.
+        """
+        ret = file_name
+
+        if int(str(self._vhdl_standard)) < int(str(VHDL.STD_2019)) and (
+            file_name
+            in {
+                "LanguageSupport2019Pkg.vhd",
+                "FileLinePathPkg.vhd",
+                "AssertApiPkg.vhd",
+                "DynamicVectorGenericPkg.vhd",
+                "DynamicVectorPkg_instances.vhd",
+                "RandomPkg2019.vhd",
+            }
+        ):
+            ret = self._osvvm_file_map(file_name)
+
+        if not self._simulator_class.supports_vhdl_package_generics() and (
+            file_name
+            in [
+                "ScoreboardPkg_IntV.vhd",
+                "ScoreboardPkg_slv.vhd",
+                "ScoreboardPkg_int.vhd",
+                "ScoreboardPkg_signed.vhd",
+                "ScoreboardPkg_unsigned.vhd",
+                "MemoryGenericPkg.vhd",
+                "MemoryPkg.vhd",
+                "ScoreboardGenericPkg.vhd",
+            ]
+        ):
+            ret = self._osvvm_file_map(file_name)
+
+        if file_name in [
+            "CoverageVendorApiPkg_Aldec.vhd",
+            "CoverageVendorApiPkg_default.vhd",
+            "CoverageVendorApiPkg_NVC.vhd",
+        ]:
+            ret = self._osvvm_file_map(file_name)
+
+        return ret
+
+    def _add_osvvm_file_to_lib(self, file_name, lib_name):
+        """
+        Use this when building a custom osvvm library based on included osvvm
+        """
+        bname = self._osvvm_file_select(file_name)
+        if bname != "":
+            lib_name.add_source_files(VHDL_PATH / "osvvm" / bname, preprocessors=[])
+
     def _add_osvvm(self):
         """
         Add osvvm library
         """
         library = self._add_library_if_not_exist(
-            "osvvm", "Library 'OSVVM' previously defined. Skipping addition of builtin OSVVM (2023.04)."
+            "osvvm", "Library 'OSVVM' previously defined. Skipping addition of builtin OSVVM (2026.05)."
         )
         if library is None:
             return
 
-        simulator_coverage_api = self._simulator_class.get_osvvm_coverage_api()
-        supports_vhdl_package_generics = self._simulator_class.supports_vhdl_package_generics()
-
         if not osvvm_is_installed():
-            raise RuntimeError(
-                """
+            raise RuntimeError("""
 Found no OSVVM VHDL files. Did you forget to run
 
 git submodule update --init --recursive
 
-in your VUnit Git repository? You have to do this first if installing using setup.py."""
-            )
+in your VUnit Git repository? You have to do this first if installing using setup.py.""")
 
         for file_name in glob(str(VHDL_PATH / "osvvm" / "*.vhd")):
             bname = Path(file_name).name
+            # print ("adding file before checks", file_name, simulator_coverage_api, self._simulator_class)
 
-            if (bname == "AlertLogPkg_body_BVUL.vhd") or ("2019" in bname):
+            bname = self._osvvm_file_select(bname)
+            if bname == "":
                 continue
 
-            if ((simulator_coverage_api != "rivierapro") and (bname == "VendorCovApiPkg_Aldec.vhd")) or (
-                (simulator_coverage_api == "rivierapro") and (bname == "VendorCovApiPkg.vhd")
-            ):
-                continue
-
-            if not supports_vhdl_package_generics and (
-                bname
-                in [
-                    "ScoreboardGenericPkg.vhd",
-                    "ScoreboardPkg_int.vhd",
-                    "ScoreboardPkg_slv.vhd",
-                    "MemoryPkg.vhd",
-                    "MemoryGenericPkg.vhd",
-                ]
-            ):
-                continue
-
-            if supports_vhdl_package_generics and (
-                bname
-                in [
-                    "ScoreboardPkg_int_c.vhd",
-                    "ScoreboardPkg_slv_c.vhd",
-                    "MemoryPkg_c.vhd",
-                    "MemoryPkg_orig_c.vhd",
-                ]
-            ):
-                continue
-
-            library.add_source_files(file_name, preprocessors=[])
+            # print ("file passed checks", new_file_name)
+            library.add_source_files(VHDL_PATH / "osvvm" / bname, preprocessors=[])
 
     def _add_vhdl_logging(self, use_external_log):
         """

--- a/vunit/sim_if/activehdl.py
+++ b/vunit/sim_if/activehdl.py
@@ -54,24 +54,59 @@ class ActiveHDLInterface(SimulatorInterface):
         return cls.find_toolchain(["vsim", "avhdl"])
 
     @classmethod
+    def test_version(cls, major, minor):
+        proc = Process([str(Path(cls.find_prefix()) / "vcom"), "-version"], env=cls.get_env())
+        consumer = VersionConsumer()
+        proc.consume_output(consumer)
+        if consumer.version is not None:
+            return consumer.version >= Version(major, minor)
+
+        return False
+
+    @classmethod
     def supports_vhdl_call_paths(cls):
         """
         Returns True when this simulator supports VHDL-2019 call paths
         """
-        return True
+        return cls.test_version(12, 0)
 
     @classmethod
     def supports_vhdl_package_generics(cls):
         """
         Returns True when this simulator supports VHDL package generics
         """
-        proc = Process([str(Path(cls.find_prefix()) / "vcom"), "-version"], env=cls.get_env())
-        consumer = VersionConsumer()
-        proc.consume_output(consumer)
-        if consumer.version is not None:
-            return consumer.version >= Version(10, 1)
+        return cls.test_version(10, 1)
 
+    @classmethod
+    def supports_2019_generics(cls):
+        """
+        Returns True when this simulator supports VHDL 2019 generics
+        OSVVM variable
+        """
         return False
+
+    @classmethod
+    def supports_2019_impure_functions(cls):
+        """
+        Returns True when this simulator supports VHDL 2019 impure functions
+        OSVVM variable Supports2019ImpureFunctions
+        """
+        return cls.test_version(12, 0)
+
+    @classmethod
+    def supports_2019_assert_api(cls):
+        """
+        Returns True when this simulator supports VHDL 2019 assertion api
+        OSVVM variable Supports2019AssertApi
+        """
+        return cls.test_version(12, 0)
+
+    @classmethod
+    def osvvm_tool_name(cls):
+        """
+        Returns True when this simulator supports VHDL package generics
+        """
+        return "ActiveHDL"
 
     @staticmethod
     def supports_coverage():

--- a/vunit/sim_if/ghdl.py
+++ b/vunit/sim_if/ghdl.py
@@ -189,6 +189,7 @@ class GHDLInterface(SimulatorInterface, ViewerMixin):  # pylint: disable=too-man
     def supports_vhdl_call_paths(cls):
         """
         Returns True when this simulator supports VHDL-2019 call paths
+        OSVVM variable Supports2019FilePath
         """
         return False
 
@@ -197,7 +198,37 @@ class GHDLInterface(SimulatorInterface, ViewerMixin):  # pylint: disable=too-man
         """
         Returns True when this simulator supports VHDL package generics
         """
-        return True
+        return False
+
+    @classmethod
+    def supports_2019_generics(cls):
+        """
+        Returns True when this simulator supports VHDL 2019 generics
+        """
+        return False
+
+    @classmethod
+    def supports_2019_impure_functions(cls):
+        """
+        Returns True when this simulator supports VHDL 2019 impure functions
+        OSVVM variable Supports2019ImpureFunctions
+        """
+        return False
+
+    @classmethod
+    def supports_2019_assert_api(cls):
+        """
+        Returns True when this simulator supports VHDL 2019 assertion api
+        OSVVM variable Supports2019AssertApi
+        """
+        return False
+
+    @classmethod
+    def osvvm_tool_name(cls):
+        """
+        Returns True when this simulator supports VHDL package generics
+        """
+        return "GHDL"
 
     @classmethod
     def supports_vhpi(cls):

--- a/vunit/sim_if/modelsim.py
+++ b/vunit/sim_if/modelsim.py
@@ -156,6 +156,7 @@ class ModelSimInterface(VsimSimulatorMixin, SimulatorInterface):  # pylint: disa
     def supports_vhdl_call_paths(cls):
         """
         Returns True when this simulator supports VHDL-2019 call paths
+        OSVVM variable Supports2019FilePath
         """
         return True
 
@@ -165,6 +166,37 @@ class ModelSimInterface(VsimSimulatorMixin, SimulatorInterface):  # pylint: disa
         Returns True when this simulator supports VHDL package generics
         """
         return True
+
+    @classmethod
+    def supports_2019_generics(cls):
+        """
+        Returns True when this simulator supports VHDL 2019 generics
+        """
+        return False
+
+    @classmethod
+    def supports_2019_impure_functions(cls):
+        """
+        Returns True when this simulator supports VHDL 2019 impure functions
+        OSVVM variable Supports2019ImpureFunctions
+        """
+        return False
+
+    @classmethod
+    def supports_2019_assert_api(cls):
+        """
+        Returns True when this simulator supports VHDL 2019 assertion api
+        OSVVM variable Supports2019AssertApi
+        """
+        return False
+
+    @classmethod
+    def osvvm_tool_name(cls):
+        """
+        Returns True when this simulator supports VHDL package generics
+        OSVVM variable ToolName
+        """
+        return "modelsim"
 
     @staticmethod
     def supports_coverage():

--- a/vunit/sim_if/nvc.py
+++ b/vunit/sim_if/nvc.py
@@ -30,7 +30,8 @@ class NVCInterface(SimulatorInterface, ViewerMixin):  # pylint: disable=too-many
     """
     Interface for NVC simulator
     """
-
+    _minor = 0
+    _major = 0
     name = "nvc"
     executable = environ.get("NVC", "nvc")
     supports_gui_flag = True
@@ -93,6 +94,8 @@ class NVCInterface(SimulatorInterface, ViewerMixin):  # pylint: disable=too-many
         self._supports_jit = major > 1 or (major == 1 and minor >= 9)
         self._ieee_warnings_global = major > 1 or (major == 1 and minor >= 16)
         self._supports_coverage_merge = major > 1 or (major == 1 and minor >= 15)
+        self._major = major
+        self._minor = minor
 
         if self.use_color:
             environ["NVC_COLORS"] = "always"
@@ -144,15 +147,60 @@ class NVCInterface(SimulatorInterface, ViewerMixin):  # pylint: disable=too-many
     def supports_vhdl_call_paths(cls):
         """
         Returns True when this simulator supports VHDL-2019 call paths
+        OSVVM variable Supports2019FilePath
         """
-        return True
+        if cls._major is not None:
+            if (cls._major == 1 and cls._minor >= 15) or (cls._major > 1):
+                return True
+
+        return False
 
     @classmethod
     def supports_vhdl_package_generics(cls):
         """
         Returns True when this simulator supports VHDL package generics
+        OSVVM variable
         """
         return True
+
+    @classmethod
+    def supports_2019_generics(cls):
+        """
+        Returns True when this simulator supports VHDL package generics
+        OSVVM variable
+        """
+        return False
+
+    @classmethod
+    def supports_2019_impure_functions(cls):
+        """
+        Returns True when this simulator supports VHDL package generics
+        OSVVM variable Supports2019ImpureFunctions
+        """
+        if cls._major is not None:
+            if (cls._major == 1 and cls._minor >= 13) or (cls._major > 1):
+                return True
+
+        return False
+
+    @classmethod
+    def supports_2019_assert_api(cls):
+        """
+        Returns True when this simulator supports VHDL package generics
+        OSVVM variable Supports2019AssertApi
+        """
+        if cls._major is not None:
+            if (cls._major == 1 and cls._minor >= 15) or (cls._major > 1):
+                return True
+
+        return False
+
+    @classmethod
+    def osvvm_tool_name(cls):
+        """
+        Returns True when this simulator supports VHDL package generics
+        """
+        return "NVC"
 
     def setup_library_mapping(self, project):
         """

--- a/vunit/sim_if/rivierapro.py
+++ b/vunit/sim_if/rivierapro.py
@@ -97,15 +97,63 @@ class RivieraProInterface(VsimSimulatorMixin, SimulatorInterface):
     def supports_vhdl_call_paths(cls):
         """
         Returns True when this simulator supports VHDL-2019 call paths
+        OSVVM variable Supports2019FilePath
         """
-        return True
+        version = cls._get_version()
+        if version.year is not None:
+            if (version.year == 2021 and version.month >= 4) or (version.year > 2021):
+                return True
+
+        return False
 
     @classmethod
     def supports_vhdl_package_generics(cls):
         """
         Returns True when this simulator supports VHDL package generics
+        OSVVM variable
         """
-        return True
+        return False
+
+    @classmethod
+    def supports_2019_generics(cls):
+        """
+        Returns True when this simulator supports VHDL 2019 generics
+        OSVVM variable
+        """
+        return False
+
+    @classmethod
+    def supports_2019_impure_functions(cls):
+        """
+        Returns True when this simulator supports VHDL 2019 impure functions
+        OSVVM variable Supports2019ImpureFunctions
+        """
+        version = cls._get_version()
+        if version.year is not None:
+            if (version.year == 2021 and version.month >= 4) or (version.year > 2021):
+                return True
+
+        return False
+
+    @classmethod
+    def supports_2019_assert_api(cls):
+        """
+        Returns True when this simulator supports VHDL 2019 assertion api
+        OSVVM variable Supports2019AssertApi
+        """
+        version = cls._get_version()
+        if version.year is not None:
+            if (version.year == 2021 and version.month >= 4) or (version.year > 2021):
+                return True
+
+        return False
+
+    @classmethod
+    def osvvm_tool_name(cls):
+        """
+        Returns an equivalent string to the OSVVM variable ToolName
+        """
+        return "RivieraPRO"
 
     @staticmethod
     def supports_coverage():

--- a/vunit/ui/__init__.py
+++ b/vunit/ui/__init__.py
@@ -1312,6 +1312,13 @@ other preprocessors. Lowest value first. The order between preprocessors with th
         """
         self._builtins.add("osvvm")
 
+    def add_osvvm_file_to_lib(self, file_name, lib_name):
+        """
+        Adds a method to pass osvvm files through the file selection process
+        Useful if trying to build osvvm with customised packages
+        """
+        self._builtins._add_osvvm_file_to_lib(file_name, lib_name)  # pylint: disable=protected-access
+
     def add_json4vhdl(self):
         """
         Removed json4vhdl add-on.


### PR DESCRIPTION
- osvvm submodule bumped to osvvm 2026.05
- reworked builtins.py to use a file map function to provided support for the osvvm/depreciated files
- added a number of functions to the simulator interface classes so that the file mapping can properly select the correct file
- updated osvvm_log_integration/run.py example to use updated builtin add_osvvm_file_to_lib.