### PR TITLE
Publish wheels over sdist

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -194,7 +194,7 @@ jobs:
     - name: '🐍 Install dependencies'
       run: |
         pip install -U pip
-        pip install -U setuptools wheel twine
+        pip install -U build twine
 
     - name: '🚀 Build and deploy to PyPI'
       if: github.repository == 'VUnit/vunit'
@@ -203,5 +203,5 @@ jobs:
         TWINE_PASSWORD: ${{ secrets.VUNIT_HDL_PYPI_DEPLOY_TOKEN }}
       run: |
         ./tools/release.py validate
-        python setup.py sdist
+        python -m build --wheel
         twine upload dist/*

--- a/setup.py
+++ b/setup.py
@@ -41,6 +41,8 @@ DATA_FILES += find_all_files("vunit", endings=[".tcl"])
 DATA_FILES += find_all_files(str(Path("vunit") / "vhdl"))
 DATA_FILES += find_all_files(str(Path("vunit") / "verilog"), endings=[".v", ".sv", ".svh"])
 DATA_FILES = [os.path.relpath(file_name, "vunit") for file_name in DATA_FILES]
+# PEP 561 marker so downstream projects can pick up vunit's type hints.
+DATA_FILES.append("py.typed")
 
 setup(
     version=version(),


### PR DESCRIPTION
This change updates CI/CD to publish wheels instead of source distributions to avoid the security concern of arbitrary code execution via `setup.py`