### PR TITLE
updating SYSTEM_VERILOG_EXTENSIONS to include .svh

### DIFF
--- a/vunit/source_file.py
+++ b/vunit/source_file.py
@@ -348,7 +348,7 @@ class VHDLSourceFile(SourceFile):
 # lower case representation of supported extensions
 VHDL_EXTENSIONS = (".vhd", ".vhdl", ".vho")
 VERILOG_EXTENSIONS = (".v", ".vp", ".vams", ".vo")
-SYSTEM_VERILOG_EXTENSIONS = (".sv", ".svp")
+SYSTEM_VERILOG_EXTENSIONS = (".sv", ".svh", ".svp")
 VERILOG_FILE_TYPES = ("verilog", "systemverilog")
 FILE_TYPES = ("vhdl",) + VERILOG_FILE_TYPES
 


### PR DESCRIPTION
Add systemverilog header files into the allowed list of extensions. See https://verificationacademy.com/forums/t/what-are-difference-between-sv-and-svh-file/29594/2 for more info.